### PR TITLE
feat(schema): raise velocity cap to 50 m/s and generalize description for drones

### DIFF
--- a/src/reflex/embodiments/schema.json
+++ b/src/reflex/embodiments/schema.json
@@ -180,8 +180,8 @@
         "max_ee_velocity": {
           "type": "number",
           "exclusiveMinimum": 0,
-          "maximum": 10.0,
-          "description": "End-effector velocity cap (m/s for arms; flight speed for aerial)."
+          "maximum": 50.0,
+          "description": "Velocity cap (m/s) — end-effector for arms, flight speed for aerial embodiments."
         },
         "max_gripper_velocity": {
           "type": "number",


### PR DESCRIPTION
## Description
Raised the schema maximum for `max_ee_velocity` from `10.0` to `50.0` m/s to accommodate high-speed UAVs/drones, and generalized the field description.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure / CI update

## How Has This Been Tested?
- [x] `pytest tests/` passes locally
- [ ] `reflex doctor` sanity check
- [x] Other (please specify): Schema validation verified against existing and new presets

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have kept the PR scoped to a single concern (one concern per PR)
