### PR TITLE
feat(ci): welcome first-time contributors on good first issues

### DIFF
--- a/.github/workflows/welcome_good_first_issue.yml
+++ b/.github/workflows/welcome_good_first_issue.yml
@@ -1,0 +1,78 @@
+name: Welcome Good First Issue Contributors
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  welcome:
+    # Ignore pull request comments
+    if: github.event.issue.pull_request == null
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Evaluate conditions
+        id: check
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+
+            // 1. Check label (case-insensitive)
+            const labels = issue.labels.map(l => l.name.toLowerCase());
+            const hasGoodFirstIssue = labels.includes("good first issue");
+
+            // 2. Only first comment (includes current comment)
+            const isFirstComment = issue.comments === 1;
+
+            // 3. Ignore bots
+            const isBot = comment.user.type === "Bot";
+
+            // 4. Only first-time / external contributors.
+            //    NONE = no association with repo; FIRST_TIME_CONTRIBUTOR = first-ever
+            //    contribution. CONTRIBUTOR (prior merged commits) intentionally excluded
+            //    — they're not first-timers and shouldn't see the welcome message.
+            const allowedAssociations = [
+              "NONE",
+              "FIRST_TIME_CONTRIBUTOR"
+            ];
+            const isExternal = allowedAssociations.includes(
+              comment.author_association
+            );
+
+            return hasGoodFirstIssue && isFirstComment && !isBot && isExternal;
+
+      - name: Post welcome message
+        if: steps.check.outputs.result == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const message = [
+              "👋 Thanks for your interest in this issue!",
+              "",
+              "This is a great place to start contributing 🎉",
+              "",
+              "Before you begin, please read our contributing guide:",
+              "👉 https://github.com/" + owner + "/" + repo + "/blob/main/CONTRIBUTING.md",
+              "",
+              "### Getting started",
+              "- Comment that you're working on it",
+              "- Follow the setup steps in CONTRIBUTING.md",
+              "- Open a PR when ready",
+              "",
+              "If you get stuck, just ask here — happy to help! 🚀"
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: message
+            });


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/welcome_good_first_issue.yml`: posts a welcome message when a user comments for the first time on an issue labeled `good first issue`.
- Triggers only on `issue_comment` create events; gated by label, first-comment, non-bot, and `author_association` checks.

## Adapted from #105

@happypeepo opened #105 with effectively this same workflow — credit goes to them (preserved via `Co-Authored-By` on the commit). One change vs. that PR:

**Dropped `CONTRIBUTOR` from `allowedAssociations`.** GitHub's `CONTRIBUTOR` designation means the commenter already has prior merged commits in the repo — i.e. not a first-timer. Welcoming them to "your first issue!" is the opposite of the workflow's intent. Now only `NONE` and `FIRST_TIME_CONTRIBUTOR` trigger the welcome.

Added an inline comment in the workflow explaining the rationale, so future contributors don't accidentally re-add `CONTRIBUTOR`.

## Closes / supersedes

- Closes #80
- Supersedes #105 (closing that one with a note crediting @happypeepo)

## Test plan

- [x] Workflow file passes YAML parse (verified locally via `yq` shape check).
- [ ] Live-test on a forked repo after merge (workflow files don't execute from PR branches before merging on this repo.
EOF
)