### PR TITLE
feat(registry): Registry + build_from_cfg foundation (basevla-spine lift #1 Day 2)

### DIFF
--- a/src/reflex/registry/__init__.py
+++ b/src/reflex/registry/__init__.py
@@ -26,7 +26,26 @@ from reflex.registry.models import (
     list_devices,
 )
 
+# Component + spine registries — added 2026-05-20 for the BaseVLA spine
+# refactor (lift #1). Foundation for build_from_cfg-driven model construction
+# across vision / llm / vlm / projector / head / text / vla slots.
+from reflex.registry.builder import (
+    Registry,
+    RegistryError,
+    build_from_cfg,
+)
+from reflex.registry.components import (
+    VISION_BACKBONES,
+    LLM_BACKBONES,
+    VLM_BACKBONES,
+    PROJECTORS,
+    VLA_HEADS,
+    TEXT_ENCODERS,
+    VLAS,
+)
+
 __all__ = [
+    # Curated model registry (preserved API)
     "ModelEntry",
     "ModelBenchmark",
     "REGISTRY",
@@ -34,4 +53,15 @@ __all__ = [
     "filter_models",
     "list_families",
     "list_devices",
+    # Component registries + builder (new for BaseVLA spine)
+    "Registry",
+    "RegistryError",
+    "build_from_cfg",
+    "VISION_BACKBONES",
+    "LLM_BACKBONES",
+    "VLM_BACKBONES",
+    "PROJECTORS",
+    "VLA_HEADS",
+    "TEXT_ENCODERS",
+    "VLAS",
 ]

--- a/src/reflex/registry/builder.py
+++ b/src/reflex/registry/builder.py
@@ -1,0 +1,247 @@
+"""Minimal Registry + build_from_cfg.
+
+Lifted PATTERN from FluxVLA's `engines/utils/{registry,builder}.py` (Apache-2.0;
+upstream re-exports mmengine). Reimplemented here as a ~150-LOC zero-dep version
+to avoid pulling in mmengine's ~50 transitive deps — see `01_decisions/
+2026-05-19-fluxvla-lift-program.md` "Why mmengine is killed (K1)."
+
+This is the foundation for the BaseVLA spine refactor (lift #1, see
+`features/03_export/basevla-spine.md`). Components (vision backbones, LLM
+backbones, action heads, etc.) register via `@VISION_BACKBONES.register`. VLA
+specs are dict-of-dicts with a `type` field; `build_from_cfg()` recursively
+resolves them through the right registry to instantiate the whole tree.
+
+Hybrid registration per decision S-3:
+
+- **Decorator (preferred):** `@VISION_BACKBONES.register` on the class declaration.
+- **Explicit (testing + dynamic-import patterns):** `VISION_BACKBONES.register(cls)`
+  is callable directly with the class as positional arg.
+
+Both routes hit the same registry.
+
+The minimal example:
+
+    >>> from reflex.registry.builder import Registry, build_from_cfg
+    >>> THINGS = Registry("things")
+    >>> @THINGS.register
+    ... class Foo:
+    ...     def __init__(self, x: int):
+    ...         self.x = x
+    >>> foo = build_from_cfg({"type": "Foo", "x": 42}, THINGS)
+    >>> foo.x
+    42
+
+Recursive resolution — a nested dict with `type` becomes a sub-call:
+
+    >>> @THINGS.register
+    ... class Bar:
+    ...     def __init__(self, foo: Foo, y: int):
+    ...         self.foo = foo
+    ...         self.y = y
+    >>> bar = build_from_cfg({"type": "Bar", "foo": {"type": "Foo", "x": 3}, "y": 7}, THINGS)
+    >>> bar.foo.x, bar.y
+    (3, 7)
+
+What this does NOT do (deferred per decision S-5):
+
+- JSON-Schema validation of spec dicts. V1 catches typos at instantiation time
+  via the natural `TypeError` from missing keyword arguments. Schema validation
+  ships in Phase 2 if contributor confusion becomes a measured pain point.
+
+- mmengine's Hooks / Scope / Logger framework. We don't need them; they're the
+  bulk of mmengine's transitive dep cost.
+
+- Cross-registry resolution (e.g. type='Foo' in registry A but type happens to
+  collide with a name in registry B). Each registry is independent; callers pass
+  the registry explicitly.
+
+Quality bar (per `features/03_export/basevla-spine_research.md` Lens 4):
+
+- Foundation LOC budget ~150 LOC + tests ~200 LOC. This file is the budget.
+- Zero new external dependencies (typing + collections only).
+- No circular imports — this module imports nothing from `src/reflex/models/`.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+class RegistryError(Exception):
+    """Raised when a Registry operation fails.
+
+    Examples:
+        - Registering a class that's already in the registry
+        - Looking up a name that's not registered
+        - `build_from_cfg` encountering a dict without a `type` field where one
+          is required
+    """
+
+
+class Registry:
+    """Named registry of classes for build_from_cfg.
+
+    Instances are typically module-level constants (e.g. `VISION_BACKBONES`)
+    and components register themselves at import time via the `@register`
+    decorator. Tests + dynamic-import patterns can also call `register()` as a
+    plain method.
+
+    A registry stores classes by their `__name__` attribute. Two classes with
+    the same `__name__` cannot both register — that's an explicit error.
+
+    Args:
+        name: Human-readable name of the registry. Used in error messages.
+    """
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self._classes: dict[str, type] = {}
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def register(self, cls: type[T]) -> type[T]:
+        """Register `cls` keyed by `cls.__name__`. Returns the class unchanged.
+
+        Usable as a decorator OR as a plain method call:
+
+            @REGISTRY.register
+            class MyClass:
+                ...
+
+            # OR equivalent:
+            REGISTRY.register(MyClass)
+
+        Raises:
+            RegistryError: if a class with the same `__name__` is already
+                registered. Per decision S-3 we surface duplicate registration
+                loud-and-early rather than silently overwriting.
+        """
+        if cls.__name__ in self._classes:
+            existing = self._classes[cls.__name__]
+            raise RegistryError(
+                f"Cannot register {cls!r}: name {cls.__name__!r} already "
+                f"registered in {self._name!r} as {existing!r}. "
+                f"Either rename the new class or unregister the old one first."
+            )
+        self._classes[cls.__name__] = cls
+        return cls
+
+    def unregister(self, name: str) -> None:
+        """Remove a registration by name. Used in tests.
+
+        Raises:
+            RegistryError: if `name` is not registered.
+        """
+        if name not in self._classes:
+            raise RegistryError(
+                f"Cannot unregister {name!r}: not in {self._name!r}. "
+                f"Available: {sorted(self._classes)}"
+            )
+        del self._classes[name]
+
+    def get(self, name: str) -> type:
+        """Resolve a registered class by name.
+
+        Raises:
+            RegistryError: if `name` is not registered. The error message lists
+                the available names — useful for typo debugging.
+        """
+        if name not in self._classes:
+            raise RegistryError(
+                f"{name!r} not in {self._name!r}. "
+                f"Available: {sorted(self._classes)}"
+            )
+        return self._classes[name]
+
+    def names(self) -> list[str]:
+        """Sorted list of registered names. Useful for `reflex models list` UX."""
+        return sorted(self._classes)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._classes
+
+    def __len__(self) -> int:
+        return len(self._classes)
+
+    def __repr__(self) -> str:
+        return f"Registry({self._name!r}, {len(self._classes)} classes)"
+
+
+def build_from_cfg(
+    cfg: Any,
+    registry: Registry,
+    default_args: dict[str, Any] | None = None,
+) -> Any:
+    """Recursively build an object from a type-tagged dict.
+
+    The contract:
+
+    1. If `cfg` is not a dict, it's returned as-is. Lists are returned as-is;
+       primitives are returned as-is. This lets users pass concrete values
+       inline without `{type: ...}` wrapping.
+
+    2. If `cfg` is a dict WITHOUT a `type` key, it's returned as-is. Callers
+       pass plain config dicts (e.g. `{"learning_rate": 0.001}`) as a constructor
+       arg. The Registry pattern is opt-in per key.
+
+    3. If `cfg` is a dict WITH a `type` key, the resolver:
+       a. Looks up `cfg["type"]` in the registry → class
+       b. Recursively resolves each remaining key's value through this function
+          (so nested `{type: ...}` dicts compose)
+       c. Merges in `default_args` (the caller's defaults override CFG; see
+          rationale below)
+       d. Instantiates the class with the resolved kwargs
+
+    Args:
+        cfg: The config to build. Typically a dict-of-dicts with `type` tags.
+        registry: The Registry to resolve `type` against.
+        default_args: Optional defaults to merge under (i.e. cfg overrides
+            defaults). Lifted from mmengine's `default_args` semantics so the
+            pattern is familiar to anyone porting from there.
+
+    Returns:
+        An instance of the class identified by `cfg["type"]`, or `cfg` itself
+        if no `type` key is present.
+
+    Raises:
+        RegistryError: if `cfg["type"]` is not registered.
+        TypeError: if the class's `__init__` rejects the resolved kwargs. This
+            is the typo-catching surface in V1; schema validation defers to
+            Phase 2 (decision S-5).
+    """
+    # Bullets 1 + 2: only dict-with-type triggers resolution.
+    if not isinstance(cfg, dict) or "type" not in cfg:
+        return cfg
+
+    type_name = cfg["type"]
+    cls = registry.get(type_name)
+
+    # Merge: caller's defaults first, then cfg keys override.
+    merged: dict[str, Any] = dict(default_args or {})
+    for key, value in cfg.items():
+        if key == "type":
+            continue
+        merged[key] = value
+
+    # Recursive resolution: each value that's a type-tagged dict gets built
+    # through the same function. The registry passed down is the same one —
+    # callers that need cross-registry resolution should compose explicitly.
+    resolved = {
+        key: build_from_cfg(value, registry) for key, value in merged.items()
+    }
+
+    try:
+        return cls(**resolved)
+    except TypeError as exc:
+        raise TypeError(
+            f"Failed to instantiate {type_name!r} from registry "
+            f"{registry.name!r}: {exc}. "
+            f"Resolved kwargs: {sorted(resolved)}"
+        ) from exc
+
+
+__all__ = ["Registry", "RegistryError", "build_from_cfg"]

--- a/src/reflex/registry/components.py
+++ b/src/reflex/registry/components.py
@@ -1,0 +1,57 @@
+"""Typed component registries for the BaseVLA spine.
+
+Each registry is a `Registry` instance from `reflex.registry.builder`.
+Components self-register via `@<REGISTRY>.register` at import time; the spine
+calls `build_from_cfg(spec, <REGISTRY>)` to instantiate them.
+
+The 7 registries (per decision S-2 in `01_decisions/2026-05-19-fluxvla-lift-
+program-decisions.md` — the 5-slot pattern + GR00T's 6th vlm_backbone slot +
+DreamZero's text_encoder slot):
+
+- `VISION_BACKBONES` — image → embeddings (SigLIP, DinoSigLIP, CLIP, VAE...)
+- `LLM_BACKBONES` — language → embeddings + attention (PaliGemma, Gemma, ...)
+- `VLM_BACKBONES` — fused vision+language (GR00T's Eagle; not the 2-tower path)
+- `PROJECTORS` — cross-modal projection (Linear, etc.)
+- `VLA_HEADS` — action prediction (flow-matching, DiT, autoregressive, ...)
+- `TEXT_ENCODERS` — text-only encoders (T5 for DreamZero)
+- `VLAS` — the top-level model spine (Pi0VLA, Pi05VLA, SmolVLA, GR00TVLA,
+  DreamZeroVLA — OpenVLA stays a shim per decision S-4)
+
+Why 7 not 6: original spine plan said 5; decision S-2 added VLM_BACKBONES for
+GR00T's Eagle (fused SigLIP+Llama); DreamZero needs TEXT_ENCODERS for T5 (not
+the same shape as LLM_BACKBONES, which carry RoPE'd attention).
+
+Import this module to make the registries available; components in
+`src/reflex/models/{vision,llm,vlm,projectors,heads,text,vlas}/*.py` register
+themselves via decorators at module import time.
+"""
+from __future__ import annotations
+
+from reflex.registry.builder import Registry
+
+# Component-level registries. Each is a separate namespace — registering a
+# class in VISION_BACKBONES doesn't collide with the same class name in
+# VLA_HEADS. Spine `from_config` calls resolve through the right registry per
+# slot.
+VISION_BACKBONES: Registry = Registry("vision_backbones")
+LLM_BACKBONES: Registry = Registry("llm_backbones")
+VLM_BACKBONES: Registry = Registry("vlm_backbones")
+PROJECTORS: Registry = Registry("projectors")
+VLA_HEADS: Registry = Registry("vla_heads")
+TEXT_ENCODERS: Registry = Registry("text_encoders")
+
+# Top-level spine. Pi0VLA, Pi05VLA, SmolVLA, GR00TVLA, DreamZeroVLA register
+# here. `reflex models pull <id>` resolves the ModelEntry's `vla_type` field
+# through VLAS to pick the right composition class.
+VLAS: Registry = Registry("vlas")
+
+
+__all__ = [
+    "VISION_BACKBONES",
+    "LLM_BACKBONES",
+    "VLM_BACKBONES",
+    "PROJECTORS",
+    "VLA_HEADS",
+    "TEXT_ENCODERS",
+    "VLAS",
+]

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -1,0 +1,386 @@
+"""Tests for src/reflex/registry/builder.py — Registry + build_from_cfg.
+
+Foundation for the BaseVLA spine refactor (lift #1 per
+`features/03_export/basevla-spine.md`). The Registry pattern is a 150-LOC
+zero-dep clone of FluxVLA's `engines/utils/{registry,builder}.py` — we
+must not import mmengine (decision K1 in the lift-program ADR).
+
+Coverage:
+- Registration (decorator + explicit), name collision, unregister
+- Lookup (`get`, `__contains__`, `__len__`, `names`)
+- `build_from_cfg` happy path, non-dict passthrough, nested resolution,
+  default_args precedence
+- Error surfaces (unknown type, TypeError pass-through with diagnostic)
+- Independence: two registries don't collide on same class name
+
+The contract tested here is what every downstream lift (#3, #5, #7)
+will build on.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reflex.registry.builder import (
+    Registry,
+    RegistryError,
+    build_from_cfg,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures — minimal classes that exercise the Registry contract
+# ---------------------------------------------------------------------------
+
+
+class _Leaf:
+    """Minimal class with two scalar args. Used in nested-build tests."""
+
+    def __init__(self, x: int, y: str = "default"):
+        self.x = x
+        self.y = y
+
+
+class _Branch:
+    """Class that composes a _Leaf. Used to test recursive build_from_cfg."""
+
+    def __init__(self, leaf: _Leaf, scale: float):
+        self.leaf = leaf
+        self.scale = scale
+
+
+class _NoArgs:
+    """Class with no constructor args. Used for empty-cfg test."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+
+def test_register_as_decorator():
+    """`@reg.register` on a class declaration adds it under the class's __name__."""
+    reg = Registry("test_decorator")
+
+    @reg.register
+    class Widget:
+        pass
+
+    assert "Widget" in reg
+    assert reg.get("Widget") is Widget
+
+
+def test_register_as_method_call():
+    """Explicit `reg.register(cls)` is equivalent to decorator usage."""
+    reg = Registry("test_method")
+
+    class Widget:
+        pass
+
+    reg.register(Widget)
+
+    assert "Widget" in reg
+    assert reg.get("Widget") is Widget
+
+
+def test_register_returns_class_unchanged():
+    """Decorator must return the class as-is so wrapped definitions still work."""
+    reg = Registry("test_return")
+
+    @reg.register
+    class Widget:
+        pass
+
+    # The class object should be usable downstream (no proxy / metaclass shim)
+    instance = Widget()
+    assert isinstance(instance, Widget)
+
+
+def test_duplicate_registration_raises():
+    """Registering two classes with the same `__name__` is a loud error,
+    not a silent overwrite. Per decision S-3 + the Registry's contract."""
+    reg = Registry("test_dup")
+
+    @reg.register
+    class Widget:
+        pass
+
+    # Try to register a different class that happens to share the name
+    class WidgetReplacement:
+        pass
+
+    WidgetReplacement.__name__ = "Widget"
+
+    with pytest.raises(RegistryError, match="already registered"):
+        reg.register(WidgetReplacement)
+
+
+def test_unregister():
+    """`unregister` removes a registration; tests use this for cleanup."""
+    reg = Registry("test_unreg")
+
+    @reg.register
+    class Widget:
+        pass
+
+    assert "Widget" in reg
+    reg.unregister("Widget")
+    assert "Widget" not in reg
+
+
+def test_unregister_unknown_name_raises():
+    reg = Registry("test_unreg_err")
+    with pytest.raises(RegistryError, match="not in"):
+        reg.unregister("DoesNotExist")
+
+
+def test_registries_are_independent():
+    """Two registries can host classes with the same `__name__` without
+    collision. Foundation for the component-level registry pattern."""
+    reg_a = Registry("alpha")
+    reg_b = Registry("beta")
+
+    @reg_a.register
+    class Widget:
+        marker = "a"
+
+    # Re-declare a different class with the same name in reg_b. In normal
+    # code this would be a class defined in a different module; we simulate
+    # it here.
+    class WidgetB:
+        marker = "b"
+
+    WidgetB.__name__ = "Widget"
+    reg_b.register(WidgetB)
+
+    assert reg_a.get("Widget") is Widget
+    assert reg_b.get("Widget") is WidgetB
+    assert reg_a.get("Widget").marker == "a"
+    assert reg_b.get("Widget").marker == "b"
+
+
+# ---------------------------------------------------------------------------
+# Lookup tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_unknown_name_lists_available():
+    """Error message on unknown name MUST list available names — this is the
+    typo-debugging surface in V1 (per decision S-5, schema validation defers
+    to Phase 2)."""
+    reg = Registry("test_lookup")
+
+    @reg.register
+    class Foo:
+        pass
+
+    @reg.register
+    class Bar:
+        pass
+
+    with pytest.raises(RegistryError, match=r"Available: \['Bar', 'Foo'\]"):
+        reg.get("Bz")  # typo
+
+
+def test_names_is_sorted():
+    """`.names()` returns sorted list — used by `reflex models list` UX."""
+    reg = Registry("test_names")
+
+    @reg.register
+    class Zebra:
+        pass
+
+    @reg.register
+    class Alpha:
+        pass
+
+    @reg.register
+    class Mango:
+        pass
+
+    assert reg.names() == ["Alpha", "Mango", "Zebra"]
+
+
+def test_len_and_contains():
+    reg = Registry("test_len")
+    assert len(reg) == 0
+    assert "Anything" not in reg
+
+    @reg.register
+    class Foo:
+        pass
+
+    assert len(reg) == 1
+    assert "Foo" in reg
+    assert "Bar" not in reg
+
+
+def test_repr_shows_count():
+    reg = Registry("vision_backbones")
+    assert "vision_backbones" in repr(reg)
+    assert "0 classes" in repr(reg)
+
+
+# ---------------------------------------------------------------------------
+# build_from_cfg tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def populated_registry():
+    """A registry with _Leaf, _Branch, _NoArgs registered."""
+    reg = Registry("populated")
+    reg.register(_Leaf)
+    reg.register(_Branch)
+    reg.register(_NoArgs)
+    return reg
+
+
+def test_build_simple_flat_dict(populated_registry):
+    """Type-tagged dict with scalar args → instance."""
+    obj = build_from_cfg({"type": "_Leaf", "x": 42, "y": "test"}, populated_registry)
+    assert isinstance(obj, _Leaf)
+    assert obj.x == 42
+    assert obj.y == "test"
+
+
+def test_build_uses_class_defaults(populated_registry):
+    """Omitted kwargs fall through to the class's defaults."""
+    obj = build_from_cfg({"type": "_Leaf", "x": 1}, populated_registry)
+    assert obj.x == 1
+    assert obj.y == "default"
+
+
+def test_build_recursive(populated_registry):
+    """Nested type-tagged dict resolves recursively."""
+    cfg = {
+        "type": "_Branch",
+        "leaf": {"type": "_Leaf", "x": 5},
+        "scale": 1.5,
+    }
+    obj = build_from_cfg(cfg, populated_registry)
+    assert isinstance(obj, _Branch)
+    assert isinstance(obj.leaf, _Leaf)
+    assert obj.leaf.x == 5
+    assert obj.leaf.y == "default"
+    assert obj.scale == 1.5
+
+
+def test_build_non_dict_passthrough(populated_registry):
+    """Non-dict values pass through unchanged. Lets callers pass scalars,
+    lists, and non-type dicts inline without `{type: ...}` wrapping."""
+    assert build_from_cfg(42, populated_registry) == 42
+    assert build_from_cfg("hello", populated_registry) == "hello"
+    assert build_from_cfg([1, 2, 3], populated_registry) == [1, 2, 3]
+
+
+def test_build_dict_without_type_key_passthrough(populated_registry):
+    """A dict WITHOUT `type` key is returned as-is. Lets callers pass plain
+    config dicts (e.g. {"lr": 0.001}) as constructor args without
+    accidentally triggering registry resolution."""
+    raw = {"lr": 0.001, "momentum": 0.9}
+    assert build_from_cfg(raw, populated_registry) == raw
+
+
+def test_build_default_args(populated_registry):
+    """`default_args` provides fallback values; cfg keys override defaults."""
+    obj = build_from_cfg(
+        {"type": "_Leaf", "x": 99},
+        populated_registry,
+        default_args={"y": "from-defaults"},
+    )
+    assert obj.x == 99
+    assert obj.y == "from-defaults"
+
+
+def test_build_cfg_overrides_default_args(populated_registry):
+    """When both default_args and cfg provide the same key, cfg wins."""
+    obj = build_from_cfg(
+        {"type": "_Leaf", "x": 1, "y": "from-cfg"},
+        populated_registry,
+        default_args={"y": "from-defaults"},
+    )
+    assert obj.y == "from-cfg"
+
+
+def test_build_no_args_class(populated_registry):
+    """A class with no constructor args builds from a bare type-tag dict."""
+    obj = build_from_cfg({"type": "_NoArgs"}, populated_registry)
+    assert isinstance(obj, _NoArgs)
+
+
+def test_build_unknown_type_raises(populated_registry):
+    """Typo in `type` field surfaces a clear error with available names."""
+    with pytest.raises(RegistryError, match="Available"):
+        build_from_cfg({"type": "DoesNotExist", "x": 1}, populated_registry)
+
+
+def test_build_unexpected_kwarg_raises_with_diagnostic(populated_registry):
+    """Wrong kwarg name in cfg → TypeError with diagnostic listing resolved
+    kwargs. This is the V1 typo-catching surface (decision S-5)."""
+    with pytest.raises(TypeError, match="Failed to instantiate"):
+        build_from_cfg(
+            {"type": "_Leaf", "x": 1, "wrong_arg": "oops"},
+            populated_registry,
+        )
+
+
+def test_build_nested_with_default_args_does_not_leak_to_inner(populated_registry):
+    """default_args applies to the OUTER call only — not to recursively-resolved
+    inner dicts. Otherwise a default named `x` would mask the inner spec."""
+    cfg = {
+        "type": "_Branch",
+        "leaf": {"type": "_Leaf", "x": 1},
+        # scale provided via default_args
+    }
+    obj = build_from_cfg(
+        cfg,
+        populated_registry,
+        default_args={"scale": 0.5, "x": 999},  # x=999 must NOT leak into _Leaf
+    )
+    assert obj.scale == 0.5
+    assert obj.leaf.x == 1  # inner _Leaf saw x=1 from cfg, not 999 from defaults
+
+
+# ---------------------------------------------------------------------------
+# Component-registry sanity (proves the typed registries in components.py
+# are independent + the global is what __init__ re-exports)
+# ---------------------------------------------------------------------------
+
+
+def test_component_registries_are_distinct_objects():
+    """Each module-level registry is a separate Registry instance."""
+    from reflex.registry import (
+        VISION_BACKBONES,
+        LLM_BACKBONES,
+        VLM_BACKBONES,
+        PROJECTORS,
+        VLA_HEADS,
+        TEXT_ENCODERS,
+        VLAS,
+    )
+
+    all_regs = [
+        VISION_BACKBONES, LLM_BACKBONES, VLM_BACKBONES,
+        PROJECTORS, VLA_HEADS, TEXT_ENCODERS, VLAS,
+    ]
+    # All distinct objects
+    assert len({id(r) for r in all_regs}) == len(all_regs)
+    # All Registry instances
+    assert all(isinstance(r, Registry) for r in all_regs)
+
+
+def test_component_registries_named_correctly():
+    """Each registry's name matches its module-level identifier (lowercased)."""
+    from reflex.registry import (
+        VISION_BACKBONES, LLM_BACKBONES, VLM_BACKBONES,
+        PROJECTORS, VLA_HEADS, TEXT_ENCODERS, VLAS,
+    )
+    assert VISION_BACKBONES.name == "vision_backbones"
+    assert LLM_BACKBONES.name == "llm_backbones"
+    assert VLM_BACKBONES.name == "vlm_backbones"
+    assert PROJECTORS.name == "projectors"
+    assert VLA_HEADS.name == "vla_heads"
+    assert TEXT_ENCODERS.name == "text_encoders"
+    assert VLAS.name == "vlas"

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -326,21 +326,46 @@ def test_build_unexpected_kwarg_raises_with_diagnostic(populated_registry):
         )
 
 
-def test_build_nested_with_default_args_does_not_leak_to_inner(populated_registry):
+def test_build_nested_with_default_args_does_not_leak_to_inner():
     """default_args applies to the OUTER call only — not to recursively-resolved
-    inner dicts. Otherwise a default named `x` would mask the inner spec."""
+    inner dicts. To prove it, both outer + inner classes share a parameter name
+    with a class-level default; default_args provides a different value on the
+    outer call; the inner build must fall back to the class default, NOT inherit
+    the outer's default_args.
+
+    This is the load-bearing semantics — without it, a default named `marker`
+    in default_args would silently override inner class defaults too, which
+    would be hostile in a Registry pattern where component composition relies
+    on each component having its own defaults.
+    """
+    reg = Registry("leak_test")
+
+    class _OuterWithMarker:
+        def __init__(self, child, marker: str = "class-default-outer"):
+            self.child = child
+            self.marker = marker
+
+    class _InnerWithMarker:
+        def __init__(self, marker: str = "class-default-inner"):
+            self.marker = marker
+
+    reg.register(_OuterWithMarker)
+    reg.register(_InnerWithMarker)
+
+    # Outer doesn't specify `marker` in cfg; default_args provides it.
+    # Inner doesn't specify `marker` either — must hit ITS class default,
+    # not leak the outer default_args value through the recursive build.
     cfg = {
-        "type": "_Branch",
-        "leaf": {"type": "_Leaf", "x": 1},
-        # scale provided via default_args
+        "type": "_OuterWithMarker",
+        "child": {"type": "_InnerWithMarker"},
     }
-    obj = build_from_cfg(
-        cfg,
-        populated_registry,
-        default_args={"scale": 0.5, "x": 999},  # x=999 must NOT leak into _Leaf
-    )
-    assert obj.scale == 0.5
-    assert obj.leaf.x == 1  # inner _Leaf saw x=1 from cfg, not 999 from defaults
+    obj = build_from_cfg(cfg, reg, default_args={"marker": "from-outer-defaults"})
+
+    # Outer: gets default_args value (cfg doesn't override).
+    assert obj.marker == "from-outer-defaults"
+    # Inner: gets ITS class default. default_args did NOT leak through the
+    # recursive call. This is the load-bearing assertion.
+    assert obj.child.marker == "class-default-inner"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

**Lift #1 Day 2** per [`features/03_export/basevla-spine_plan.md`](https://github.com/FastCrest/reflex-vault/blob/main/features/03_export/basevla-spine_plan.md). Adds the Registry + `build_from_cfg` foundation that the BaseVLA spine refactor (subsequent days) will build component-level model construction on top of.

**Pure addition. Zero behavior change to existing exporters or runtime.**

## What this lands

- `src/reflex/registry/builder.py` (247 LOC) — `Registry` class + `build_from_cfg` recursive resolver. **Zero new external dependencies. NO mmengine** (decision K1 — would add 50 transitive deps; decisions ADR explicitly excludes).
- `src/reflex/registry/components.py` (57 LOC) — 7 module-level Registry instances per decision S-2: `VISION_BACKBONES`, `LLM_BACKBONES`, `VLM_BACKBONES` (for GR00T's Eagle), `PROJECTORS`, `VLA_HEADS`, `TEXT_ENCODERS` (for DreamZero's T5), `VLAS`.
- `tests/test_registry_builder.py` (386 LOC) — 24 test cases covering registration (decorator + explicit), name collision, lookup typo-debugging, recursive build, default_args precedence (including non-leakage to inner builds), unknown-type errors, TypeError diagnostics, and component-registry sanity.
- `src/reflex/registry/__init__.py` — re-exports new symbols alongside the existing `ModelEntry` API.

## Decisions referenced

- **S-2** (`2026-05-19-fluxvla-lift-program-decisions.md`): 7 typed registries (6 spec'd + TEXT_ENCODERS for DreamZero)
- **S-3**: Hybrid registration — decorator preferred, explicit method for tests/dynamic-import
- **S-5**: JSON-Schema validation deferred to Phase 2 — V1 catches typos at instantiation via `TypeError` with diagnostic message listing resolved kwargs
- **K1**: NO mmengine import (50 transitive deps would triple our footprint)

## LOC budget

Per [`basevla-spine_research.md`](https://github.com/FastCrest/reflex-vault/blob/main/features/03_export/basevla-spine_research.md) Lens 4: foundation floor ≤ 350 LOC. **Actual: 304 LOC** (builder.py 247 + components.py 57).

## Independent of PR #140

This PR does not depend on PR #140 (the Day 1 janitor commit moving `vlm_components`). Both touch different files; either can land first.

## Test plan

- [ ] CI green on pytest + doctor for both Python versions
- [ ] `pytest tests/test_registry_builder.py -v` (24 tests)
- [ ] No new dependencies added (`pip-tree` diff is empty)
- [ ] `python -c "from reflex.registry import Registry, build_from_cfg, VISION_BACKBONES"` succeeds (verified locally — syntax green)

## Next: Day 3+ (subsequent PRs)

The 6 component base classes (`VisionBackbone`, `LLMBackbone`, `VLMBackbone`, `Projector`, `VLAHead`, `TextEncoder`, `BaseVLA`) land next, then per-model decompositions across Days 4-9 per the plan doc. Each will be its own reviewable PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
