### PR TITLE
feat(models): SigLIPBackbone vision component (basevla-spine lift #1 Day 4b)

### DIFF
--- a/src/reflex/models/vision/siglip_backbone.py
+++ b/src/reflex/models/vision/siglip_backbone.py
@@ -1,0 +1,114 @@
+"""SigLIPBackbone — SigLIP vision tower wrapped as a spine VisionBackbone.
+
+Per Romir's 2026-05-20 fork decision in the lift #1 Day 4 design:
+**SigLIP is split out as a separate `vision_backbone` slot**, NOT folded into
+PaliGemma's `llm_backbone`. Cleaner spine taxonomy; downstream lifts (#3
+inference-only-weights, #5 fast-kernels) bind to a discrete component.
+
+Loads via either:
+- A HuggingFace model id (the standard `transformers.SiglipVisionModel.from_pretrained`)
+- A pre-built `SiglipVisionModel` instance (for tests + Day 4c which extracts
+  the vision tower from a PaliGemmaForConditionalGeneration via
+  `paligemma_model.vision_tower`)
+
+Output: per-image patch embeddings `[batch, num_patches, hidden_dim]`. For
+pi0's PaliGemma-3B-pt-224 ([224×224 input, 14×14 patch] → 256 patches,
+1152 hidden), this is `[B, 256, 1152]`.
+
+Registered under `VISION_BACKBONES` per decision S-3 hybrid-registration.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.nn as nn
+
+from reflex.models.vision import VisionBackbone
+from reflex.registry.components import VISION_BACKBONES
+
+if TYPE_CHECKING:
+    pass
+
+
+@VISION_BACKBONES.register
+class SigLIPBackbone(VisionBackbone, nn.Module):
+    """SigLIP vision tower wrapper.
+
+    Args (exactly one of model_id / model required):
+        model_id: HF repo id to load via `SiglipVisionModel.from_pretrained`
+            (e.g. `"google/paligemma-3b-pt-224"` will extract the vision
+            tower from PaliGemma; pure SigLIP repos like
+            `"google/siglip-base-patch16-224"` work too).
+        model: A pre-built `transformers.SiglipVisionModel` instance. Used by
+            Day 4c to wrap an existing `paligemma.vision_tower`.
+        output_hidden_states: Whether to return all layer hidden states
+            (pi0 uses only `last_hidden_state`; defaults False).
+
+    Raises:
+        ValueError: if neither or both of `model_id` / `model` are provided.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_id: str | None = None,
+        model: Any = None,
+        output_hidden_states: bool = False,
+    ) -> None:
+        nn.Module.__init__(self)
+        if (model_id is None) == (model is None):
+            raise ValueError(
+                "Provide exactly one of `model_id` or `model` "
+                "(got model_id=%r, model=%r)." % (model_id, model)
+            )
+
+        if model is not None:
+            # Pre-built instance — typically extracted from a PaliGemma model
+            # via paligemma.vision_tower (see Day 4c).
+            self.model = model
+        else:
+            # Lazy import — transformers is an existing reflex dep but the
+            # SiglipVisionModel auto-loader hits HuggingFace, which isn't
+            # needed for tests that pass a stub model.
+            from transformers import SiglipVisionModel
+            self.model = SiglipVisionModel.from_pretrained(
+                model_id,
+                output_hidden_states=output_hidden_states,
+            )
+
+        self.output_hidden_states = output_hidden_states
+
+    def forward(
+        self,
+        images: torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        """Images → patch embeddings.
+
+        Args:
+            images: `[batch, channels, height, width]` pixel tensor.
+                Standard SigLIP input — float32 [-1, 1] range after the
+                upstream image processor's normalization.
+
+        Returns:
+            `last_hidden_state` of shape `[batch, num_patches, hidden_dim]`.
+            For pi0's PaliGemma-3B (224×224 input, 14×14 patches): `[B, 256, 1152]`.
+        """
+        outputs = self.model(pixel_values=images)
+        return outputs.last_hidden_state
+
+    def prepare_triton(self, prefix: str = "") -> dict[str, torch.Tensor]:
+        """Flatten weights for `--inference-only-weights` mode (lift #3).
+
+        Returns every parameter under the given prefix. For a SigLIP-Base-Patch16-224
+        wrapped here, that's ~100M params (~400 MB FP32 / ~200 MB BF16).
+        """
+        return {
+            f"{prefix}{name}": param.detach()
+            for name, param in self.named_parameters()
+        }
+
+
+__all__ = ["SigLIPBackbone"]

--- a/tests/test_siglip_backbone.py
+++ b/tests/test_siglip_backbone.py
@@ -1,0 +1,133 @@
+"""Tests for SigLIPBackbone — vision-tower component on the BaseVLA spine.
+
+Lift #1 Day 4b per `features/03_export/basevla-spine_plan.md`. Validates:
+
+- registration on the VISION_BACKBONES registry
+- construction via pre-built model (the Day 4c path)
+- construction via model_id is documented but NOT tested here (would hit
+  HuggingFace at test time, which is brittle + slow)
+- forward() shape contract on a tiny stub
+- prepare_triton() returns expected key structure
+- input validation (must provide exactly one of model_id / model)
+
+The pi0/pi05/smolvla integration parity tests live in their respective
+per-VLA test files (Day 4f+).
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from reflex.models.vision import VisionBackbone
+from reflex.models.vision.siglip_backbone import SigLIPBackbone
+from reflex.registry.components import VISION_BACKBONES
+
+
+# ─── Registration ───────────────────────────────────────────────────────
+
+
+def test_siglip_backbone_registered():
+    """The @VISION_BACKBONES.register decorator fires at import time."""
+    assert "SigLIPBackbone" in VISION_BACKBONES
+    assert VISION_BACKBONES.get("SigLIPBackbone") is SigLIPBackbone
+
+
+def test_siglip_backbone_is_vision_backbone_subclass():
+    """Inherits from the spine ABC."""
+    assert issubclass(SigLIPBackbone, VisionBackbone)
+
+
+# ─── Construction validation ────────────────────────────────────────────
+
+
+def test_rejects_both_model_and_model_id():
+    """Exactly one of model / model_id must be provided."""
+    stub = _make_stub_model()
+    with pytest.raises(ValueError, match="exactly one"):
+        SigLIPBackbone(model_id="anything", model=stub)
+
+
+def test_rejects_neither_model_nor_model_id():
+    with pytest.raises(ValueError, match="exactly one"):
+        SigLIPBackbone()
+
+
+def test_constructs_with_pre_built_model():
+    """The model= path used by Day 4c PaliGemma extraction."""
+    stub = _make_stub_model()
+    backbone = SigLIPBackbone(model=stub)
+    assert backbone.model is stub
+    assert backbone.output_hidden_states is False  # default
+
+
+# ─── Forward shape contract ─────────────────────────────────────────────
+
+
+def test_forward_returns_last_hidden_state():
+    """forward(pixel_values) returns the model's last_hidden_state tensor."""
+    stub = _make_stub_model(hidden_dim=8, num_patches=4)
+    backbone = SigLIPBackbone(model=stub)
+
+    images = torch.randn(2, 3, 16, 16)  # batch=2, dummy 16×16 RGB
+    out = backbone(images)
+    # Stub returns [batch, num_patches, hidden_dim]
+    assert out.shape == (2, 4, 8)
+
+
+def test_forward_ignores_extra_args():
+    """ABC signature has *args/**kwargs — extras dropped, no crash."""
+    stub = _make_stub_model(hidden_dim=8, num_patches=4)
+    backbone = SigLIPBackbone(model=stub)
+    images = torch.randn(1, 3, 16, 16)
+    out = backbone(images, "ignored", foo=42)
+    assert out.shape == (1, 4, 8)
+
+
+# ─── prepare_triton (lift #3 interface) ─────────────────────────────────
+
+
+def test_prepare_triton_returns_all_params():
+    """prepare_triton enumerates every parameter under prefix."""
+    stub = _make_stub_model(hidden_dim=8, num_patches=4)
+    backbone = SigLIPBackbone(model=stub)
+
+    weights = backbone.prepare_triton(prefix="vision.")
+    # Stub model has one nn.Parameter named 'patch_embed.weight'
+    assert "vision.model.patch_embed.weight" in weights
+    assert weights["vision.model.patch_embed.weight"].requires_grad is False
+
+
+def test_prepare_triton_default_prefix():
+    """Default prefix='' produces top-level keys."""
+    stub = _make_stub_model(hidden_dim=8, num_patches=4)
+    backbone = SigLIPBackbone(model=stub)
+    weights = backbone.prepare_triton()
+    assert "model.patch_embed.weight" in weights
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────
+
+
+def _make_stub_model(hidden_dim: int = 1152, num_patches: int = 256) -> nn.Module:
+    """Build a minimal SigLIP-shaped stub for testing without HF downloads.
+
+    Returns an nn.Module that exposes:
+    - `.patch_embed.weight` (so prepare_triton has at least one param)
+    - `__call__(pixel_values=...)` returning a namespace with `.last_hidden_state`
+      of shape `[batch, num_patches, hidden_dim]`
+    """
+    class _Stub(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.patch_embed = nn.Module()
+            self.patch_embed.weight = nn.Parameter(torch.zeros(1, 1))
+
+        def forward(self, *, pixel_values, **kwargs):
+            batch = pixel_values.shape[0]
+            from types import SimpleNamespace
+            return SimpleNamespace(
+                last_hidden_state=torch.zeros(batch, num_patches, hidden_dim),
+            )
+
+    return _Stub()


### PR DESCRIPTION
Per the 2026-05-20 design fork: SigLIP split out as separate `vision_backbone` slot (not folded into PaliGemma's llm_backbone). Cleaner spine taxonomy; downstream lifts #3 + #5 bind to a discrete component.

Day 4c will wrap PaliGemma's language stack as LLMBackbone using `SigLIPBackbone(model=paligemma_model.vision_tower)` to extract the vision side from the upstream PaliGemma model.

8 unit tests cover: registration, ABC subclass, construction validation (both/neither args reject), pre-built model path (the Day 4c extraction surface), forward shape via stub, prepare_triton with/without prefix. Tests don't hit HuggingFace at test time — stub model mimics SigLIP's call signature.

Validation per the established discipline: syntax ✓ AST sweep ✓ live import + forward smoke ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)