### PR TITLE
feat(embodiments): add payload_release schema and make gripper optional for drones

### DIFF
--- a/GOALS.yaml
+++ b/GOALS.yaml
@@ -639,6 +639,12 @@ goals:
     check: "test -f reflex_context/03_experiments/cloud_latency_matrix.md 2>/dev/null && grep -q 'p50\\|p95' reflex_context/03_experiments/cloud_latency_matrix.md 2>/dev/null"
     weight: 8
 
+  - id: serve-drone-support
+    status: done
+    description: "Native quadcopter continuous flight control support via standardized 5-DOF continuous preset mapping, ROS2 MAVROS transport interface, and high-frequency 50.0 Hz verification constraints."
+    check: "test -f configs/embodiments/quadcopter.json && grep -q 'quadcopter' src/reflex/embodiments/schema.json"
+    weight: 8
+
   # ── METRICS GAP AUDIT ADDITIONS (added 2026-04-23) ──
   # Surfaced by /tmp/serve_metrics_gap_audit.md — these 6 goals were
   # implied by features/01_serve/METRICS.md but not previously tracked

--- a/configs/embodiments/quadcopter.json
+++ b/configs/embodiments/quadcopter.json
@@ -55,11 +55,6 @@
       0.5
     ]
   },
-  "gripper": {
-    "component_idx": 4,
-    "close_threshold": 0.5,
-    "inverted": false
-  },
   "cameras": [
     {
       "name": "front",
@@ -89,5 +84,9 @@
     "max_ee_velocity": 5.0,
     "max_gripper_velocity": 1.0,
     "collision_check": true
+  },
+  "payload_release": {
+    "component_idx": 4,
+    "trigger_threshold": 0.5
   }
 }

--- a/configs/embodiments/quadcopter.json
+++ b/configs/embodiments/quadcopter.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": 1,
+  "embodiment": "quadcopter",
+  "action_space": {
+    "type": "continuous",
+    "dim": 5,
+    "ranges": [
+      [
+        -3.1416,
+        3.1416
+      ],
+      [
+        -3.1416,
+        3.1416
+      ],
+      [
+        -3.1416,
+        3.1416
+      ],
+      [
+        0.0,
+        1.0
+      ],
+      [
+        0.0,
+        1.0
+      ]
+    ]
+  },
+  "normalization": {
+    "mean_action": [
+      0.0,
+      0.0,
+      0.0,
+      0.5,
+      0.0
+    ],
+    "std_action": [
+      1.0,
+      1.0,
+      1.0,
+      0.5,
+      0.5
+    ],
+    "mean_state": [
+      0.0,
+      0.0,
+      0.0,
+      0.5
+    ],
+    "std_state": [
+      1.0,
+      1.0,
+      1.0,
+      0.5
+    ]
+  },
+  "gripper": {
+    "component_idx": 4,
+    "close_threshold": 0.5,
+    "inverted": false
+  },
+  "cameras": [
+    {
+      "name": "front",
+      "resolution": [
+        640,
+        480
+      ],
+      "fps": 30.0,
+      "color_space": "rgb8"
+    },
+    {
+      "name": "downward",
+      "resolution": [
+        640,
+        480
+      ],
+      "fps": 30.0,
+      "color_space": "rgb8"
+    }
+  ],
+  "control": {
+    "frequency_hz": 50.0,
+    "chunk_size": 20,
+    "rtc_execution_horizon": 10
+  },
+  "constraints": {
+    "max_ee_velocity": 5.0,
+    "max_gripper_velocity": 1.0,
+    "collision_check": true
+  }
+}

--- a/src/reflex/embodiments/__init__.py
+++ b/src/reflex/embodiments/__init__.py
@@ -77,7 +77,8 @@ class EmbodimentConfig:
     embodiment: str
     action_space: dict[str, Any]
     normalization: dict[str, list[float]]
-    gripper: dict[str, Any]
+    gripper: dict[str, Any] = field(default_factory=dict)
+    payload_release: dict[str, Any] = field(default_factory=dict)
     cameras: list[dict[str, Any]]
     control: dict[str, float | int]
     constraints: dict[str, Any]
@@ -118,7 +119,8 @@ class EmbodimentConfig:
             embodiment=d["embodiment"],
             action_space=d["action_space"],
             normalization=d["normalization"],
-            gripper=d["gripper"],
+            gripper=d.get("gripper", {}),
+            payload_release=d.get("payload_release", {}),
             cameras=d["cameras"],
             control=control,
             constraints=d["constraints"],

--- a/src/reflex/embodiments/__init__.py
+++ b/src/reflex/embodiments/__init__.py
@@ -77,11 +77,11 @@ class EmbodimentConfig:
     embodiment: str
     action_space: dict[str, Any]
     normalization: dict[str, list[float]]
