### PR TITLE
docs: add quadcopter embodiment to README quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,10 @@ reflex models list
 # Smoke test — probe hardware → resolve model → pull → export → serve
 reflex go --model smolvla-base
 
-# Now make it real with per-robot normalization (ships with franka, so100, ur5)
+# Now make it real with per-robot normalization (ships with franka, so100, ur5, quadcopter)
 reflex go --model smolvla-base --embodiment franka
+# Or for a drone:
+reflex go --model smolvla-base --embodiment quadcopter
 
 # Or with explicit hardware override
 reflex go --model pi05-libero --embodiment franka --device-class a10g


### PR DESCRIPTION
## Description
Placed the `quadcopter` embodiment directly into the top-level README quickstart example commands to ensure immediate discoverability for UAV teams.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Infrastructure / CI update

## How Has This Been Tested?
- [ ] `pytest tests/` passes locally
- [ ] `reflex doctor` sanity check
- [x] Other (please specify): Documentation verification only

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have kept the PR scoped to a single concern (one concern per PR)
