### PR TITLE
docs: add drone state vector guidance to getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -85,6 +85,8 @@ Test it:
 curl -X POST http://localhost:8000/act \
   -H 'content-type: application/json' \
   -d '{"instruction":"pick up the red cup","state":[0.1,0.2,0.3,0.4,0.5,0.6]}'
+
+> **For drone deployments:** send IMU/attitude state instead of joint positions, e.g., `"state": [roll, pitch, yaw, altitude]`.
 ```
 
 You'll get back something like:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -85,9 +85,9 @@ Test it:
 curl -X POST http://localhost:8000/act \
   -H 'content-type: application/json' \
   -d '{"instruction":"pick up the red cup","state":[0.1,0.2,0.3,0.4,0.5,0.6]}'
+```
 
 > **For drone deployments:** send IMU/attitude state instead of joint positions, e.g., `"state": [roll, pitch, yaw, altitude]`.
-```
 
 You'll get back something like:
 


### PR DESCRIPTION
## Description
Added a callout in `docs/getting_started.md` instructing drone operators on formatting their state vectors (e.g., `[roll, pitch, yaw, altitude]`) instead of sending arm joint positions.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Infrastructure / CI update

## How Has This Been Tested?
- [ ] `pytest tests/` passes locally
- [ ] `reflex doctor` sanity check
- [x] Other (please specify): Documentation verification only

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have kept the PR scoped to a single concern (one concern per PR)
