### PR TITLE
docs(embodiments): add Quadcopter to __init__.py module docstring

### DIFF
--- a/src/reflex/embodiments/__init__.py
+++ b/src/reflex/embodiments/__init__.py
@@ -1,4 +1,4 @@
-"""Per-embodiment configs (Franka, SO-100, UR5, Trossen, Stretch, custom).
+"""Per-embodiment configs (Franka, SO-100, UR5, Trossen, Stretch, Quadcopter, custom).
 
 Read by `reflex serve --embodiment <name>` so the runtime knows the robot's
 action space, normalization stats, gripper layout, control rate, and safety


### PR DESCRIPTION
## Description
The `__init__.py` module docstring in `src/reflex/embodiments` omitted the `Quadcopter` embodiment. Added `Quadcopter` to the parenthetical list to surface it correctly in IDE tooltips and `help()`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Infrastructure / CI update

## How Has This Been Tested?
- [x] `pytest tests/` passes locally
- [ ] `reflex doctor` sanity check
- [x] Other (please specify): Docstring verification

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have kept the PR scoped to a single concern (one concern per PR)
