### PR TITLE
docs: add MAVROS topic hint in README ROS2 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ source /opt/ros/humble/setup.bash   # or iron / jazzy
 # `reflex serve --transport ros2` in a future release.
 reflex ros2-serve ./my_export \
   --image-topic /camera/image_raw \
-  --state-topic /joint_states \
+  --state-topic /joint_states \    # or /mavros/imu/data for drones
   --task-topic  /reflex/task \
   --action-topic /reflex/actions \
   --rate-hz 20


### PR DESCRIPTION
## Description
Updated the `reflex ros2-serve` example command in `README.md` to explicitly mention `/mavros/imu/data` as the state topic for drones.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Infrastructure / CI update

## How Has This Been Tested?
- [ ] `pytest tests/` passes locally
- [ ] `reflex doctor` sanity check
- [x] Other (please specify): Documentation verification only

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have kept the PR scoped to a single concern (one concern per PR)
