### PR TITLE
feat(modal): per-episode video frame dumps + decomposed policy fallback

### DIFF
--- a/scripts/modal_libero_lerobot_native.py
+++ b/scripts/modal_libero_lerobot_native.py
@@ -170,6 +170,7 @@ def run_ported_libero(
     snapflow_student: str = "",
     snapflow_onnx: str = "",
     preprocessor_ref: str = "",
+    save_video_dir: str = "",
 ):
     """Port of openpi/examples/libero/main.py rolled out end-to-end.
 
@@ -414,12 +415,17 @@ def run_ported_libero(
                 action_plan = collections.deque()
                 t = 0
                 done = False
+                video_frames = [] if save_video_dir else None
+                if video_frames is not None:
+                    video_frames.append(np.ascontiguousarray(obs["agentview_image"][::-1, ::-1]))
 
                 while t < max_steps + num_steps_wait:
                     try:
                         # num_steps_wait: let objects settle
                         if t < num_steps_wait:
                             obs, _, done, info = env.step(LIBERO_DUMMY_ACTION)
+                            if video_frames is not None:
+                                video_frames.append(np.ascontiguousarray(obs["agentview_image"][::-1, ::-1]))
                             t += 1
                             continue
 
@@ -553,6 +559,8 @@ def run_ported_libero(
 
                         action = action_plan.popleft()
                         obs, _, done, info = env.step(action.tolist())
+                        if video_frames is not None:
+                            video_frames.append(np.ascontiguousarray(obs["agentview_image"][::-1, ::-1]))
                         if done:
                             task_result["success"] += 1
                             results["total_success"] += 1
@@ -582,6 +590,15 @@ def run_ported_libero(
                 print(f"  ep {ep} (init_idx={init_idx}): "
                       f"{'SUCCESS' if done else 'fail'} at {t} steps "
                       f"({time.time()-task_start:.1f}s total)")
+                if video_frames is not None and len(video_frames) > 0:
+                    from pathlib import Path as _P
+                    _P(save_video_dir).mkdir(parents=True, exist_ok=True)
+                    tag = "S" if done else "F"
+                    out = _P(save_video_dir) / (
+                        f"teacher_t{task_idx}_ep{ep}_seed{seed}_steps{t}_{tag}.npz"
+                    )
+                    np.savez_compressed(str(out), frames=np.array(video_frames, dtype=np.uint8))
+                    print(f"    frames → {out} ({len(video_frames)} frames)")
             except Exception as e:
                 err_tb = traceback.format_exc()
                 print(f"  episode error: {e}")
@@ -622,6 +639,7 @@ def main(
     snapflow_student: str = "",
     snapflow_onnx: str = "",
     preprocessor_ref: str = "",
+    save_video_dir: str = "",
 ):
     """
     --num-episodes N          episodes per task (OpenPI default: 50)
@@ -655,7 +673,9 @@ def main(
         task_suite_name=suite,
         task_indices=task_list,
         snapflow_student=snapflow_student,
+        snapflow_onnx=snapflow_onnx,
         preprocessor_ref=preprocessor_ref,
+        save_video_dir=save_video_dir,
     )
     print("\n=== RESULT ===")
     print(f"  model: {r.get('model')}")

--- a/scripts/modal_libero_pi05_decomposed.py
+++ b/scripts/modal_libero_pi05_decomposed.py
@@ -191,10 +191,15 @@ def run_decomposed_libero(
     phash_hamming: int = 6,
     preprocessor_ref: str = "lerobot/pi05_libero_finetuned_v044",
     seed: int = 7,
+    save_video_dir: str = "",
 ):
     """LIBERO rollout through the decomposed ONNX chain. Mirrors
     ``modal_libero_lerobot_native.run_ported_libero`` but swaps the
     forward path for ``Pi05DecomposedInference``.
+
+    save_video_dir: if non-empty, write per-episode MP4 of agentview camera
+    to that path inside the container (typically a /onnx_out subpath so it
+    persists on the volume). Filename encodes task/ep/seed/steps/success.
     """
     import collections
     import logging
