### PR TITLE
fix(deps): scope numpy<2 upper bound to aarch64 (Jetson) only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,15 @@ dependencies = [
     "typer>=0.9.0",
     "rich>=13.0.0",
     "pydantic>=2.0.0",
-    "numpy>=1.24.0,<2.0",
+    # numpy upper bound is Jetson-only — JetPack ships bundled CUDA libs
+    # compiled against numpy 1.x ABI; numpy 2.x's ABI break corrupts ORT +
+    # JAX wheels on aarch64. On x86_64 (Modal A100, customer desktops) +
+    # arm64 (M-series Mac dev hosts) numpy 2.x is fine, AND the
+    # [monolithic] extra's lerobot==0.5.1 dep REQUIRES numpy>=2.0 — pinning
+    # numpy<2 globally makes lerobot uninstallable on Modal (caught by the
+    # 2026-05-20 lift #4 smoke fire). Split via PEP-508 platform marker.
+    "numpy>=1.24.0,<2.0; platform_machine == 'aarch64'",
+    "numpy>=1.24.0; platform_machine != 'aarch64'",
     "pyyaml>=6.0",
     # Always needed: hub access for `reflex export <hf_id>` and tokenizer/config
     # loading for the auto-detect path. Apr-14 install-path verification caught


### PR DESCRIPTION
## Summary

The Jetson commit (`f9811d2`) pinned `numpy>=1.24.0,<2.0` globally to protect JetPack-bundled CUDA libs. That cap was correct for Jetson (aarch64) but unintentionally extended to x86_64 + Mac arm64 where:

- numpy 2.x works fine
- `lerobot==0.5.1` (pinned in `[monolithic]` + `[native]` extras) REQUIRES `numpy>=2.0`

Result: `pip install reflex-vla[monolithic]` is UNRESOLVABLE on Modal A100. All reflex+lerobot Modal experiments have been silently blocked since `f9811d2` landed.

## How it surfaced

Caught while firing a 1-task / 1-episode smoke against `scripts/modal_libero_pi05_decomposed.py` to validate behavior preservation through the rollout-helper refactor (PR #139). The image build failed at `pip install` with `ResolutionImpossible`.

## Fix

Split the numpy constraint via PEP 508 platform marker:

```toml
"numpy>=1.24.0,<2.0; platform_machine == 'aarch64'",  # Jetson preserved
"numpy>=1.24.0; platform_machine != 'aarch64'",       # x86 + arm64 freed
```

Verified locally: on arm64 (Mac), constraint 2 evaluates true, constraint 1 evaluates false. On aarch64, inverse. pip resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)