### PR TITLE
fix: green main test suite — 3 prod bugs + 7 stale tests

### DIFF
--- a/src/reflex/diagnostics/__init__.py
+++ b/src/reflex/diagnostics/__init__.py
@@ -108,6 +108,7 @@ class Check:
 
 # Registry — populated lazily on first run_all_checks() call
 _REGISTRY: list[Check] = []
+_REGISTRY_LOADED: bool = False
 
 
 def register(check: Check) -> None:
@@ -116,8 +117,16 @@ def register(check: Check) -> None:
 
 
 def _ensure_registry_loaded() -> None:
-    """Import every check_*.py module so they self-register. Idempotent."""
-    if _REGISTRY:
+    """Import every check_*.py module so they self-register. Idempotent.
+
+    Uses a separate flag rather than `if _REGISTRY:` so a partial-load
+    (e.g. when a single check_*.py was imported directly elsewhere) still
+    triggers the full sweep. Re-imports are cheap — sys.modules caches them
+    and `register()` is at module top-level so it only fires once per
+    interpreter regardless of how many times you import the module.
+    """
+    global _REGISTRY_LOADED
+    if _REGISTRY_LOADED:
         return
     # Day 1 checks
     from . import (  # noqa: F401
@@ -145,6 +154,7 @@ def _ensure_registry_loaded() -> None:
         check_modal_auth,
         check_vla_eval_importable,
     )
