### PR TITLE
feat(models): BaseVLA spine + 6 component bases + name_mapping (basevla-spine lift #1 Day 3)

### DIFF
--- a/src/reflex/models/__init__.py
+++ b/src/reflex/models/__init__.py
@@ -1,1 +1,15 @@
-"""VLA model definitions for export."""
+"""VLA model definitions — both the legacy per-model modules (adapt, smolvla)
+AND the BaseVLA spine (lift #1 Day 3+).
+
+The spine is the long-term home for model composition; legacy modules stay
+in place until each VLA is decomposed onto the spine (Days 4-9 per
+`features/03_export/basevla-spine_plan.md`).
+"""
+from reflex.models._name_mapping import apply_name_mapping
+from reflex.models.base_vla import ALL_SLOTS, BaseVLA
+
+__all__ = [
+    "BaseVLA",
+    "ALL_SLOTS",
+    "apply_name_mapping",
+]

--- a/src/reflex/models/_name_mapping.py
+++ b/src/reflex/models/_name_mapping.py
@@ -1,0 +1,111 @@
+"""Per-VLA name_mapping walker for HF checkpoint compatibility.
+
+Lifted from FluxVLA's `base_vla.py:201-299` pattern per decision S-1
+(`01_decisions/2026-05-19-fluxvla-lift-program-decisions.md`) — per-VLA-config,
+NOT per-component. Each VLA class declares its rename map; the walker applies
+it to an incoming HF state_dict before loading into the spine's components.
+
+Why per-VLA-config not per-component: keeps the spine's component classes
+oblivious to HF-checkpoint naming conventions. The naming is a VLA-level
+concern (each VLA has its own historical naming from upstream training); the
+components just need cleanly-named weights at load time.
+
+Pattern (in a VLA subclass):
+
+    @VLAS.register
+    class Pi05VLA(BaseVLA):
+        # Strip 'module.' prefix from DDP-trained checkpoints; route
+        # paligemma_with_expert.paligemma.model.language_model.* → llm_backbone.*
+        NAME_MAPPING = {
+            "module.": "",
+            "paligemma_with_expert.paligemma.model.language_model": "llm_backbone",
+            "paligemma_with_expert.gemma_expert": "llm_backbone.expert",
+            "action_in_proj": "vla_head.action_in_proj",
+            "action_out_proj": "vla_head.action_out_proj",
+            "state_proj": "projector.state_proj",
+        }
+        ...
+
+The walker is intentionally simple — first-match-wins prefix substitution.
+For checkpoints that need regex-level remapping, override
+`apply_name_mapping()` on the VLA subclass instead.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+
+
+def apply_name_mapping(
+    state_dict: dict[str, "torch.Tensor"],
+    name_mapping: dict[str, str],
+    *,
+    strict: bool = False,
+) -> dict[str, "torch.Tensor"]:
+    """Rename state_dict keys via a per-VLA name_mapping dict.
+
+    The mapping is iterated in declaration order; first prefix match wins.
+    Keys without any matching prefix pass through unchanged (callers can
+    set `strict=True` to raise on unmatched keys instead).
+
+    Args:
+        state_dict: HF checkpoint as `{old_key: tensor}`.
+        name_mapping: `{src_prefix: dst_prefix}`. Empty src_prefix is invalid.
+        strict: If True, raise KeyError for any state_dict key that doesn't
+            match any name_mapping prefix. Useful for catching upstream HF
+            checkpoint layout drift early (per CLAUDE.md "fail loudly").
+
+    Returns:
+        New dict with renamed keys. The original state_dict is not mutated.
+
+    Raises:
+        KeyError: if `strict=True` and a state_dict key matches no prefix.
+        ValueError: if `name_mapping` contains an empty src_prefix (ambiguous).
+    """
+    # Validate mapping eagerly — easier to debug at load time than at use time.
+    for src in name_mapping:
+        if not src:
+            raise ValueError(
+                "name_mapping contains empty src_prefix — would match every key. "
+                "If you intended to add a prefix to all keys, use a non-empty "
+                "marker (e.g. 'model.') as the src."
+            )
+
+    # Preserve mapping declaration order for first-match-wins semantics.
+    # (dict iteration is insertion-ordered as of Python 3.7+.)
+    mapping_items = list(name_mapping.items())
+
+    renamed: dict[str, "torch.Tensor"] = {}
+    unmatched: list[str] = []
+
+    for old_key, tensor in state_dict.items():
+        new_key = _rename_key(old_key, mapping_items)
+        if new_key is old_key and strict:
+            # Pure identity → no prefix matched → unmatched in strict mode.
+            unmatched.append(old_key)
+        renamed[new_key] = tensor
+
+    if strict and unmatched:
+        sample = unmatched[:5]
+        more = f" (+ {len(unmatched) - 5} more)" if len(unmatched) > 5 else ""
+        raise KeyError(
+            f"{len(unmatched)} state_dict key(s) matched no name_mapping prefix "
+            f"in strict mode. First 5: {sample}{more}. "
+            f"Either add a passthrough entry to name_mapping (e.g. "
+            f"'kept_prefix.': 'kept_prefix.') or call with strict=False."
+        )
+
+    return renamed
+
+
+def _rename_key(key: str, mapping_items: list[tuple[str, str]]) -> str:
+    """First-match-wins prefix substitution. Returns key unchanged if no match."""
+    for src_prefix, dst_prefix in mapping_items:
+        if key.startswith(src_prefix):
+            return dst_prefix + key[len(src_prefix):]
+    return key
+
+
+__all__ = ["apply_name_mapping"]

--- a/src/reflex/models/base_vla.py
+++ b/src/reflex/models/base_vla.py
@@ -1,0 +1,384 @@
+"""BaseVLA abstract spine — foundation for the model-agnostic VLA refactor.
+
+Lifted PATTERN from FluxVLA's `fluxvla/models/vlas/base_vla.py:36-299` per
+the lift-program ADR + decisions (S-1 through S-5 in `01_decisions/
+2026-05-19-fluxvla-lift-program-decisions.md`). Reimplemented without
+mmengine / GenerationMixin / nn.Module-as-abstract — we don't need their
+training-spine machinery; we need a clean composition surface that
+exporters and the runtime can both walk.
+
+Per decision S-2: **six component slots**, not the five FluxVLA spec'd.
+GR00T's Eagle (fused SigLIP + Llama) doesn't decompose into the standard
+vision_backbone + llm_backbone pattern, so it gets its own `vlm_backbone`
+slot. DreamZero's T5 text encoder doesn't fit `llm_backbone` (no RoPE'd
+attention) so it gets `text_encoder`.
+
+| Slot | Used by |
+|---|---|
+| `vision_backbone` | pi0, pi0.5, smolvla (SigLIP / DinoSigLIP) |
+| `llm_backbone` | pi0, pi0.5, smolvla (PaliGemma / SmolLM2) |
+| `vlm_backbone` | GR00T (Eagle = SigLIP+Llama fused) |
+| `projector` | most VLAs (action/state projection) |
+| `vla_head` | every VLA (flow-matching / DiT / argmax) |
+| `text_encoder` | DreamZero (T5) |
+
+Concrete VLAs declare `REQUIRED_SLOTS` + `OPTIONAL_SLOTS` to enforce
+which slots their composition needs. The spine raises at construction
+if a required slot is missing.
+
+Per decision S-3 (hybrid registration): subclasses register via the
+`@VLAS.register` decorator from `reflex.registry.components`.
+
+Per decision S-5: JSON-Schema validation defers to Phase 2 — V1 catches
+typos at instantiation time via natural `TypeError` from missing kwargs.
+
+Construction surface (lift #1 Day 4+):
+
+    @VLAS.register
+    class Pi05VLA(BaseVLA):
+        REQUIRED_SLOTS = ("vision_backbone", "llm_backbone", "projector", "vla_head")
+        OPTIONAL_SLOTS = ()
+        NAME_MAPPING = {...}
+
+        def forward(self, batch):
+            ...
+
+        def predict_action(self, images, state, instruction):
+            ...
+
+    pi05 = Pi05VLA.from_config({
+        "vision_backbone": {"type": "SigLIPBackbone", "model_id": "..."},
+        "llm_backbone": {"type": "PaliGemmaWithExpert", "model_id": "..."},
+        "projector": {"type": "LinearProjector", ...},
+        "vla_head": {"type": "FlowMatchingHead", ...},
+    })
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from reflex.models._name_mapping import apply_name_mapping
+
+if TYPE_CHECKING:
+    import torch
+
+
+# All component slot names recognized by the spine. Subclasses pick from
+# this set via REQUIRED_SLOTS + OPTIONAL_SLOTS.
+ALL_SLOTS: tuple[str, ...] = (
+    "vision_backbone",
+    "llm_backbone",
+    "vlm_backbone",
+    "projector",
+    "vla_head",
+    "text_encoder",
+)
+
+
+class BaseVLA(ABC):
+    """Abstract spine for vision-language-action models.
+
+    Concrete VLAs subclass BaseVLA + register via `@VLAS.register`. The
+    constructor accepts component instances (any of the 6 slots, optional
+    for the spine but required-per-VLA via REQUIRED_SLOTS) and stores them
+    as attributes.
+
+    `from_config(spec)` is the recommended construction path — it resolves
+    type-tagged dicts through the Registry. Direct kwarg construction is
+    supported for tests + dynamic patterns.
+
+    Subclass contract:
+
+    - **REQUIRED_SLOTS** (class var): slot names that MUST be provided to
+      the constructor. Missing required slot raises ValueError.
+    - **OPTIONAL_SLOTS** (class var): slot names that MAY be provided.
+      Slots not in either set are rejected.
+    - **NAME_MAPPING** (class var): per-VLA HF-checkpoint rename map
+      (per decision S-1). Default empty dict = no renaming.
+    - **forward(batch)** (abstract): the model's main forward pass.
+    - **predict_action(...)** (abstract): inference-time action prediction.
+      Signature is VLA-specific; the abstract method just declares it exists.
+
+    Provided concretely:
+
+    - **prepare_inference_weights()**: flatten all components' `prepare_triton`
+      outputs into one dict. Used by `--inference-only-weights` mode in
+      lift #3. Override only if your VLA needs custom weight aggregation.
+    - **load_state_dict(state_dict, *, strict=False)**: apply NAME_MAPPING
+      then load into the spine's components. Per decision S-1.
+    """
+
+    # ── Class-level contract — subclasses MUST override ────────────────
+    REQUIRED_SLOTS: ClassVar[tuple[str, ...]] = ()
+    OPTIONAL_SLOTS: ClassVar[tuple[str, ...]] = ()
+    NAME_MAPPING: ClassVar[dict[str, str]] = {}
+
+    # ── Construction ─────────────────────────────────────────────────────
+
+    def __init__(
+        self,
+        *,
+        vision_backbone: Any = None,
+        llm_backbone: Any = None,
+        vlm_backbone: Any = None,
+        projector: Any = None,
+        vla_head: Any = None,
+        text_encoder: Any = None,
+    ) -> None:
+        # Subclasses must declare REQUIRED_SLOTS / OPTIONAL_SLOTS.
+        # Validate the subclass declaration is sane.
+        cls = type(self)
+        declared = set(cls.REQUIRED_SLOTS) | set(cls.OPTIONAL_SLOTS)
+        unknown = declared - set(ALL_SLOTS)
+        if unknown:
+            raise TypeError(
+                f"{cls.__name__} declares unknown slot(s): {sorted(unknown)}. "
+                f"Valid slots: {ALL_SLOTS}. Adding a new slot type requires "
+                f"a spine extension proposal — see basevla-spine.md anti-goals."
+            )
+        overlap = set(cls.REQUIRED_SLOTS) & set(cls.OPTIONAL_SLOTS)
+        if overlap:
+            raise TypeError(
+                f"{cls.__name__}: slot(s) {sorted(overlap)} appear in both "
+                f"REQUIRED_SLOTS and OPTIONAL_SLOTS. Pick one."
+            )
+
+        # Bind passed components to attributes.
+        passed = {
+            "vision_backbone": vision_backbone,
+            "llm_backbone": llm_backbone,
+            "vlm_backbone": vlm_backbone,
+            "projector": projector,
+            "vla_head": vla_head,
+            "text_encoder": text_encoder,
+        }
+
+        # Validate required slots are populated.
+        missing = [
+            slot for slot in cls.REQUIRED_SLOTS
+            if passed.get(slot) is None
+        ]
+        if missing:
+            raise ValueError(
+                f"{cls.__name__} missing required slot(s): {missing}. "
+                f"REQUIRED_SLOTS = {cls.REQUIRED_SLOTS}"
+            )
+
+        # Validate non-declared slots aren't populated (catches typos
+        # where caller passes vlm_backbone to a 2-tower model).
+        passed_slots = {s for s, v in passed.items() if v is not None}
+        undeclared = passed_slots - declared
+        if undeclared:
+            raise ValueError(
+                f"{cls.__name__} received component(s) for undeclared "
+                f"slot(s): {sorted(undeclared)}. REQUIRED + OPTIONAL = "
+                f"{sorted(declared)}"
+            )
+
+        # Bind all 6 slots (declared get the value, undeclared stay None).
+        for slot in ALL_SLOTS:
+            setattr(self, slot, passed.get(slot))
+
+    # ── Construction-from-config (the spine's primary entry point) ──────
+
+    @classmethod
+    def from_config(cls, spec: dict[str, Any]) -> "BaseVLA":
+        """Build a VLA instance from a type-tagged spec dict.
+
+        Spec format:
+            {
+                "vision_backbone": {"type": "SigLIPBackbone", "model_id": "..."},
+                "llm_backbone": {"type": "PaliGemmaWithExpert", ...},
+                ...
+            }
+
+        Each slot value is either:
+        - A type-tagged dict → resolved through the matching component
+          Registry (VISION_BACKBONES / LLM_BACKBONES / etc.)
+        - A pre-built component instance → passed through unchanged
+        - None → slot stays unbound (and must be in OPTIONAL_SLOTS)
+
+        Returns:
+            A new instance of `cls`.
+
+        Raises:
+            ValueError: if a required slot is missing or an undeclared
+                slot is provided.
+            RegistryError: if a slot's `type` doesn't resolve in the
+                matching component registry.
+        """
+        # Lazy import to avoid circular: components.py imports builder.py,
+        # both depend on this file's __all__ exposure indirectly.
+        from reflex.registry.builder import build_from_cfg
+        from reflex.registry.components import (
+            VISION_BACKBONES,
+            LLM_BACKBONES,
+            VLM_BACKBONES,
+            PROJECTORS,
+            VLA_HEADS,
+            TEXT_ENCODERS,
+        )
+
+        slot_registries = {
+            "vision_backbone": VISION_BACKBONES,
+            "llm_backbone": LLM_BACKBONES,
+            "vlm_backbone": VLM_BACKBONES,
+            "projector": PROJECTORS,
+            "vla_head": VLA_HEADS,
+            "text_encoder": TEXT_ENCODERS,
+        }
+
+        kwargs: dict[str, Any] = {}
+        for slot, value in spec.items():
+            if slot not in ALL_SLOTS:
+                raise ValueError(
+                    f"Unknown slot {slot!r} in spec for {cls.__name__}. "
+                    f"Valid: {ALL_SLOTS}"
+                )
+            if value is None:
+                kwargs[slot] = None
+            elif isinstance(value, dict) and "type" in value:
+                kwargs[slot] = build_from_cfg(value, slot_registries[slot])
+            else:
+                # Pre-built instance — pass through.
+                kwargs[slot] = value
+
+        return cls(**kwargs)
+
+    # ── Abstract methods — subclasses MUST implement ────────────────────
+
+    @abstractmethod
+    def forward(self, batch: Any) -> Any:
+        """Forward pass — VLA-specific signature.
+
+        Subclasses define the exact input/output shape. The spine just
+        guarantees this method exists.
+        """
+        ...
+
+    @abstractmethod
+    def predict_action(
+        self,
+        *,
+        images: Any,
+        state: Any,
+        instruction: str,
+    ) -> Any:
+        """Inference-time action prediction.
+
+        Standard signature across VLAs to keep the runtime + chat surface
+        uniform. VLA-specific details (chunk size, action_dim, denoise
+        steps) are subclass concerns.
+        """
+        ...
+
+    # ── Concrete methods — subclasses MAY override ───────────────────────
+
+    def prepare_inference_weights(self, prefix: str = "") -> dict[str, "torch.Tensor"]:
+        """Flatten all components' prepare_triton outputs into one dict.
+
+        Used by `--inference-only-weights` mode (lift #3). Calls each
+        bound component's `prepare_triton(prefix=<slot>.)` and merges
+        the returned dicts.
+
+        Components return empty dicts by default (the base ABCs ship a
+        no-op `prepare_triton`); lift #3 fills in the real
+        implementations per-component.
+
+        Args:
+            prefix: Optional prefix prepended to ALL keys. Useful when
+                composing one VLA's weights into a larger dict.
+
+        Returns:
+            `{full_key: tensor}` — e.g.
+            `{"vision_backbone.patch_embed.weight": <tensor>, ...}`.
+            Empty if no components are bound or no components override
+            `prepare_triton`.
+        """
+        flat: dict[str, "torch.Tensor"] = {}
+        for slot in ALL_SLOTS:
+            component = getattr(self, slot, None)
+            if component is None:
+                continue
+            if not hasattr(component, "prepare_triton"):
+                # Component base classes provide a default; user-supplied
+                # components without it are silently skipped (caller can
+                # validate themselves if they care).
+                continue
+            slot_prefix = f"{prefix}{slot}."
+            sub_weights = component.prepare_triton(prefix=slot_prefix)
+            flat.update(sub_weights)
+        return flat
+
+    def load_state_dict(
+        self,
+        state_dict: dict[str, "torch.Tensor"],
+        *,
+        strict: bool = False,
+    ) -> None:
+        """Apply NAME_MAPPING + route weights to components.
+
+        Per decision S-1 — the NAME_MAPPING is per-VLA-config (class var).
+        This method:
+
+        1. Applies NAME_MAPPING to the input state_dict.
+        2. Groups keys by slot prefix (the leading segment matches a slot
+           name in ALL_SLOTS).
+        3. For each slot, delegates `{slot-prefix}.x.y.z` → `component.x.y.z`
+           via the component's own load_state_dict if present (PyTorch
+           Modules support this natively; plain components must implement
+           it explicitly).
+
+        Args:
+            state_dict: HF checkpoint state_dict.
+            strict: If True, every key in the (renamed) state_dict must
+                map to a bound component slot. False = unmatched keys
+                are silently dropped (default for backward compatibility
+                with HF checkpoints that ship extra metadata).
+        """
+        renamed = apply_name_mapping(state_dict, self.NAME_MAPPING)
+
+        # Group by slot prefix.
+        by_slot: dict[str, dict[str, "torch.Tensor"]] = {s: {} for s in ALL_SLOTS}
+        unassigned: list[str] = []
+        for key, tensor in renamed.items():
+            slot_name, _, sub_key = key.partition(".")
+            if slot_name in ALL_SLOTS and sub_key:
+                by_slot[slot_name][sub_key] = tensor
+            else:
+                unassigned.append(key)
+
+        if strict and unassigned:
+            sample = unassigned[:5]
+            more = f" (+ {len(unassigned) - 5} more)" if len(unassigned) > 5 else ""
+            raise KeyError(
+                f"{len(unassigned)} renamed key(s) don't start with a known "
+                f"slot prefix. First 5: {sample}{more}. Valid slots: "
+                f"{ALL_SLOTS}"
+            )
+
+        # Delegate per-slot loading.
+        for slot, sub_state in by_slot.items():
+            if not sub_state:
+                continue
+            component = getattr(self, slot, None)
+            if component is None:
+                if strict:
+                    raise ValueError(
+                        f"state_dict has keys for slot {slot!r} but no "
+                        f"component is bound there in {type(self).__name__}."
+                    )
+                continue
+            if hasattr(component, "load_state_dict"):
+                # PyTorch nn.Module pattern: signature is
+                # (state_dict, strict=True). Some custom components may
+                # take only the state_dict. Try the rich signature first.
+                try:
+                    component.load_state_dict(sub_state, strict=strict)
+                except TypeError:
+                    # Fall back to single-arg signature.
+                    component.load_state_dict(sub_state)
+
+
+__all__ = ["BaseVLA", "ALL_SLOTS"]

--- a/src/reflex/models/heads/__init__.py
+++ b/src/reflex/models/heads/__init__.py
@@ -1,0 +1,46 @@
+"""VLAHead abstract base — action-prediction head for the BaseVLA spine.
+
+Per decision S-2 + S-3. Subclasses register via `@VLA_HEADS.register`.
+
+The head is the one component every VLA has — it produces actions. Heads
+differ markedly across VLA families (flow-matching vs DiT diffusion vs
+autoregressive argmax-over-bins) so the base ABC stays minimal.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+
+
+class VLAHead(ABC):
+    """Abstract action head — context embeddings → action chunk.
+
+    Subclass contract:
+
+    - `__init__(self, config: Any)` — accept VLA-spec config.
+    - `forward(self, context, ...)` — abstract; the input shape depends
+      on the head type. Flow-matching heads take VLM context + noise +
+      timestep; DiT heads take VLM KV + noise + timestep; OpenVLA's
+      argmax head takes Llama hidden states.
+    - `prepare_triton(self, prefix: str = "") -> dict[str, torch.Tensor]` —
+      no-op default; lift #3 fills in.
+
+    Concrete examples (added in lift #1 Days 4-7):
+    - `FlowMatchingHead` — pi0/pi0.5/smolvla shared flow-matching head
+    - `DiTHead` — GR00T's diffusion transformer head
+    - `OpenVLAHead` — Llama-2 argmax-over-bins (lives in `exporters/openvla.py`
+      shim per decision S-4, NOT on the spine)
+    """
+
+    @abstractmethod
+    def forward(self, context: Any, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+    def prepare_triton(self, prefix: str = "") -> dict[str, "torch.Tensor"]:
+        return {}
+
+
+__all__ = ["VLAHead"]

--- a/src/reflex/models/llm/__init__.py
+++ b/src/reflex/models/llm/__init__.py
@@ -1,0 +1,56 @@
+"""LLMBackbone abstract base — language-model slot for the BaseVLA spine.
+
+Per decision S-2 + S-3. Subclasses register via `@LLM_BACKBONES.register`.
+
+This slot is for **2-tower** VLAs where the language model is a distinct
+component (PaliGemma + Gemma expert; SmolLM2 + action expert). For
+**fused** VLMs like GR00T's Eagle, use `VLMBackbone` instead (the spine's
+6th slot, decision S-2).
+
+For text-only encoders without RoPE'd attention (DreamZero's T5), use
+`TextEncoder` instead.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+
+
+class LLMBackbone(ABC):
+    """Abstract language model — tokens → contextualized embeddings + KV.
+
+    Subclass contract:
+
+    - `__init__(self, config: Any)` — accept VLA-spec config.
+    - `forward(self, input_ids, attention_mask, ...)` — abstract; the
+      exact signature is VLA-specific (single-tower vs dual-tower with
+      action expert, with/without past_kv).
+    - `prepare_triton(self, prefix: str = "") -> dict[str, torch.Tensor]` —
+      no-op default; lift #3 fills in.
+
+    Concrete examples (added in lift #1 Days 4-7):
+    - `PaliGemmaBackbone` — Pi0/Pi0.5's language tower (without expert)
+    - `PaliGemmaWithExpert` — Pi0.5's fused paligemma + gemma_expert
+    - `SmolLM2Backbone` — SmolVLA's language tower
+    - `GemmaExpertBackbone` — standalone Gemma action expert (Pi0 path)
+    """
+
+    @abstractmethod
+    def forward(
+        self,
+        input_ids: Any,
+        attention_mask: Any | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Token IDs → embeddings + (optional) KV cache. VLA-specific shape."""
+        ...
+
+    def prepare_triton(self, prefix: str = "") -> dict[str, "torch.Tensor"]:
+        return {}
+
+
+__all__ = ["LLMBackbone"]

--- a/src/reflex/models/projectors/__init__.py
+++ b/src/reflex/models/projectors/__init__.py
@@ -1,0 +1,43 @@
+"""Projector abstract base — cross-modal projection slot for the BaseVLA spine.
+
+Per decision S-2 + S-3. Subclasses register via `@PROJECTORS.register`.
+
+Projectors handle dim/shape adaptation between components — e.g. mapping
+robot state vector to VLM hidden space, or projecting action embeddings
+from expert hidden to action_dim. Most VLAs need at least one; some
+(DreamZero) embed projection inside the head.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+
+
+class Projector(ABC):
+    """Abstract cross-modal projection — input embeddings → output embeddings.
+
+    Subclass contract:
+
+    - `__init__(self, config: Any)` — accept VLA-spec config.
+    - `forward(self, x, ...)` — abstract; the input shape depends on
+      what's being projected (state vector, action embeddings, etc.).
+    - `prepare_triton(self, prefix: str = "") -> dict[str, torch.Tensor]` —
+      no-op default; lift #3 fills in.
+
+    Concrete examples (added in lift #1 Days 4-7):
+    - `LinearProjector` — single nn.Linear, the common case
+    - `StateProjector` — robot-state → VLM-hidden
+    """
+
+    @abstractmethod
+    def forward(self, x: Any, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+    def prepare_triton(self, prefix: str = "") -> dict[str, "torch.Tensor"]:
+        return {}
+
+
+__all__ = ["Projector"]

--- a/src/reflex/models/text/__init__.py
+++ b/src/reflex/models/text/__init__.py
@@ -1,0 +1,50 @@
+"""TextEncoder abstract base — pure text encoder slot for the BaseVLA spine.
+
+The 7th slot per decision S-2 — specifically for VLAs where the text
+encoder is structurally separate from the language model (DreamZero's T5
+is a text-only encoder, NOT a RoPE'd LLM). For 2-tower VLAs where the
+language model handles both encoding and attention, use `LLMBackbone`.
+
+Subclasses register via `@TEXT_ENCODERS.register` from
+`reflex.registry.components`.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+
+
+class TextEncoder(ABC):
+    """Abstract text-only encoder — input_ids → text embeddings.
+
+    Subclass contract:
+
+    - `__init__(self, config: Any)` — accept VLA-spec config.
+    - `forward(self, input_ids, attention_mask, ...)` — abstract;
+      VLA-specific output shape (T5 returns encoder hidden states; future
+      encoders may differ).
+    - `prepare_triton(self, prefix: str = "") -> dict[str, torch.Tensor]` —
+      no-op default; lift #3 fills in.
+
+    Concrete examples (added in lift #7 DreamZero):
+    - `T5Encoder` — DreamZero's T5 text encoder
+    """
+
+    @abstractmethod
+    def forward(
+        self,
+        input_ids: Any,
+        attention_mask: Any | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        ...
+
+    def prepare_triton(self, prefix: str = "") -> dict[str, "torch.Tensor"]:
+        return {}
+
+
+__all__ = ["TextEncoder"]

--- a/src/reflex/models/vision/__init__.py
+++ b/src/reflex/models/vision/__init__.py
@@ -1,0 +1,54 @@
+"""VisionBackbone abstract base — vision-encoder slot for the BaseVLA spine.
+
+Per decision S-2 + S-3 in `01_decisions/2026-05-19-fluxvla-lift-program-
+decisions.md`. Subclasses register via `@VISION_BACKBONES.register` from
+`reflex.registry.components` and are referenced from VLA spec dicts as
+`{"type": "<ClassName>", ...}`.
+
+The `prepare_triton(prefix="")` method is a concrete no-op default per
+decision S-2 — bundling the lift #3 (inference-only-weights) interface
+into the spine refactor frees lift #3 from per-component retrofit. Real
+implementations land in lift #3 Day 1.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+
+
+class VisionBackbone(ABC):
+    """Abstract vision encoder — image(s) → embedding tensor.
+
+    Subclass contract:
+
+    - `__init__(self, config: Any)` — accept VLA-spec config; subclasses
+      decide what config fields they need.
+    - `forward(self, images, ...)` — abstract; the call shape is
+      VLA-specific (single image vs multi-camera; tensor vs PIL etc).
+    - `prepare_triton(self, prefix: str = "") -> dict[str, torch.Tensor]` —
+      concrete no-op default; override in lift #3 to flatten weights.
+
+    Concrete examples (added in lift #1 Days 4-7):
+    - `SigLIPBackbone` — PaliGemma's vision tower
+    - `DinoSigLIPBackbone` — fused Dino + SigLIP
+    - `SmolVLAVisionBackbone` — SmolVLM2 vision tower
+    """
+
+    @abstractmethod
+    def forward(self, images: Any) -> Any:
+        """Image → vision embeddings. VLA-specific input/output shape."""
+        ...
+
+    def prepare_triton(self, prefix: str = "") -> dict[str, "torch.Tensor"]:
+        """Flatten this backbone's weights for `--inference-only-weights` mode.
+
+        No-op default — subclasses override in lift #3 to return
+        `{f"{prefix}<param_path>": tensor}` for every parameter.
+        """
+        return {}
+
+
+__all__ = ["VisionBackbone"]

--- a/src/reflex/models/vlm/__init__.py
+++ b/src/reflex/models/vlm/__init__.py
@@ -1,0 +1,54 @@
+"""VLMBackbone abstract base — fused vision-language slot for the BaseVLA spine.
+
+The 6th slot added per decision S-2 specifically for **fused VLMs** that
+don't decompose into separate vision_backbone + llm_backbone (GR00T's
+Eagle = SigLIP+Llama with internal cross-attention; future fused VLMs).
+
+For 2-tower VLAs, use `VisionBackbone` + `LLMBackbone` separately. For
+text-only encoders (DreamZero's T5), use `TextEncoder`.
+
+Subclasses register via `@VLM_BACKBONES.register` from
+`reflex.registry.components`.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+
+
+class VLMBackbone(ABC):
+    """Abstract fused vision-language model — (images, tokens) → joint embeddings.
+
+    Subclass contract:
+
+    - `__init__(self, config: Any)` — accept VLA-spec config.
+    - `forward(self, images, input_ids, attention_mask, ...)` — abstract;
+      VLA-specific. Eagle, for instance, returns image+text joint
+      embeddings; future fused VLMs may differ.
+    - `prepare_triton(self, prefix: str = "") -> dict[str, torch.Tensor]` —
+      no-op default; lift #3 fills in.
+
+    Concrete examples (added in lift #1 Day 7):
+    - `EagleBackbone` — GR00T's SigLIP+Qwen3+mlp1 fused stack
+    """
+
+    @abstractmethod
+    def forward(
+        self,
+        images: Any,
+        input_ids: Any,
+        attention_mask: Any | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """(images, tokens) → joint embeddings. VLA-specific output shape."""
+        ...
+
+    def prepare_triton(self, prefix: str = "") -> dict[str, "torch.Tensor"]:
+        return {}
+
+
+__all__ = ["VLMBackbone"]

--- a/tests/test_models_abstract.py
+++ b/tests/test_models_abstract.py
@@ -1,0 +1,315 @@
+"""Tests for the BaseVLA spine + 6 component base ABCs.
+
+Lift #1 Day 3 acceptance gate per `features/03_export/basevla-spine_plan.md`.
+Covers:
+
+- ABC enforcement (direct instantiation TypeError)
+- BaseVLA slot validation (required, optional, declared, undeclared)
+- BaseVLA.from_config dispatch through component registries
+- BaseVLA.prepare_inference_weights aggregation
+- BaseVLA.load_state_dict with NAME_MAPPING
+- apply_name_mapping walker (first-match-wins, strict mode, empty-prefix)
+"""
+from __future__ import annotations
+
+import pytest
+
+from reflex.models import ALL_SLOTS, BaseVLA, apply_name_mapping
+from reflex.models.vision import VisionBackbone
+from reflex.models.llm import LLMBackbone
+from reflex.models.vlm import VLMBackbone
+from reflex.models.projectors import Projector
+from reflex.models.heads import VLAHead
+from reflex.models.text import TextEncoder
+
+
+# ─── ABC enforcement ────────────────────────────────────────────────────
+
+
+def test_basevla_cannot_be_instantiated_directly():
+    """BaseVLA is abstract — direct instantiation must TypeError."""
+    with pytest.raises(TypeError, match="abstract"):
+        BaseVLA()
+
+
+def test_component_bases_cannot_be_instantiated_directly():
+    """Every component base class is abstract."""
+    for cls in (VisionBackbone, LLMBackbone, VLMBackbone, Projector, VLAHead, TextEncoder):
+        with pytest.raises(TypeError, match="abstract"):
+            cls()
+
+
+def test_basevla_subclass_without_abstract_impls_cannot_instantiate():
+    """A subclass that doesn't implement forward + predict_action stays abstract."""
+    class _Partial(BaseVLA):
+        REQUIRED_SLOTS = ()
+        OPTIONAL_SLOTS = ()
+        # Missing forward + predict_action
+
+    with pytest.raises(TypeError, match="abstract"):
+        _Partial()
+
+
+# ─── BaseVLA slot validation ────────────────────────────────────────────
+
+
+# Minimal concrete classes used across slot tests.
+
+class _StubVisionBackbone(VisionBackbone):
+    def forward(self, images): return images
+
+
+class _StubLLMBackbone(LLMBackbone):
+    def forward(self, input_ids, attention_mask=None, *args, **kwargs):
+        return input_ids
+
+
+class _StubVLMBackbone(VLMBackbone):
+    def forward(self, images, input_ids, attention_mask=None, *args, **kwargs):
+        return (images, input_ids)
+
+
+class _StubProjector(Projector):
+    def forward(self, x, *args, **kwargs): return x
+
+
+class _StubVLAHead(VLAHead):
+    def forward(self, context, *args, **kwargs): return context
+
+
+class _StubTextEncoder(TextEncoder):
+    def forward(self, input_ids, attention_mask=None, *args, **kwargs):
+        return input_ids
+
+
+class _MinimalVLA(BaseVLA):
+    """Concrete VLA with empty slot requirements — for slot-validation tests."""
+    REQUIRED_SLOTS = ()
+    OPTIONAL_SLOTS = ALL_SLOTS
+
+    def forward(self, batch): return batch
+
+    def predict_action(self, *, images, state, instruction):
+        return None
+
+
+def test_basevla_instantiates_with_no_slots_when_all_optional():
+    """All slots optional → ok with no components."""
+    v = _MinimalVLA()
+    for slot in ALL_SLOTS:
+        assert getattr(v, slot) is None
+
+
+def test_basevla_binds_passed_components_to_attributes():
+    v = _MinimalVLA(vision_backbone=_StubVisionBackbone(), projector=_StubProjector())
+    assert isinstance(v.vision_backbone, _StubVisionBackbone)
+    assert isinstance(v.projector, _StubProjector)
+    # Unbound slots stay None
+    assert v.llm_backbone is None
+    assert v.vla_head is None
+
+
+def test_basevla_required_slot_missing_raises():
+    class _NeedsHead(BaseVLA):
+        REQUIRED_SLOTS = ("vla_head",)
+        OPTIONAL_SLOTS = ()
+        def forward(self, batch): return batch
+        def predict_action(self, *, images, state, instruction): return None
+
+    with pytest.raises(ValueError, match="missing required slot"):
+        _NeedsHead()
+
+
+def test_basevla_required_slot_present_succeeds():
+    class _NeedsHead(BaseVLA):
+        REQUIRED_SLOTS = ("vla_head",)
+        OPTIONAL_SLOTS = ()
+        def forward(self, batch): return batch
+        def predict_action(self, *, images, state, instruction): return None
+
+    v = _NeedsHead(vla_head=_StubVLAHead())
+    assert isinstance(v.vla_head, _StubVLAHead)
+
+
+def test_basevla_undeclared_slot_passed_raises():
+    """If a slot isn't in REQUIRED or OPTIONAL but caller passes it, raise.
+
+    Catches the typo where a 2-tower model is given a vlm_backbone.
+    """
+    class _TwoTowerOnly(BaseVLA):
+        REQUIRED_SLOTS = ("vision_backbone", "llm_backbone", "vla_head")
+        OPTIONAL_SLOTS = ()
+        def forward(self, batch): return batch
+        def predict_action(self, *, images, state, instruction): return None
+
+    with pytest.raises(ValueError, match="undeclared"):
+        _TwoTowerOnly(
+            vision_backbone=_StubVisionBackbone(),
+            llm_backbone=_StubLLMBackbone(),
+            vla_head=_StubVLAHead(),
+            vlm_backbone=_StubVLMBackbone(),  # not declared
+        )
+
+
+def test_basevla_unknown_slot_in_class_decl_raises():
+    """Subclass that declares an invalid slot name fails at construction."""
+    class _Bogus(BaseVLA):
+        REQUIRED_SLOTS = ("nonexistent_slot",)
+        OPTIONAL_SLOTS = ()
+        def forward(self, batch): return batch
+        def predict_action(self, *, images, state, instruction): return None
+
+    with pytest.raises(TypeError, match="unknown slot"):
+        _Bogus()
+
+
+def test_basevla_slot_in_both_required_and_optional_raises():
+    class _Overlap(BaseVLA):
+        REQUIRED_SLOTS = ("vision_backbone",)
+        OPTIONAL_SLOTS = ("vision_backbone",)
+        def forward(self, batch): return batch
+        def predict_action(self, *, images, state, instruction): return None
+
+    with pytest.raises(TypeError, match="REQUIRED.*OPTIONAL"):
+        _Overlap()
+
+
+# ─── from_config dispatch ────────────────────────────────────────────────
+
+
+def test_basevla_from_config_resolves_type_tagged_dicts(monkeypatch):
+    """from_config takes a spec dict + builds via component registries."""
+    from reflex.registry.components import VISION_BACKBONES, VLA_HEADS
+
+    # Register stubs (use try/finally to clean up after the test).
+    VISION_BACKBONES.register(_StubVisionBackbone)
+    VLA_HEADS.register(_StubVLAHead)
+
+    try:
+        class _SpineVLA(BaseVLA):
+            REQUIRED_SLOTS = ("vision_backbone", "vla_head")
+            OPTIONAL_SLOTS = ()
+            def forward(self, batch): return batch
+            def predict_action(self, *, images, state, instruction): return None
+
+        v = _SpineVLA.from_config({
+            "vision_backbone": {"type": "_StubVisionBackbone"},
+            "vla_head": {"type": "_StubVLAHead"},
+        })
+        assert isinstance(v.vision_backbone, _StubVisionBackbone)
+        assert isinstance(v.vla_head, _StubVLAHead)
+    finally:
+        VISION_BACKBONES.unregister("_StubVisionBackbone")
+        VLA_HEADS.unregister("_StubVLAHead")
+
+
+def test_basevla_from_config_passes_through_prebuilt_instances():
+    """from_config accepts a pre-built component instance directly."""
+    pre_built = _StubVLAHead()
+
+    v = _MinimalVLA.from_config({"vla_head": pre_built})
+    assert v.vla_head is pre_built
+
+
+def test_basevla_from_config_unknown_slot_raises():
+    with pytest.raises(ValueError, match="Unknown slot"):
+        _MinimalVLA.from_config({"foo": {"type": "Bar"}})
+
+
+# ─── prepare_inference_weights aggregation ──────────────────────────────
+
+
+def test_prepare_inference_weights_aggregates_across_components():
+    """Each component's prepare_triton dict gets prefixed + merged."""
+    import torch
+
+    class _LoadedVision(VisionBackbone):
+        def forward(self, images): return images
+        def prepare_triton(self, prefix=""):
+            return {f"{prefix}patch_embed.weight": torch.zeros(3)}
+
+    class _LoadedHead(VLAHead):
+        def forward(self, context, *args, **kwargs): return context
+        def prepare_triton(self, prefix=""):
+            return {f"{prefix}action_out.weight": torch.ones(7)}
+
+    v = _MinimalVLA(vision_backbone=_LoadedVision(), vla_head=_LoadedHead())
+    weights = v.prepare_inference_weights()
+    assert set(weights.keys()) == {
+        "vision_backbone.patch_embed.weight",
+        "vla_head.action_out.weight",
+    }
+    assert torch.equal(weights["vision_backbone.patch_embed.weight"], torch.zeros(3))
+    assert torch.equal(weights["vla_head.action_out.weight"], torch.ones(7))
+
+
+def test_prepare_inference_weights_skips_unbound_slots():
+    """Unbound slots contribute nothing — no errors."""
+    v = _MinimalVLA()  # All slots empty
+    weights = v.prepare_inference_weights()
+    assert weights == {}
+
+
+def test_prepare_inference_weights_supports_outer_prefix():
+    """Caller-supplied prefix is prepended to all keys."""
+    import torch
+
+    class _LoadedHead(VLAHead):
+        def forward(self, context, *args, **kwargs): return context
+        def prepare_triton(self, prefix=""):
+            return {f"{prefix}w": torch.zeros(1)}
+
+    v = _MinimalVLA(vla_head=_LoadedHead())
+    weights = v.prepare_inference_weights(prefix="pi05.")
+    assert set(weights.keys()) == {"pi05.vla_head.w"}
+
+
+# ─── apply_name_mapping walker ──────────────────────────────────────────
+
+
+def test_apply_name_mapping_first_match_wins():
+    """Mapping iteration is declaration-ordered; first prefix match wins."""
+    import torch
+    state = {
+        "module.backbone.weight": torch.zeros(1),
+        "backbone.weight": torch.ones(1),  # would also match 'backbone.' if 'module.' didn't strip first
+    }
+    mapping = {"module.": "", "backbone.": "renamed."}
+    renamed = apply_name_mapping(state, mapping)
+    # 'module.backbone.weight' → strip 'module.' → 'backbone.weight' (not re-mapped because
+    # the result of the first match isn't re-walked)
+    assert "backbone.weight" in renamed
+    # 'backbone.weight' (the original key, no module. prefix) → matches 'backbone.' → 'renamed.weight'
+    assert "renamed.weight" in renamed
+
+
+def test_apply_name_mapping_passthrough_for_unmatched():
+    import torch
+    state = {"unmatched.key": torch.zeros(1)}
+    renamed = apply_name_mapping(state, {"prefix.": "x."})
+    assert renamed == state  # passthrough
+
+
+def test_apply_name_mapping_empty_prefix_rejected():
+    """Empty src_prefix would match everything — ambiguous, reject."""
+    import torch
+    with pytest.raises(ValueError, match="empty src_prefix"):
+        apply_name_mapping({"k": torch.zeros(1)}, {"": "renamed."})
+
+
+def test_apply_name_mapping_strict_mode_raises_on_unmatched():
+    import torch
+    state = {
+        "matched.key": torch.zeros(1),
+        "unmatched.key": torch.zeros(1),
+    }
+    with pytest.raises(KeyError, match="matched no name_mapping prefix"):
+        apply_name_mapping(state, {"matched.": "renamed."}, strict=True)
+
+
+def test_apply_name_mapping_does_not_mutate_input():
+    import torch
+    state = {"old.key": torch.zeros(1)}
+    original = dict(state)
+    apply_name_mapping(state, {"old.": "new."})
+    assert state == original  # untouched


### PR DESCRIPTION
## Summary

**Lift #1 Day 3** per [`features/03_export/basevla-spine_plan.md`](https://github.com/FastCrest/reflex-vault/blob/main/features/03_export/basevla-spine_plan.md). Foundation for the BaseVLA spine refactor. Pure addition — zero behavior change to existing exporters/runtime.

Implements the abstract spine + 6 component base classes + per-VLA name_mapping walker. Days 4-9 decompose each existing exporter onto this spine with per-model parity gates.

## What this lands (~830 LOC including tests)

- **`src/reflex/models/base_vla.py`** (~320 LOC) — `BaseVLA` ABC with 6 slots (per decision S-2: vision/llm/vlm/projectors/heads/text). REQUIRED_SLOTS + OPTIONAL_SLOTS contract validated at construction (raises on missing required, undeclared slot pass, unknown slot name, required/optional overlap). `from_config(spec)` resolves type-tagged dicts through component registries. `prepare_inference_weights()` aggregates components' prepare_triton outputs (lift #3 substrate). `load_state_dict()` applies NAME_MAPPING + routes by slot prefix.

- **`src/reflex/models/_name_mapping.py`** (~95 LOC) — Per-VLA name_mapping walker per decision S-1 (faithful FluxVLA port, NOT per-component). First-match-wins prefix substitution; strict mode catches HF layout drift early.

- **`src/reflex/models/{vision,llm,vlm,projectors,heads,text}/__init__.py`** (~50 LOC each) — 6 component base ABCs. Each declares abstract `forward()` + concrete `prepare_triton(prefix)` no-op default per decision S-2 (bundles lift #3 interface into spine refactor to avoid per-component retrofit).

- **`tests/test_models_abstract.py`** (~270 LOC, 18 tests) — ABC enforcement, slot validation (5 cases), from_config dispatch (3 cases), prepare_inference_weights aggregation (3 cases), apply_name_mapping walker (5 cases including strict mode + immutability).

## Decisions referenced

- **S-1**: per-VLA-config name_mapping (faithful FluxVLA port). Implemented as `BaseVLA.NAME_MAPPING` class var + `apply_name_mapping` walker.
- **S-2**: 6 slots including `vlm_backbone` (GR00T's Eagle) + `text_encoder` (DreamZero's T5). Validated via `ALL_SLOTS` constant.
- **S-3**: hybrid registration (decorator + explicit) — uses the Day 2 registries.
- **S-5**: JSON-Schema validation deferred. V1 catches typos via clear `TypeError` + diagnostic messages.

## Pre-merge validation (per the lift #4 review-pass discipline)

- [x] `ast.parse` syntax check on all 10 new files
- [x] AST orphan-imports sweep — zero suspect names referenced without import
- [x] Live import test: `PYTHONPATH=src python -c "from reflex.models import BaseVLA..."` succeeds with no circular deps
- [ ] CI pytest green (deferred — local venv has unrelated logfire/otel breakage)
- [ ] Doctor regression smoke green

## Independent of in-flight work

- No collision with the existing dead `src/reflex/models/smolvla.py` (unused) or `src/reflex/models/adapt.py` (its own test). Day 6 will add `models/vlas/smolvla.py` (different path).
- No collision with PR #143's numpy fix or any other open PR.

## Next: Day 4

Decompose pi0 as the spine canary — proves the design works on a real VLA before pi0.5/smolvla/gr00t decomposition. Will be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
