### PR TITLE
Add sha256 file hashing tests

### DIFF
--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,0 +1,32 @@
+from reflex.verification_report import _HASH_CHUNK, _sha256
+
+
+def test_sha256_empty_file(tmp_path):
+    path = tmp_path / "empty.bin"
+    path.write_bytes(b"")
+
+    assert _sha256(path) == (
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    )
+
+
+def test_sha256_small_file(tmp_path):
+    path = tmp_path / "small.bin"
+    path.write_bytes(b"abc")
+
+    assert _sha256(path) == (
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    )
+
+
+def test_sha256_large_file(tmp_path):
+    path = tmp_path / "large.bin"
+    payload = b"reflex-vla-sha256-test\n" * (
+        (_HASH_CHUNK // len(b"reflex-vla-sha256-test\n")) + 3
+    )
+    path.write_bytes(payload)
+
+    assert len(payload) > _HASH_CHUNK
+    assert _sha256(path) == (
+        "be4d788a195785d6e979d2958e8095ec19af664d4413416b474dc0e4f7a15c24"
+    )


### PR DESCRIPTION
## Description
Adds unit coverage for `reflex.verification_report._sha256` across empty, small, and chunk-spanning files using fixed expected SHA256 digests.

Closes #36

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure / CI update
- [x] Test coverage

## How Has This Been Tested?
- [ ] `pytest tests/` passes locally
- [ ] `reflex doctor` sanity check
- [x] Other: `PYTHONPATH=src pytest tests/test_verification.py -q`
- [x] Other: `ruff check tests/test_verification.py`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have kept the PR scoped to a single concern (one concern per PR)