@@ -218,8 +223,6 @@ def run_decomposed_libero(
     torch.load = _compat_load
 
     # ─── Load PyTorch policy (preprocessing + config only) ──────────
-    print(f"[decomposed] Loading SnapFlow student from {student_checkpoint}")
-    from reflex.distill.snapflow_pi0_model import load_snapflow_student
     from lerobot.processor.pipeline import PolicyProcessorPipeline
     from lerobot.processor.converters import (
         batch_to_transition, transition_to_batch,
@@ -229,7 +232,25 @@ def run_decomposed_libero(
         OBS_LANGUAGE_ATTENTION_MASK, OBS_LANGUAGE_TOKENS, ACTION,
     )
 
-    policy = load_snapflow_student(student_checkpoint)
+    # Two ways to source the policy (config + _preprocess_images helper):
+    # 1) SnapFlow student dir on the volume (has model.safetensors) — preferred
+    #    when the student PyTorch checkpoint lives alongside the decomposed
+    #    ONNX export.
+    # 2) Fallback: load PI05Policy from preprocessor_ref (HF id). Inference
+    #    actually runs through ONNX so the policy weights here are unused —
+    #    only config + _preprocess_images matter.
+    student_ckpt_path = Path(student_checkpoint)
+    if (student_ckpt_path / "model.safetensors").exists():
+        print(f"[decomposed] Loading SnapFlow student from {student_checkpoint}")
+        from reflex.distill.snapflow_pi0_model import load_snapflow_student
+        policy = load_snapflow_student(student_checkpoint)
+    else:
+        from lerobot.policies.pi05.modeling_pi05 import PI05Policy
+        fallback = preprocessor_ref or "lerobot/pi05_libero_finetuned_v044"
+        print(f"[decomposed] No model.safetensors at {student_checkpoint}; "
+              f"loading PI05Policy from {fallback} (config + preprocessing only — "
+              f"inference still runs through decomposed ONNX)")
+        policy = PI05Policy.from_pretrained(fallback)
     policy.eval().to("cuda").to(torch.float32)
     cfg = policy.config
     chunk_size = cfg.chunk_size
@@ -427,11 +448,16 @@ def run_decomposed_libero(
                 action_plan = collections.deque()
                 t = 0
                 done = False
+                video_frames = [] if save_video_dir else None
+                if video_frames is not None:
+                    video_frames.append(np.ascontiguousarray(obs["agentview_image"][::-1, ::-1]))
 
                 while t < max_steps + num_steps_wait:
                     try:
                         if t < num_steps_wait:
                             obs, _, done, info = env.step(LIBERO_DUMMY_ACTION)
+                            if video_frames is not None:
+                                video_frames.append(np.ascontiguousarray(obs["agentview_image"][::-1, ::-1]))
                             t += 1
                             continue
 
@@ -494,6 +520,8 @@ def run_decomposed_libero(
 
                         action = action_plan.popleft()
                         obs, _, done, info = env.step(np.asarray(action).tolist())
+                        if video_frames is not None:
+                            video_frames.append(np.ascontiguousarray(obs["agentview_image"][::-1, ::-1]))
                         t += 1
                         if done:
                             break
@@ -515,6 +543,14 @@ def run_decomposed_libero(
                 if success:
                     task_result["success"] += 1
                 print(f"  ep {ep}: {'✓' if success else '✗'} (steps={t})")
+                if video_frames is not None and len(video_frames) > 0:
+                    Path(save_video_dir).mkdir(parents=True, exist_ok=True)
+                    tag = "S" if success else "F"
+                    out = Path(save_video_dir) / (
+                        f"student_t{task_idx}_ep{ep}_seed{seed}_steps{t}_{tag}.npz"
+                    )
+                    np.savez_compressed(str(out), frames=np.array(video_frames, dtype=np.uint8))
+                    print(f"    frames → {out} ({len(video_frames)} frames)")
             except Exception as ep_exc:
                 print(f"  ep {ep}: ERROR {ep_exc}")
                 task_result["episodes"].append({
@@ -551,6 +587,7 @@ def main(
     phash_hamming: int = 6,
     preprocessor_ref: str = "lerobot/pi05_libero_finetuned_v044",
     seed: int = 7,
+    save_video_dir: str = "",
 ):
     """
     --student-checkpoint   Path to SnapFlow student dir on volume (for
@@ -592,6 +629,7 @@ def main(
         phash_hamming=phash_hamming,
         preprocessor_ref=preprocessor_ref,
         seed=seed,
+        save_video_dir=save_video_dir,
     )
     print("\n=== RESULT ===")
     print(f"  model: {r.get('model')}")


### PR DESCRIPTION
## Summary

Two LIBERO Modal rollout scripts pick up a per-episode video frame dump flag (`--save-video-dir`) and a couple of smaller quality-of-life fixes. Eval/spike scripts only — nothing in `src/` changes.

## What's in

### 1. Per-episode video frame dumps (both scripts)

New `save_video_dir: str = ""` param plumbed `main() → run_*_libero()`. When non-empty:

- Captures `obs["agentview_image"][::-1, ::-1]` per simulation step
- Per episode, writes `<dir>/{teacher,student}_t{task}_ep{N}_seed{S}_steps{T}_{S|F}.npz`
- Filename encodes task index, episode, seed, step count, and S/F outcome → failed episodes (`_F.npz`) are immediately findable for replay analysis

### 2. `snapflow_onnx` plumbing (teacher script only)

`run_ported_libero()` already accepted `snapflow_onnx` as a param but `main()` wasn't passing it through. One-line fix.

### 3. Policy-loader fallback (decomposed/student script only) — **the load-bearing change**

When `student_checkpoint` doesn't contain `model.safetensors`, fall back to `PI05Policy.from_pretrained(preprocessor_ref)`:

```python
if (student_ckpt_path / "model.safetensors").exists():
    policy = load_snapflow_student(student_checkpoint)
else:
    # Fallback: load PI05Policy from preprocessor_ref (HF id)
    policy = PI05Policy.from_pretrained(...)
```

Inference still runs through the ONNX chain — policy weights are unused — but the `config` + `_preprocess_images` helper still need to come from somewhere. This lets you run the decomposed eval against a bare `preprocessor_ref` without needing a sibling SnapFlow student dir.

**Review ask:** confirm this fallback path is intentional (vs me having introduced it during an earlier session debugging spike).

## Test plan

- [ ] Confirm policy-loader fallback was a deliberate addition (or strip + re-PR if not)
- [ ] (Optional) Dry-run on Modal with `--save-video-dir /onnx_out/video_test` on 1 task to verify frames land
- [ ] Confirm `--save-video-dir ""` (default) is a no-op (no frame capture overhead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
