### PR TITLE
feat(models): PaliGemmaBackbone language component (basevla-spine lift #1 Day 4c)

### DIFF
--- a/src/reflex/models/llm/paligemma_backbone.py
+++ b/src/reflex/models/llm/paligemma_backbone.py
@@ -1,0 +1,174 @@
+"""PaliGemmaBackbone — PaliGemma's language path wrapped as a spine LLMBackbone.
+
+Per Romir's 2026-05-20 design fork: SigLIP is split out as the
+`vision_backbone` slot (see `models/vision/siglip_backbone.py`). This
+backbone wraps **the rest of PaliGemma** — language_model (Gemma2) +
+multi_modal_projector + token embeddings — for use in the BaseVLA spine's
+`llm_backbone` slot.
+
+How the slots split at runtime:
+
+    images       → SigLIPBackbone        → image embeds [B, 256, vision_hidden]
+                                         ↓
+                   PaliGemmaBackbone     → multi_modal_projector
+                                         → merge with text embeds
+                                         → language_model.forward(inputs_embeds=…)
+                                         → hidden states [B, seq, text_hidden]
+                                         ↓
+                   (action head consumes hidden states)
+
+The PaliGemma model object is held in full (vision_tower attribute included)
+but vision_tower is **never called** through this class — that's
+SigLIPBackbone's responsibility. The vision_tower attribute is kept rather
+than deleted so the model's state_dict matches the upstream HF checkpoint
+naming (avoids state_dict load drift).
+
+Loads via either:
+
+- A HuggingFace model id (`PaliGemmaForConditionalGeneration.from_pretrained`)
+- A pre-built `PaliGemmaForConditionalGeneration` instance (for tests; also
+  used by `Pi0VLA.from_pretrained` in Day 4f where the same PaliGemma model
+  is split between SigLIPBackbone(model=paligemma.model.vision_tower) and
+  this class)
+
+Registered under `LLM_BACKBONES` per decision S-3 hybrid-registration.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.nn as nn
+
+from reflex.models.llm import LLMBackbone
+from reflex.registry.components import LLM_BACKBONES
+
+if TYPE_CHECKING:
+    pass
+
+
+@LLM_BACKBONES.register
+class PaliGemmaBackbone(LLMBackbone, nn.Module):
+    """PaliGemma language path wrapper (vision_tower NOT called at runtime).
+
+    Args (exactly one of model_id / model required):
+        model_id: HF repo id to load via
+            `PaliGemmaForConditionalGeneration.from_pretrained` (e.g.
+            `"google/paligemma-3b-pt-224"`).
+        model: A pre-built `PaliGemmaForConditionalGeneration` instance. Used
+            by Day 4f Pi0VLA where the same model is split between
+            SigLIPBackbone(model=paligemma.model.vision_tower) and this class.
+        dtype: Optional dtype to cast the loaded model to (e.g. torch.bfloat16).
+            None → leave at whatever the checkpoint stores (typically float32).
+
+    Raises:
+        ValueError: if neither or both of `model_id` / `model` are provided.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_id: str | None = None,
+        model: Any = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        nn.Module.__init__(self)
+        if (model_id is None) == (model is None):
+            raise ValueError(
+                "Provide exactly one of `model_id` or `model` "
+                f"(got model_id={model_id!r}, model={model!r})."
+            )
+
+        if model is not None:
+            self.model = model
+        else:
+            from transformers import PaliGemmaForConditionalGeneration
+            self.model = PaliGemmaForConditionalGeneration.from_pretrained(model_id)
+
+        if dtype is not None:
+            self.model = self.model.to(dtype=dtype)
+
+    # ── Convenience accessors that downstream composition code (Day 4f
+    # Pi0VLA orchestrator) uses to compose the multimodal forward. Each
+    # is a thin property so callers don't have to reach into `.model.model`.
+
+    @property
+    def language_model(self) -> nn.Module:
+        """Gemma2 decoder (the language tower). Used directly by Pi0VLA's
+        forward orchestrator to call `language_model(inputs_embeds=...)`."""
+        return self.model.model.language_model
+
+    @property
+    def multi_modal_projector(self) -> nn.Module:
+        """Image-embed → language-hidden-dim projection. Pi0VLA calls this
+        on SigLIPBackbone's output before merging with text embeds."""
+        return self.model.model.multi_modal_projector
+
+    @property
+    def embed_tokens(self) -> nn.Module:
+        """Token embedding table. Pi0VLA uses this to embed input_ids
+        before merging in the projected image embeds."""
+        return self.language_model.embed_tokens
+
+    @property
+    def text_hidden_size(self) -> int:
+        """Hidden dim of the language tower (1152 for PaliGemma-3B-pt-224)."""
+        return self.model.config.text_config.hidden_size
+
+    # ── ABC contract ────────────────────────────────────────────────────
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        *args: Any,
+        inputs_embeds: torch.Tensor | None = None,
+        past_key_values: Any | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run the language path.
+
+        Two call shapes:
+
+        1. `forward(input_ids, attention_mask)` — embed tokens internally,
+           run through language_model. No image merging. Used for text-only
+           probes + the chat model surface.
+
+        2. `forward(inputs_embeds=<pre-merged>, attention_mask=...)` — caller
+           pre-merged image embeds into the text-embed sequence. Used by
+           Pi0VLA orchestrator at Day 4f.
+
+        Returns the raw `language_model` output (typically a `BaseModelOutput`
+        with `last_hidden_state` and `past_key_values`).
+        """
+        if inputs_embeds is None and input_ids is None:
+            raise ValueError("Must provide either input_ids or inputs_embeds.")
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        return self.language_model(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            **kwargs,
+        )
+
+    def prepare_triton(self, prefix: str = "") -> dict[str, torch.Tensor]:
+        """Flatten weights for `--inference-only-weights` mode (lift #3).
+
+        Excludes the vision_tower weights — those belong to SigLIPBackbone's
+        prepare_triton output. Includes language_model + multi_modal_projector
+        + the rest of PaliGemma.
+        """
+        out: dict[str, torch.Tensor] = {}
+        for name, param in self.named_parameters():
+            # Skip vision_tower — SigLIPBackbone owns those weights.
+            # The dotted-path under self.model is e.g.
+            # `model.model.vision_tower.vision_model.embeddings.patch_embedding.weight`.
+            if ".vision_tower." in name:
+                continue
+            out[f"{prefix}{name}"] = param.detach()
+        return out
+
+
+__all__ = ["PaliGemmaBackbone"]

--- a/tests/test_paligemma_backbone.py
+++ b/tests/test_paligemma_backbone.py
@@ -1,0 +1,217 @@
+"""Tests for PaliGemmaBackbone — language-tower component on the BaseVLA spine.
+
+Lift #1 Day 4c per `features/03_export/basevla-spine_plan.md`. Validates:
+
+- registration on the LLM_BACKBONES registry
+- construction via pre-built model (the Day 4f extraction path) + input
+  validation (must provide exactly one of model_id / model)
+- forward shape contract with stub model (text-only + inputs_embeds paths)
+- prepare_triton excludes vision_tower weights (those belong to SigLIPBackbone)
+- accessor properties (language_model / multi_modal_projector / embed_tokens
+  / text_hidden_size)
+
+The pi0 parity tests with the real PaliGemma-3B model live in Day 4f's
+per-VLA tests + the Modal smoke. This file tests the wrapper contract.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from reflex.models.llm import LLMBackbone
+from reflex.models.llm.paligemma_backbone import PaliGemmaBackbone
+from reflex.registry.components import LLM_BACKBONES
+
+
+# ─── Registration + ABC ─────────────────────────────────────────────────
+
+
+def test_paligemma_backbone_registered():
+    assert "PaliGemmaBackbone" in LLM_BACKBONES
+    assert LLM_BACKBONES.get("PaliGemmaBackbone") is PaliGemmaBackbone
+
+
+def test_paligemma_backbone_is_llm_backbone_subclass():
+    assert issubclass(PaliGemmaBackbone, LLMBackbone)
+
+
+# ─── Construction validation ────────────────────────────────────────────
+
+
+def test_rejects_both_model_and_model_id():
+    stub = _make_stub_paligemma()
+    with pytest.raises(ValueError, match="exactly one"):
+        PaliGemmaBackbone(model_id="anything", model=stub)
+
+
+def test_rejects_neither_model_nor_model_id():
+    with pytest.raises(ValueError, match="exactly one"):
+        PaliGemmaBackbone()
+
+
+def test_constructs_with_pre_built_model():
+    stub = _make_stub_paligemma()
+    backbone = PaliGemmaBackbone(model=stub)
+    assert backbone.model is stub
+
+
+def test_accessors_route_to_paligemma_internals():
+    """language_model / multi_modal_projector / embed_tokens / text_hidden_size
+    accessor properties navigate the paligemma.model.model.* structure."""
+    stub = _make_stub_paligemma(text_hidden=64)
+    backbone = PaliGemmaBackbone(model=stub)
+    assert backbone.language_model is stub.model.language_model
+    assert backbone.multi_modal_projector is stub.model.multi_modal_projector
+    assert backbone.embed_tokens is stub.model.language_model.embed_tokens
+    assert backbone.text_hidden_size == 64
+
+
+# ─── Forward shape contract ─────────────────────────────────────────────
+
+
+def test_forward_with_input_ids_embeds_internally():
+    """Path 1: input_ids → embed → language_model."""
+    stub = _make_stub_paligemma(text_hidden=8, vocab_size=16)
+    backbone = PaliGemmaBackbone(model=stub)
+
+    input_ids = torch.zeros(2, 5, dtype=torch.long)
+    attention_mask = torch.ones(2, 5, dtype=torch.bool)
+    out = backbone(input_ids=input_ids, attention_mask=attention_mask)
+    # Stub returns a SimpleNamespace with last_hidden_state of shape [2, 5, 8]
+    assert out.last_hidden_state.shape == (2, 5, 8)
+
+
+def test_forward_with_inputs_embeds_bypasses_embedding():
+    """Path 2: caller-supplied inputs_embeds skip the embedding step."""
+    stub = _make_stub_paligemma(text_hidden=8, vocab_size=16)
+    backbone = PaliGemmaBackbone(model=stub)
+
+    inputs_embeds = torch.randn(2, 5, 8)
+    out = backbone(inputs_embeds=inputs_embeds, attention_mask=torch.ones(2, 5))
+    assert out.last_hidden_state.shape == (2, 5, 8)
+
+
+def test_forward_requires_one_of_input_ids_or_inputs_embeds():
+    backbone = PaliGemmaBackbone(model=_make_stub_paligemma())
+    with pytest.raises(ValueError, match="input_ids or inputs_embeds"):
+        backbone()
+
+
+# ─── prepare_triton excludes vision_tower ───────────────────────────────
+
+
+def test_prepare_triton_excludes_vision_tower_weights():
+    """vision_tower weights belong to SigLIPBackbone — must NOT appear here."""
+    stub = _make_stub_paligemma_with_vision_tower(text_hidden=8)
+    backbone = PaliGemmaBackbone(model=stub)
+    weights = backbone.prepare_triton(prefix="pi0.llm.")
+
+    # multi_modal_projector should be included
+    assert any("multi_modal_projector" in k for k in weights), (
+        f"Expected multi_modal_projector params; got keys: {sorted(weights)}"
+    )
+
+    # vision_tower must NOT be included
+    assert not any("vision_tower" in k for k in weights), (
+        f"vision_tower weights leaked into PaliGemmaBackbone.prepare_triton: "
+        f"{sorted(k for k in weights if 'vision_tower' in k)}"
+    )
+
+
+def test_prepare_triton_with_default_prefix():
+    stub = _make_stub_paligemma_with_vision_tower()
+    backbone = PaliGemmaBackbone(model=stub)
+    weights = backbone.prepare_triton()
+    # Some key exists
+    assert len(weights) > 0
+    # No vision tower
+    assert not any("vision_tower" in k for k in weights)
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────
+
+
+def _make_stub_paligemma(text_hidden: int = 1152, vocab_size: int = 32000):
+    """Minimal PaliGemma-shaped stub mirroring `paligemma.model.model.*` access."""
+
+    # The actual structure is paligemma.model (PaliGemmaModel).{vision_tower,
+    # multi_modal_projector, language_model}. PaliGemmaBackbone.language_model
+    # returns self.model.model.language_model.
+    class _LM(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed_tokens = nn.Embedding(vocab_size, text_hidden)
+
+        def forward(self, *, inputs_embeds, attention_mask=None, past_key_values=None, **kw):
+            # Echo the embeds as hidden states (preserves shape for test assertions)
+            return SimpleNamespace(
+                last_hidden_state=inputs_embeds,
+                past_key_values=None,
+            )
+
+    class _Projector(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(8, text_hidden)
+
+    class _InnerModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.language_model = _LM()
+            self.multi_modal_projector = _Projector()
+
+    class _Stub(nn.Module):
+        def __init__(self):
+            super().__init__()
+            # paligemma.model = PaliGemmaModel(...) which holds language_model etc.
+            self.model = _InnerModel()
+            # paligemma.config.text_config.hidden_size — accessor uses this
+            self.config = SimpleNamespace(
+                text_config=SimpleNamespace(hidden_size=text_hidden),
+            )
+
+    return _Stub()
+
+
+def _make_stub_paligemma_with_vision_tower(text_hidden: int = 8):
+    """Variant that includes vision_tower with a parameter, for prepare_triton
+    exclusion testing."""
+
+    class _VisionTower(nn.Module):
+        def __init__(self):
+            super().__init__()
+            # Single parameter that should NOT appear in PaliGemmaBackbone.prepare_triton
+            self.patch_embed = nn.Linear(3, 8)
+
+    class _LM(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed_tokens = nn.Embedding(16, text_hidden)
+
+        def forward(self, *, inputs_embeds, **kw):
+            return SimpleNamespace(last_hidden_state=inputs_embeds)
+
+    class _Projector(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(8, text_hidden)
+
+    class _InnerModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.vision_tower = _VisionTower()
+            self.language_model = _LM()
+            self.multi_modal_projector = _Projector()
+
+    class _Stub(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = _InnerModel()
+            self.config = SimpleNamespace(
+                text_config=SimpleNamespace(hidden_size=text_hidden),
+            )
+
+    return _Stub()


### PR DESCRIPTION
Per the 2026-05-20 design fork: wraps the rest of PaliGemma (language_model + multi_modal_projector + token embeddings) for the llm_backbone slot. vision_tower attribute stays bound but is NEVER called — SigLIPBackbone (PR #146) owns that path.

prepare_triton() explicitly excludes `.vision_tower.` param paths so weight aggregation across slots doesn't double-count. Validated by test.

4 accessor properties (language_model / multi_modal_projector / embed_tokens / text_hidden_size) let Day 4f's Pi0VLA orchestrator compose the multimodal merge without reaching into .model.model.* internals.

10 unit tests cover: registration, ABC subclass, construction validation, accessor routing, forward (input_ids + inputs_embeds + neither raises), prepare_triton exclusion of vision_tower weights. Stubs mirror paligemma.model.model.* structure so tests don't hit HuggingFace.

Pre-merge validation: syntax ✓ AST sweep ✓ live import + registration ✓.

Day 4d next: GemmaExpertBackbone (action-side expert that cross-attends to PaliGemmaBackbone's KV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)