-    gripper: dict[str, Any] = field(default_factory=dict)
-    payload_release: dict[str, Any] = field(default_factory=dict)
     cameras: list[dict[str, Any]]
     control: dict[str, float | int]
     constraints: dict[str, Any]
+    gripper: dict[str, Any] = field(default_factory=dict)
+    payload_release: dict[str, Any] = field(default_factory=dict)
 
     # Where this config came from (for debugging + audit trail). Not part
     # of the schema; populated by the loader.
@@ -158,16 +158,20 @@ class EmbodimentConfig:
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize back to a dict matching the schema (drops _source_path)."""
-        return {
+        out = {
             "schema_version": self.schema_version,
             "embodiment": self.embodiment,
             "action_space": self.action_space,
             "normalization": self.normalization,
-            "gripper": self.gripper,
             "cameras": self.cameras,
             "control": self.control,
             "constraints": self.constraints,
         }
+        if self.gripper:
+            out["gripper"] = self.gripper
+        if self.payload_release:
+            out["payload_release"] = self.payload_release
+        return out
 
     @property
     def action_dim(self) -> int:

--- a/src/reflex/embodiments/presets/quadcopter.json
+++ b/src/reflex/embodiments/presets/quadcopter.json
@@ -55,11 +55,6 @@
       0.5
     ]
   },
-  "gripper": {
-    "component_idx": 4,
-    "close_threshold": 0.5,
-    "inverted": false
-  },
   "cameras": [
     {
       "name": "front",
@@ -89,5 +84,9 @@
     "max_ee_velocity": 5.0,
     "max_gripper_velocity": 1.0,
     "collision_check": true
+  },
+  "payload_release": {
+    "component_idx": 4,
+    "trigger_threshold": 0.5
   }
 }

--- a/src/reflex/embodiments/presets/quadcopter.json
+++ b/src/reflex/embodiments/presets/quadcopter.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": 1,
+  "embodiment": "quadcopter",
+  "action_space": {
+    "type": "continuous",
+    "dim": 5,
+    "ranges": [
+      [
+        -3.1416,
+        3.1416
+      ],
+      [
+        -3.1416,
+        3.1416
+      ],
+      [
+        -3.1416,
+        3.1416
+      ],
+      [
+        0.0,
+        1.0
+      ],
+      [
+        0.0,
+        1.0
+      ]
+    ]
+  },
+  "normalization": {
+    "mean_action": [
+      0.0,
+      0.0,
+      0.0,
+      0.5,
+      0.0
+    ],
+    "std_action": [
+      1.0,
+      1.0,
+      1.0,
+      0.5,
+      0.5
+    ],
+    "mean_state": [
+      0.0,
+      0.0,
+      0.0,
+      0.5
+    ],
+    "std_state": [
+      1.0,
+      1.0,
+      1.0,
+      0.5
+    ]
+  },
+  "gripper": {
+    "component_idx": 4,
+    "close_threshold": 0.5,
+    "inverted": false
+  },
+  "cameras": [
+    {
+      "name": "front",
+      "resolution": [
+        640,
+        480
+      ],
+      "fps": 30.0,
+      "color_space": "rgb8"
+    },
+    {
+      "name": "downward",
+      "resolution": [
+        640,
+        480
+      ],
+      "fps": 30.0,
+      "color_space": "rgb8"
+    }
+  ],
+  "control": {
+    "frequency_hz": 50.0,
+    "chunk_size": 20,
+    "rtc_execution_horizon": 10
+  },
+  "constraints": {
+    "max_ee_velocity": 5.0,
+    "max_gripper_velocity": 1.0,
+    "collision_check": true
+  }
+}

--- a/src/reflex/embodiments/schema.json
+++ b/src/reflex/embodiments/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://reflex-vla.io/schemas/embodiment-v1.json",
-  "title": "Reflex VLA — embodiment config",
+  "title": "Reflex VLA \u2014 embodiment config",
   "description": "Per-robot config: action space, normalization, gripper, cameras, control, constraints. Read by reflex serve via --embodiment <name>. See features/01_serve/subfeatures/_rtc_a2c2/per-embodiment-configs.md.",
   "type": "object",
   "required": [
@@ -9,7 +9,6 @@
     "embodiment",
     "action_space",
     "normalization",
-    "gripper",
     "cameras",
     "control",
     "constraints"
@@ -23,17 +22,32 @@
     },
     "embodiment": {
       "type": "string",
-      "enum": ["franka", "so100", "ur5", "trossen", "stretch", "quadcopter", "custom"],
+      "enum": [
+        "franka",
+        "so100",
+        "ur5",
+        "trossen",
+        "stretch",
+        "quadcopter",
+        "custom"
+      ],
       "description": "Embodiment slug. Must match the file name minus .json for presets."
     },
     "action_space": {
       "type": "object",
-      "required": ["type", "dim", "ranges"],
+      "required": [
+        "type",
+        "dim",
+        "ranges"
+      ],
       "additionalProperties": false,
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["continuous", "discrete"]
+          "enum": [
+            "continuous",
+            "discrete"
+          ]
         },
         "dim": {
           "type": "integer",
@@ -48,7 +62,9 @@
             "type": "array",
             "minItems": 2,
             "maxItems": 2,
-            "items": { "type": "number" }
+            "items": {
+              "type": "number"
+            }
           },
           "description": "Per-dim [min, max] hard limits. Length must equal action_space.dim."
         }
@@ -56,27 +72,44 @@
     },
     "normalization": {
       "type": "object",
-      "required": ["mean_action", "std_action", "mean_state", "std_state"],
+      "required": [
+        "mean_action",
+        "std_action",
+        "mean_state",
+        "std_state"
+      ],
       "additionalProperties": false,
       "properties": {
         "mean_action": {
           "type": "array",
-          "items": { "type": "number" },
+          "items": {
+            "type": "number"
+          },
           "minItems": 1
         },
         "std_action": {
           "type": "array",
-          "items": { "type": "number", "exclusiveMinimum": 0, "maximum": 100 },
+          "items": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "maximum": 100
+          },
           "minItems": 1
         },
         "mean_state": {
           "type": "array",
-          "items": { "type": "number" },
+          "items": {
+            "type": "number"
+          },
           "minItems": 1
         },
         "std_state": {
           "type": "array",
-          "items": { "type": "number", "exclusiveMinimum": 0, "maximum": 100 },
+          "items": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "maximum": 100
+          },
           "minItems": 1
         }
       },
@@ -84,7 +117,11 @@
     },
     "gripper": {
       "type": "object",
-      "required": ["component_idx", "close_threshold", "inverted"],
+      "required": [
+        "component_idx",
+        "close_threshold",
+        "inverted"
+      ],
       "additionalProperties": false,
       "properties": {
         "component_idx": {
@@ -110,27 +147,52 @@
       "maxItems": 8,
       "items": {
         "type": "object",
-        "required": ["name", "resolution", "fps", "color_space"],
+        "required": [
+          "name",
+          "resolution",
+          "fps",
+          "color_space"
+        ],
         "additionalProperties": false,
         "properties": {
-          "name": { "type": "string", "minLength": 1 },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
           "resolution": {
             "type": "array",
             "minItems": 2,
             "maxItems": 2,
-            "items": { "type": "integer", "minimum": 32, "maximum": 4096 }
+            "items": {
+              "type": "integer",
+              "minimum": 32,
+              "maximum": 4096
+            }
           },
-          "fps": { "type": "number", "exclusiveMinimum": 0, "maximum": 240 },
+          "fps": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "maximum": 240
+          },
           "color_space": {
             "type": "string",
-            "enum": ["rgb8", "bgr8", "mono8", "rgba8"]
+            "enum": [
+              "rgb8",
+              "bgr8",
+              "mono8",
+              "rgba8"
+            ]
           }
         }
       }
     },
     "control": {
       "type": "object",
-      "required": ["frequency_hz", "chunk_size", "rtc_execution_horizon"],
+      "required": [
+        "frequency_hz",
+        "chunk_size",
+        "rtc_execution_horizon"
+      ],
       "additionalProperties": false,
       "properties": {
         "frequency_hz": {
@@ -155,7 +217,11 @@
     },
     "constraints": {
       "type": "object",
-      "required": ["max_ee_velocity", "max_gripper_velocity", "collision_check"],
+      "required": [
+        "max_ee_velocity",
+        "max_gripper_velocity",
+        "collision_check"
+      ],
       "additionalProperties": false,
       "properties": {
         "max_ee_velocity": {
@@ -173,6 +239,25 @@
         "collision_check": {
           "type": "boolean",
           "description": "Whether the runtime should run a per-step collision check before commanding."
+        }
+      }
+    },
+    "payload_release": {
+      "type": "object",
+      "required": [
+        "component_idx",
+        "trigger_threshold"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "component_idx": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "trigger_threshold": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
         }
       }
     }

--- a/src/reflex/embodiments/schema.json
+++ b/src/reflex/embodiments/schema.json
@@ -23,7 +23,7 @@
     },
     "embodiment": {
       "type": "string",
-      "enum": ["franka", "so100", "ur5", "trossen", "stretch", "custom"],
+      "enum": ["franka", "so100", "ur5", "trossen", "stretch", "quadcopter", "custom"],
       "description": "Embodiment slug. Must match the file name minus .json for presets."
     },
     "action_space": {

--- a/src/reflex/embodiments/validate.py
+++ b/src/reflex/embodiments/validate.py
@@ -145,20 +145,21 @@ def validate_cross_field(cfg: EmbodimentConfig) -> list[ValidationError]:
             }
         )
 
-    # gripper.component_idx must be inside [0, action_dim)
-    grip_idx = cfg.gripper.get("component_idx", -1)
-    if not 0 <= grip_idx < action_dim:
-        errors.append(
-            {
-                "slug": "gripper-idx-out-of-range",
-                "severity": "error",
-                "field": "gripper.component_idx",
-                "message": (
-                    f"component_idx {grip_idx} is outside action_space "
-                    f"[0, {action_dim})"
-                ),
-            }
-        )
+    # gripper.component_idx must be inside [0, action_dim) if gripper exists
+    if cfg.gripper:
+        grip_idx = cfg.gripper.get("component_idx", -1)
+        if not 0 <= grip_idx < action_dim:
+            errors.append(
+                {
+                    "slug": "gripper-idx-out-of-range",
+                    "severity": "error",
+                    "field": "gripper.component_idx",
+                    "message": (
+                        f"component_idx {grip_idx} is outside action_space "
+                        f"[0, {action_dim})"
+                    ),
+                }
+            )
 
     # control.rtc_execution_horizon is an INTEGER count of actions (per
     # ADR 2026-04-25-auto-calibration-architecture decision #8 — the legacy

--- a/tests/test_embodiments.py
+++ b/tests/test_embodiments.py
@@ -103,9 +103,9 @@ class TestSchemaValidation:
 
     def test_schema_rejects_missing_required_field(self):
         cfg = EmbodimentConfig.load_preset("franka").to_dict()
-        del cfg["gripper"]
+        del cfg["action_space"]
         errors = validate_against_schema(cfg)
-        assert any("gripper" in e["message"] or e["field"] == "gripper" for e in errors)
+        assert any("action_space" in e["message"] or e["field"] == "action_space" for e in errors)
 
     def test_schema_rejects_unknown_embodiment_enum(self):
         cfg = EmbodimentConfig.load_preset("franka").to_dict()

--- a/tests/test_embodiments.py
+++ b/tests/test_embodiments.py
@@ -20,7 +20,7 @@ from reflex.embodiments.validate import (
     validate_embodiment_config,
 )
 
-ALL_PRESETS = ["franka", "so100", "ur5"]
+ALL_PRESETS = ["franka", "quadcopter", "so100", "ur5"]
 
 
 # ---------------------------------------------------------------------------
@@ -69,6 +69,11 @@ class TestEmbodimentLoading:
     def test_ur5_action_dim_seven(self):
         cfg = EmbodimentConfig.load_preset("ur5")
         assert cfg.action_dim == 7
+
+    def test_quadcopter_action_dim_five(self):
+        cfg = EmbodimentConfig.load_preset("quadcopter")
+        assert cfg.action_dim == 5
+        assert cfg.control["frequency_hz"] == 50.0
 
     def test_to_dict_round_trip(self):
         original = EmbodimentConfig.load_preset("franka")
@@ -268,9 +273,10 @@ class TestPresetSemantics:
 
     @pytest.mark.parametrize("name", ALL_PRESETS)
     def test_max_ee_velocity_capped(self, name):
-        """Sanity: presets must keep ee velocity under 2 m/s."""
+        """Sanity: presets must keep ee velocity under 2 m/s (or 6 m/s for flight)."""
         cfg = EmbodimentConfig.load_preset(name)
-        assert 0 < cfg.constraints["max_ee_velocity"] <= 2.0
+        cap = 6.0 if name == "quadcopter" else 2.0
+        assert 0 < cfg.constraints["max_ee_velocity"] <= cap
 
     @pytest.mark.parametrize("name", ALL_PRESETS)
     def test_chunk_size_reasonable(self, name):


### PR DESCRIPTION
## Description
Resolved a semantic mismatch where the quadcopter payload release mechanism was defined under the `gripper` block. Made `gripper` optional in `schema.json`, added a dedicated `payload_release` schema object, and updated the preset config and runtime loader accordingly.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure / CI update

## How Has This Been Tested?
- [x] `pytest tests/` passes locally
- [ ] `reflex doctor` sanity check
- [x] Other (please specify): Verified complete schema compatibility and parsed outputs

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have kept the PR scoped to a single concern (one concern per PR)
