### PR TITLE
docs: add quadcopter to embodiment schema enum table

### DIFF
--- a/docs/embodiment_schema.md
+++ b/docs/embodiment_schema.md
@@ -22,7 +22,7 @@ The authoritative schema is at `src/reflex/embodiments/schema.json` (JSON Schema
 | Field | Type | Notes |
 |---|---|---|
 | `schema_version` | int (= 1) | Bump only on removed/renamed fields. Additive changes don't bump. |
-| `embodiment` | enum | `franka` \| `so100` \| `ur5` \| `trossen` \| `stretch` \| `custom` |
+| `embodiment` | enum | `franka` \| `so100` \| `ur5` \| `trossen` \| `stretch` \| `quadcopter` \| `custom` |
 
 ## `action_space`
 


### PR DESCRIPTION
## Description
`docs/embodiment_schema.md` line 25 lists the embodiment enum but omits `quadcopter`. Added `quadcopter` to the enum list in the documentation table to keep it synchronized with `schema.json`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Infrastructure / CI update

## How Has This Been Tested?
- [ ] `pytest tests/` passes locally
- [ ] `reflex doctor` sanity check
- [x] Other (please specify): Documentation verification only

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have kept the PR scoped to a single concern (one concern per PR)