+    _REGISTRY_LOADED = True
 
 
 def run_all_checks(

--- a/src/reflex/diagnostics/check_rtc_chunks.py
+++ b/src/reflex/diagnostics/check_rtc_chunks.py
@@ -61,40 +61,36 @@ def _run(embodiment_name: str = "custom", rtc: bool = False, **kwargs) -> CheckR
     control = cfg.control
     chunk_size = int(control["chunk_size"])
     frequency_hz = float(control["frequency_hz"])  # robot control loop rate
-    horizon_s = float(control["rtc_execution_horizon"])
+    # rtc_execution_horizon is INTEGER COUNT OF ACTIONS per
+    # embodiments/validate.py:163 — not seconds. An earlier revision of this
+    # check multiplied by frequency_hz, over-counting by ~Hz× and flagging
+    # franka (chunk=50, horizon=25) as fail when it actually aligns 2:1.
+    actions_per_horizon = int(control["rtc_execution_horizon"])
 
-    # actions executed per RTC horizon
-    actions_per_horizon = frequency_hz * horizon_s
-
-    # Sanity check 1: horizon must consume at least one action
     if actions_per_horizon < 1:
         return CheckResult(
             check_id=CHECK_ID,
             name="RTC chunk boundary",
             status="fail",
-            expected="frequency_hz × rtc_execution_horizon ≥ 1 action",
-            actual=(
-                f"{frequency_hz}Hz × {horizon_s}s = {actions_per_horizon:.2f} actions/horizon"
-            ),
+            expected="rtc_execution_horizon ≥ 1 action",
+            actual=f"rtc_execution_horizon = {actions_per_horizon} actions",
             remediation=(
-                f"Increase rtc_execution_horizon (currently {horizon_s}s) OR "
-                f"frequency_hz (currently {frequency_hz}Hz) so the product ≥ 1. "
-                f"With 0 actions per horizon, RTC degenerates to no-RTC."
+                f"Increase rtc_execution_horizon (currently {actions_per_horizon} "
+                f"actions). With 0 actions per horizon, RTC degenerates to no-RTC."
             ),
             duration_ms=0.0,
             github_issue=GH_ISSUE,
         )
 
-    # Sanity check 2: chunk must hold at least one horizon-worth of actions
     if chunk_size < actions_per_horizon:
         return CheckResult(
             check_id=CHECK_ID,
             name="RTC chunk boundary",
             status="fail",
-            expected=f"chunk_size ≥ {actions_per_horizon:.0f} actions (one horizon)",
-            actual=f"chunk_size={chunk_size} < {actions_per_horizon:.2f} actions/horizon",
+            expected=f"chunk_size ≥ {actions_per_horizon} actions (one horizon)",
+            actual=f"chunk_size={chunk_size} < {actions_per_horizon} actions/horizon",
             remediation=(
-                f"Either increase chunk_size to ≥ {int(actions_per_horizon) + 1} OR "
+                f"Either increase chunk_size to ≥ {actions_per_horizon + 1} OR "
                 f"reduce rtc_execution_horizon. Mismatch causes the boundary stalls "
                 f"reported in LeRobot #2356."
             ),
@@ -102,19 +98,17 @@ def _run(embodiment_name: str = "custom", rtc: bool = False, **kwargs) -> CheckR
             github_issue=GH_ISSUE,
         )
 
-    # Sanity check 3 (warn): chunk_size should be a clean multiple of horizon
-    # so multiple inferences per chunk align with RTC ticks
-    if actions_per_horizon >= 1 and chunk_size % int(actions_per_horizon) != 0:
+    if chunk_size % actions_per_horizon != 0:
         return CheckResult(
             check_id=CHECK_ID,
             name="RTC chunk boundary",
             status="warn",
-            expected=f"chunk_size ({chunk_size}) is a multiple of actions_per_horizon ({int(actions_per_horizon)})",
-            actual=f"chunk_size % horizon_actions = {chunk_size % int(actions_per_horizon)}",
+            expected=f"chunk_size ({chunk_size}) is a multiple of actions_per_horizon ({actions_per_horizon})",
+            actual=f"chunk_size % horizon_actions = {chunk_size % actions_per_horizon}",
             remediation=(
                 f"Non-integer ratio means the last partial-horizon at chunk boundary "
                 f"will run with stale guidance. Consider chunk_size="
-                f"{int(actions_per_horizon) * (chunk_size // int(actions_per_horizon) + 1)} "
+                f"{actions_per_horizon * (chunk_size // actions_per_horizon + 1)} "
                 f"for cleaner alignment. Not a hard failure."
             ),
             duration_ms=0.0,
@@ -128,7 +122,7 @@ def _run(embodiment_name: str = "custom", rtc: bool = False, **kwargs) -> CheckR
         expected="chunk_size, frequency_hz, rtc_execution_horizon align cleanly",
         actual=(
             f"chunk_size={chunk_size}, frequency_hz={frequency_hz}, "
-            f"horizon={horizon_s}s ({actions_per_horizon:.0f} actions/horizon)"
+            f"horizon={actions_per_horizon} actions"
         ),
         remediation="",
         duration_ms=0.0,

--- a/src/reflex/pro/license.py
+++ b/src/reflex/pro/license.py
@@ -331,10 +331,15 @@ def issue_dev_license(
     `load_license` accepts (with a warning). Phase 1.5 will require all
     licenses to come from the signing endpoint; `issue_dev_license` will
     move to a `--dev-license` CLI flag that emits a warning at startup.
+
+    Writes as license_version=LICENSE_VERSION_LEGACY_UNSIGNED so the
+    loader takes the legacy unsigned path. Writing it as the current
+    LICENSE_VERSION (=2) trips signature verification, which fails on
+    the empty signature field — the dev path stops working.
     """
     now = datetime.now(timezone.utc)
     license = ProLicense(
-        license_version=LICENSE_VERSION,
+        license_version=LICENSE_VERSION_LEGACY_UNSIGNED,
         customer_id=customer_id,
         tier=tier,
         issued_at=now.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,19 @@
 """Pytest fixtures shared across the test suite.
 
-Sets a wide terminal width so Rich/Click don't elide option names in
-``--help`` output. CI environments (GitHub Actions Linux runners)
-default to a width where Rich abbreviates long flag names to ``--...``,
-which breaks substring assertions like ``"--export-mode" in result.output``.
-Setting COLUMNS=200 at session start makes the rendered help stable
-across local (Mac terminal) and CI (no-TTY Linux runner).
+CI-only behavior of Click+Rich's help renderer that broke us:
+- When `CI=true` (set by GitHub Actions), Rich inserts ANSI color
+  escapes BETWEEN the two `-` characters of long flag names, so the
+  literal substring `"--export-mode"` is no longer present in
+  `result.output` even though the rendered text looks identical.
+  Setting `TERM=dumb` forces Rich into no-color plain-text mode and
+  the substring search works again.
+- The CI runner's terminal width defaults narrow enough that Rich
+  elides long option names with `--...`. `COLUMNS=200` keeps the
+  rendered panel wide enough to show all names verbatim.
+
+Both env vars are set in `pytest_configure` (runs before any test
+import), so the entire suite inherits stable, plain-text help output
+matching what `--help` users see in a real shell.
 """
 from __future__ import annotations
 
@@ -15,3 +23,4 @@ import os
 def pytest_configure(config):
     os.environ["COLUMNS"] = "200"
     os.environ["LINES"] = "80"
+    os.environ["TERM"] = "dumb"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest fixtures shared across the test suite.
+
+Sets a wide terminal width so Rich/Click don't elide option names in
+``--help`` output. CI environments (GitHub Actions Linux runners)
+default to a width where Rich abbreviates long flag names to ``--...``,
+which breaks substring assertions like ``"--export-mode" in result.output``.
+Setting COLUMNS=200 at session start makes the rendered help stable
+across local (Mac terminal) and CI (no-TTY Linux runner).
+"""
+from __future__ import annotations
+
+import os
+
+
+def pytest_configure(config):
+    os.environ["COLUMNS"] = "200"
+    os.environ["LINES"] = "80"

--- a/tests/test_cli_export_end_to_end.py
+++ b/tests/test_cli_export_end_to_end.py
@@ -42,12 +42,15 @@ def test_dispatch_by_model_id():
 
 
 def test_unsupported_model_type_raises():
-    """pi0.5 / GR00T dispatch should raise a clean error until v0.3."""
+    """A model id that doesn't match any family substring AND has no
+    readable local config.json must raise a clean ValueError. (GR00T,
+    pi0.5, smolvla all hit the substring matcher now — pick a name
+    that doesn't.)"""
     from reflex.exporters import monolithic
 
     with pytest.raises(ValueError, match="Cannot infer model_type"):
         monolithic.export_monolithic(
-            "nvidia/GR00T-N1.6-3B", "/tmp/out",
+            "some-org/totally-unknown-architecture", "/tmp/out",
         )
 
 

--- a/tests/test_doctor_diagnostics.py
+++ b/tests/test_doctor_diagnostics.py
@@ -386,28 +386,48 @@ class TestCheckHardwareCompat:
 
 
 class TestSmoke:
-    def test_runs_all_10_checks(self, tmp_path):
+    # Minimum check_ids that must always be present. New checks can be
+    # registered without breaking this test, but these foundational ones
+    # can never silently disappear.
+    REQUIRED_CHECK_IDS = {
+        "check_model_load",
+        "check_onnx_provider",
+        "check_vlm_tokenization",
+        "check_image_dims",
+        "check_rtc_chunks",
+        "check_action_denorm",
+        "check_gripper",
+        "check_state_proprio",
+        "check_gpu_memory",
+        "check_hardware_compat",
+    }
+
+    def test_runs_all_registered_checks(self, tmp_path):
+        from reflex.diagnostics import _REGISTRY, _ensure_registry_loaded
+        _ensure_registry_loaded()
+        registered_ids = {check.check_id for check in _REGISTRY}
+
         results = run_all_checks(str(tmp_path), "custom", rtc=False)
-        assert len(results) == 10
-        ids = {r.check_id for r in results}
-        assert ids == {
-            "check_model_load",
-            "check_onnx_provider",
-            "check_vlm_tokenization",
-            "check_image_dims",
-            "check_rtc_chunks",
-            "check_action_denorm",
-            "check_gripper",
-            "check_state_proprio",
-            "check_gpu_memory",
-            "check_hardware_compat",
-        }
+        result_ids = {r.check_id for r in results}
+
+        assert len(results) == len(_REGISTRY), (
+            f"executed {len(results)} but registry has {len(_REGISTRY)}"
+        )
+        assert result_ids == registered_ids, (
+            f"missing: {registered_ids - result_ids}, extra: {result_ids - registered_ids}"
+        )
+        assert self.REQUIRED_CHECK_IDS <= result_ids, (
+            f"foundational checks missing: {self.REQUIRED_CHECK_IDS - result_ids}"
+        )
 
     @pytest.mark.parametrize("emb", ["franka", "so100", "ur5"])
     def test_runs_against_each_preset(self, emb, tmp_path):
+        from reflex.diagnostics import _REGISTRY, _ensure_registry_loaded
+        _ensure_registry_loaded()
+
         (tmp_path / "model.onnx").write_bytes(b"\x00")
         results = run_all_checks(str(tmp_path), emb, rtc=True)
-        assert len(results) == 10
+        assert len(results) == len(_REGISTRY)
         for r in results:
             assert r.status in {"pass", "fail", "warn", "skip"}
             if r.status == "fail":

--- a/tests/test_export_mode.py
+++ b/tests/test_export_mode.py
@@ -294,7 +294,11 @@ def test_run_parallel_pi05_exports_submits_both_workers(monkeypatch, tmp_path):
     assert expert_meta["prefix_seq_len"] == 968
     assert [call[0] for call in calls] == ["prefix", "expert"]
     assert calls[0][1][1] == str(tmp_path)
-    assert calls[1][1][-1] == 968
+    # _export_pi05_expert_worker signature:
+    # (model_id, output_dir, num_steps, student_checkpoint, variant,
+    #  past_kv_names, prefix_seq_len, per_step_expert)
+    # prefix_seq_len is positional arg 6 (0-indexed).
+    assert calls[1][1][6] == 968
 
 
 def test_write_decomposed_result_records_export_mode(tmp_path):

--- a/tests/test_install_smoke.py
+++ b/tests/test_install_smoke.py
@@ -56,17 +56,21 @@ def test_import_reflex_exposes_patch_helper():
     assert "OK" in stdout
 
 
-def test_import_reflex_version_is_v07():
-    """Sanity check on the version string."""
+def test_import_reflex_version_is_at_least_v07():
+    """Sanity check on the version string. Uses semver parsing so version
+    bumps don't break this test — only an accidental regression below
+    0.7.0 (our wheel-compatibility floor) trips the assertion."""
     snippet = textwrap.dedent("""
         import reflex
-        v = reflex.__version__
-        assert v.startswith("0.7."), f"expected 0.7.x, got {v}"
-        print(v)
+        from packaging.version import Version
+        v = Version(reflex.__version__)
+        assert v >= Version("0.7.0"), f"version regressed below 0.7.0: {v}"
+        print(reflex.__version__)
     """)
     rc, stdout, stderr = _run_in_subprocess(snippet)
     assert rc == 0, f"stderr={stderr!r}"
-    assert stdout.strip().startswith("0.7.")
+    from packaging.version import Version
+    assert Version(stdout.strip()) >= Version("0.7.0")
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific")

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -192,7 +192,10 @@ class TestCliList:
         assert "pi05-base" in ids
 
     def test_models_list_no_match_message(self, runner, cli_app):
-        result = runner.invoke(cli_app, ["models", "list", "--family", "openvla"])
+        # Use a family that's genuinely not in the registry. openvla was
+        # added in v0.9.6 so it now matches; pick a sentinel name that
+        # won't accidentally match a future addition either.
+        result = runner.invoke(cli_app, ["models", "list", "--family", "nonexistent_family_xyz"])
         assert result.exit_code == 0
         assert "No models match" in result.stdout
 
@@ -227,7 +230,7 @@ class TestCliPull:
         result = runner.invoke(cli_app, ["models", "pull", "nope-xyz"])
         assert result.exit_code == 2
         assert "Unknown model_id" in result.stdout
-        assert "Available:" in result.stdout
+        assert "Available registry ids:" in result.stdout
         # Should list every registered model
         for e in REGISTRY:
             assert e.model_id in result.stdout

--- a/tests/test_snapflow_backend.py
+++ b/tests/test_snapflow_backend.py
@@ -19,6 +19,13 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
+import importlib.util
+_LEROBOT_INSTALLED = importlib.util.find_spec("lerobot") is not None
+requires_lerobot = pytest.mark.skipif(
+    not _LEROBOT_INSTALLED,
+    reason="requires [native]/[monolithic]/[rtc] extras (lerobot)",
+)
+
 from reflex.distill.teacher_loader import (
     V03_TEACHER_ALLOWLIST,
     LoadedTeacher,
@@ -175,6 +182,7 @@ class TestPrepareBatch:
         assert not torch.allclose(n1, n2)
 
 
+@requires_lerobot
 class TestBuildPreprocessor:
     def test_overrides_rename_map_and_device(self, tmp_path):
         """_build_preprocessor should inject the image_key_map into the
@@ -230,6 +238,7 @@ class TestBuildVelocityAdapters:
                 teacher=MagicMock(), student=MagicMock(), policy_type="gr00t_n1_5",
             )
 
+    @requires_lerobot
     def test_pi_family_adapter_calls_denoise_step_with_prefix_cache(self):
         """The adapter should call policy.model.denoise_step with the
         lerobot signature (state, prefix_pad_masks, past_key_values, x_t,
@@ -313,6 +322,7 @@ class TestBuildVelocityAdapters:
         assert torch.allclose(vt, torch.full_like(x, 0.1))
         assert torch.allclose(vs, torch.full_like(x, 0.2))
 
+    @requires_lerobot
     def test_student_passes_target_time_through_denoise_step(self):
         """v0.3.1 SnapFlowPI0Pytorch: target_time is now routed through
         denoise_step → embed_suffix → target_time_embed_mlp. The backend

--- a/tests/test_vlm_prefix.py
+++ b/tests/test_vlm_prefix.py
@@ -700,12 +700,18 @@ class TestOrchestratorFullPipeline:
                 fake_image = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
                 fake_state = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
 
-                result = orch.run(fake_image, "pick up the cup", fake_state)
+                # Modern API returns (vlm_k, vlm_v) — both shape
+                # [num_layers, batch, seq, kv_dim]. Earlier signature
+                # returned a single 3D prefix; updated when expert
+                # cross-attention adopted per-layer K/V (vlm_components).
+                vlm_k, vlm_v = orch.run(fake_image, "pick up the cup", fake_state)
 
-                # Should be [1, seq, 960]
-                assert result.ndim == 3
-                assert result.shape[0] == 1
-                assert result.shape[2] == 960
+                assert vlm_k.ndim == 4 and vlm_v.ndim == 4
+                # batch dim
+                assert vlm_k.shape[1] == 1
+                assert vlm_v.shape[1] == 1
+                # k and v share the same sequence + kv_dim
+                assert vlm_k.shape == vlm_v.shape
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Main's Pytest CI has been red since today's v0.9.0 → v0.9.6 churn, which has blocked PRs #105, #107, #109. Diagnosed **3 real production bugs** (would have hit customers) + **7 tests** that drifted vs the live CLI / API surface.

## Production bugs caught

- **`src/reflex/diagnostics/__init__.py`** — `_ensure_registry_loaded()` short-circuited on `if _REGISTRY:` which broke when any single `check_*.py` was imported before `run_all_checks` (registry frozen at one entry, 9 missing). Replaced with an explicit `_REGISTRY_LOADED` bool. Customer impact: `reflex doctor` could silently miss 9 of 10 checks.
- **`src/reflex/diagnostics/check_rtc_chunks.py`** — interpreted `rtc_execution_horizon` as **seconds** and multiplied by `frequency_hz`, over-counting by `~Hz×`. Validator at `embodiments/validate.py:163` documents the field as **actions count**. Result: every well-aligned preset (franka/so100/ur5) flagged "fail" under `--rtc`. Fix: read directly as int actions.
- **`src/reflex/pro/license.py`** — `issue_dev_license` wrote `license_version=2` (signed) with empty signature; loader rejected the same file as corrupt. Dev-license escape hatch was 100% broken end-to-end. Switched to `LICENSE_VERSION_LEGACY_UNSIGNED` so the loader's unsigned path takes it.

## Stale-test drift fixes

- `test_doctor_diagnostics::TestSmoke` now derives expected check count from the registry (no more `== 10` hardcode that breaks every time we add a check)
- `test_cli_export_end_to_end::test_unsupported_model_type_raises` — GR00T now matches the substring path; use a sentinel name
- `test_install_smoke::test_import_reflex_version_is_v07` — uses semver parsing (`>= 0.7.0`) so version bumps don't break it
- `test_model_registry` — `--family openvla` now matches v0.9.6 registry; switched to sentinel family. Output string is `"Available registry ids:"` not `"Available:"`
- `test_export_mode::test_run_parallel_pi05_exports_*` — assert against positional index 6 (not `[-1]`) after `per_step_expert` arg added
- `test_vlm_prefix::TestOrchestratorFullPipeline` — `run()` now returns `(vlm_k, vlm_v)` per-layer K/V tuple, not a single 3D prefix
- `test_snapflow_backend` — 4 tests now skip when `lerobot` not installed (require `[native]`/`[monolithic]`/`[rtc]` extras, not in CI's `[dev,onnx,serve]`)

## Test plan

- [x] Verified locally on Py3.12 with CI's exact extras (`pip install -e ".[dev,onnx,serve]"`): **2441 passed, 51 skipped**
- [ ] CI green on this PR
- [ ] Once merged, re-trigger CI on #105, #107, #109 (they'll inherit the green main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
