### PR TITLE
feat(models): FlowMatchingHead wraps ExpertStack for spine (basevla-spine lift #1 Day 4e)

### DIFF
--- a/src/reflex/models/heads/flow_matching_head.py
+++ b/src/reflex/models/heads/flow_matching_head.py
@@ -1,0 +1,182 @@
+"""FlowMatchingHead — pi0/pi05/smolvla shared flow-matching head wrapped for the BaseVLA spine.
+
+Per the Day 4 design (lift #1 plan): pi0/pi05/smolvla all share a single
+expert-decoder + suffix architecture for action prediction. The existing
+implementation lives in `src/reflex/exporters/smolvla_exporter.ExpertStack`
+(history: it was added for SmolVLA first then reused for pi0/pi05 via
+each exporter's `build_*_expert_stack()` constructor).
+
+FlowMatchingHead is a thin spine-compatible wrapper around an `ExpertStack`
+instance. It:
+
+- Provides the `VLAHead` ABC contract (`forward()` + `prepare_triton()`)
+- Delegates the actual denoising computation to the wrapped ExpertStack
+- Does NOT reimplement the expert — preserves bit-identical behavior with
+  the existing pi0/pi05/smolvla exporters
+
+Construction is via a pre-built ExpertStack (the Pi0VLA / Pi05VLA /
+SmolVLA classes in Day 4f use `build_pi0_expert_stack()` from the
+existing exporter to produce the stack, then wrap it here).
+
+TODO(Day 4g cleanup): `ExpertStack` should move from `exporters/smolvla_exporter.py`
+to `models/heads/expert_stack.py` so the spine doesn't reach into the
+exporters package. Deferred to Day 4g sunset commit which removes the OLD
+per-model exporters anyway. For now we keep the cross-package import.
+
+Registered under `VLA_HEADS` per decision S-3 hybrid-registration.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.nn as nn
+
+from reflex.models.heads import VLAHead
+from reflex.registry.components import VLA_HEADS
+
+if TYPE_CHECKING:
+    pass
+
+
+@VLA_HEADS.register
+class FlowMatchingHead(VLAHead, nn.Module):
+    """Spine wrapper for pi0/pi05/smolvla's ExpertStack.
+
+    Args (exactly one of expert_stack / state_dict required):
+        expert_stack: A pre-built `ExpertStack` instance from
+            `src/reflex/exporters/smolvla_exporter.py`. Produced by
+            `build_pi0_expert_stack(state_dict)` /
+            `build_pi05_expert_stack(state_dict)` /
+            `build_expert_stack(state_dict, head_dim)` per VLA family.
+        state_dict: Raw checkpoint state_dict + `vla_family` (one of
+            "pi0", "pi05", "smolvla") — head dispatches to the right
+            builder. Convenience constructor; same shape as direct
+            expert_stack=.
+        vla_family: Required when `state_dict` is provided. Picks the
+            build function. Must be one of "pi0" / "pi05" / "smolvla".
+        head_dim: Required for SmolVLA's build_expert_stack (which needs
+            the VLM head_dim — typically 64 for SmolLM2). Ignored for
+            pi0/pi05.
+
+    Raises:
+        ValueError: if neither or both of expert_stack / state_dict
+            provided; if state_dict provided without vla_family.
+    """
+
+    SUPPORTED_FAMILIES: tuple[str, ...] = ("pi0", "pi05", "smolvla")
+
+    def __init__(
+        self,
+        *,
+        expert_stack: Any = None,
+        state_dict: dict[str, torch.Tensor] | None = None,
+        vla_family: str | None = None,
+        head_dim: int | None = None,
+    ) -> None:
+        nn.Module.__init__(self)
+        if (expert_stack is None) == (state_dict is None):
+            raise ValueError(
+                "Provide exactly one of `expert_stack` or `state_dict` "
+                f"(got expert_stack={type(expert_stack).__name__ if expert_stack else None!r}, "
+                f"state_dict={'<dict>' if state_dict else None!r})."
+            )
+
+        if state_dict is not None:
+            if vla_family not in self.SUPPORTED_FAMILIES:
+                raise ValueError(
+                    f"vla_family must be one of {self.SUPPORTED_FAMILIES} when "
+                    f"state_dict is provided (got {vla_family!r})."
+                )
+            expert_stack = self._build_from_state_dict(
+                state_dict, vla_family=vla_family, head_dim=head_dim,
+            )
+
+        self.expert_stack = expert_stack
+
+    @staticmethod
+    def _build_from_state_dict(
+        state_dict: dict[str, torch.Tensor],
+        *,
+        vla_family: str,
+        head_dim: int | None,
+    ) -> Any:
+        """Dispatch to the right exporter-side builder by VLA family.
+
+        Imports are lazy — they pull in heavy model code (PyTorch +
+        transformers) that tests don't want at import time.
+        """
+        if vla_family == "pi0":
+            from reflex.exporters.pi0_exporter import build_pi0_expert_stack
+            stack, _meta = build_pi0_expert_stack(state_dict)
+            return stack
+        elif vla_family == "pi05":
+            from reflex.exporters.pi0_exporter import build_pi05_expert_stack
+            stack, _meta = build_pi05_expert_stack(state_dict)
+            return stack
+        elif vla_family == "smolvla":
+            from reflex.exporters.smolvla_exporter import build_expert_stack
+            if head_dim is None:
+                raise ValueError(
+                    "head_dim required for SmolVLA (the VLM head_dim — "
+                    "typically 64 for SmolLM2). pi0/pi05 don't need it."
+                )
+            stack, _meta = build_expert_stack(state_dict, head_dim=head_dim)
+            return stack
+        else:
+            # Unreachable per SUPPORTED_FAMILIES validation above; defensive.
+            raise ValueError(f"Unknown vla_family: {vla_family!r}")
+
+    # ── ABC contract ────────────────────────────────────────────────────
+
+    def forward(
+        self,
+        noisy_actions: torch.Tensor,
+        timestep: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        *args: Any,
+        vlm_k: torch.Tensor | None = None,
+        vlm_v: torch.Tensor | None = None,
+        prefix_offset: torch.Tensor | None = None,
+        kv_mask: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        """One denoising step — delegates to the wrapped ExpertStack.
+
+        The first positional arg is the flow-matching "context" per the
+        VLAHead ABC, which in this head's case IS the noisy_actions tensor.
+        Naming kept as `noisy_actions` for clarity.
+
+        Args:
+            noisy_actions: `[batch, chunk, action_dim]` noised action tensor.
+            timestep: `[batch]` flow-matching timestep.
+            position_ids: `[batch, chunk]` action position indices.
+            vlm_k: optional VLM per-layer K cache for cross-attention layers
+                (only pi05/smolvla have cross-attn; pi0 ignores).
+            vlm_v: paired V cache.
+            prefix_offset: VLM prefix length per batch element (for position-id
+                offsetting in self-attention layers).
+            kv_mask: optional KV-attention mask.
+
+        Returns:
+            `[batch, chunk, action_dim]` denoised actions.
+        """
+        return self.expert_stack(
+            noisy_actions=noisy_actions,
+            timestep=timestep,
+            position_ids=position_ids,
+            vlm_k=vlm_k,
+            vlm_v=vlm_v,
+            prefix_offset=prefix_offset,
+            kv_mask=kv_mask,
+        )
+
+    def prepare_triton(self, prefix: str = "") -> dict[str, torch.Tensor]:
+        """Flatten every parameter in the wrapped ExpertStack under prefix."""
+        return {
+            f"{prefix}expert_stack.{name}": param.detach()
+            for name, param in self.expert_stack.named_parameters()
+        }
+
+
+__all__ = ["FlowMatchingHead"]

--- a/tests/test_flow_matching_head.py
+++ b/tests/test_flow_matching_head.py
@@ -1,0 +1,208 @@
+"""Tests for FlowMatchingHead — spine wrapper for pi0/pi05/smolvla ExpertStack.
+
+Lift #1 Day 4e per `features/03_export/basevla-spine_plan.md`. Validates:
+
+- registration on the VLA_HEADS registry
+- construction with pre-built expert_stack (the Day 4f composition path)
+- construction validation (exactly one of expert_stack / state_dict;
+  state_dict requires vla_family; SmolVLA requires head_dim)
+- forward() delegates to wrapped expert_stack with correct kwargs
+- prepare_triton() flattens wrapped stack's params under "expert_stack." prefix
+- ABC subclass
+
+The bit-identical-behavior parity tests vs the existing pi0/pi05/smolvla
+exporters live in Day 4g (after Pi0VLA composition lands in Day 4f).
+This file tests the wrapper contract.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from reflex.models.heads import VLAHead
+from reflex.models.heads.flow_matching_head import FlowMatchingHead
+from reflex.registry.components import VLA_HEADS
+
+
+# ─── Registration + ABC ─────────────────────────────────────────────────
+
+
+def test_flow_matching_head_registered():
+    assert "FlowMatchingHead" in VLA_HEADS
+    assert VLA_HEADS.get("FlowMatchingHead") is FlowMatchingHead
+
+
+def test_flow_matching_head_is_vla_head_subclass():
+    assert issubclass(FlowMatchingHead, VLAHead)
+
+
+# ─── Construction validation ────────────────────────────────────────────
+
+
+def test_rejects_both_expert_stack_and_state_dict():
+    stub = _make_stub_expert_stack()
+    with pytest.raises(ValueError, match="exactly one"):
+        FlowMatchingHead(expert_stack=stub, state_dict={})
+
+
+def test_rejects_neither_expert_stack_nor_state_dict():
+    with pytest.raises(ValueError, match="exactly one"):
+        FlowMatchingHead()
+
+
+def test_state_dict_requires_vla_family():
+    """state_dict alone is ambiguous — pi0 / pi05 / smolvla all have
+    different builders."""
+    with pytest.raises(ValueError, match="vla_family"):
+        FlowMatchingHead(state_dict={"some.key": torch.zeros(1)})
+
+
+def test_state_dict_rejects_unknown_vla_family():
+    with pytest.raises(ValueError, match="vla_family"):
+        FlowMatchingHead(state_dict={}, vla_family="invented_family")
+
+
+def test_constructs_with_pre_built_expert_stack():
+    stub = _make_stub_expert_stack()
+    head = FlowMatchingHead(expert_stack=stub)
+    assert head.expert_stack is stub
+
+
+# ─── forward() delegation ───────────────────────────────────────────────
+
+
+def test_forward_delegates_to_wrapped_stack():
+    """forward() passes through to expert_stack with the canonical kwarg
+    set (noisy_actions, timestep, position_ids, vlm_k, vlm_v, prefix_offset,
+    kv_mask)."""
+    stub = _make_stub_expert_stack()
+    head = FlowMatchingHead(expert_stack=stub)
+
+    noisy = torch.randn(2, 50, 7)
+    timestep = torch.tensor([0.5, 0.5])
+    pos_ids = torch.arange(50).unsqueeze(0).expand(2, -1)
+
+    out = head(noisy, timestep, pos_ids)
+    # Stub returns the input shape — verifies forward succeeded
+    assert out.shape == (2, 50, 7)
+    # Stub recorded the kwargs it received
+    assert stub.last_call["noisy_actions"] is noisy
+    assert stub.last_call["timestep"] is timestep
+    assert stub.last_call["position_ids"] is pos_ids
+    # Optional kwargs default to None
+    assert stub.last_call["vlm_k"] is None
+    assert stub.last_call["vlm_v"] is None
+
+
+def test_forward_passes_vlm_k_v_when_provided():
+    """Cross-attention path: vlm_k + vlm_v get forwarded as kwargs."""
+    stub = _make_stub_expert_stack()
+    head = FlowMatchingHead(expert_stack=stub)
+
+    noisy = torch.randn(1, 10, 7)
+    vlm_k = torch.randn(2, 1, 256, 16)  # [num_layers, B, seq, kv_dim]
+    vlm_v = torch.randn(2, 1, 256, 16)
+    head(noisy, vlm_k=vlm_k, vlm_v=vlm_v)
+    assert stub.last_call["vlm_k"] is vlm_k
+    assert stub.last_call["vlm_v"] is vlm_v
+
+
+def test_forward_ignores_extra_positional_args():
+    """ABC signature accepts *args/**kwargs — extras dropped cleanly."""
+    stub = _make_stub_expert_stack()
+    head = FlowMatchingHead(expert_stack=stub)
+    noisy = torch.randn(1, 10, 7)
+    head(noisy, None, None, "ignored_positional", random_kwarg=42)
+    # No crash; expert_stack called with the named kwargs from the signature
+    assert stub.last_call["noisy_actions"] is noisy
+
+
+# ─── prepare_triton flattens wrapped stack's params ─────────────────────
+
+
+def test_prepare_triton_returns_expert_stack_params():
+    stub = _make_stub_expert_stack()
+    head = FlowMatchingHead(expert_stack=stub)
+    weights = head.prepare_triton(prefix="vla.head.")
+
+    # Stub has one named param 'action_in_proj.weight'
+    expected_key = "vla.head.expert_stack.action_in_proj.weight"
+    assert expected_key in weights, (
+        f"Expected {expected_key} in {sorted(weights.keys())}"
+    )
+    assert weights[expected_key].requires_grad is False
+
+
+def test_prepare_triton_default_prefix_empty():
+    stub = _make_stub_expert_stack()
+    head = FlowMatchingHead(expert_stack=stub)
+    weights = head.prepare_triton()
+    assert "expert_stack.action_in_proj.weight" in weights
+
+
+# ─── SmolVLA-only constraint: head_dim required ─────────────────────────
+
+
+def test_state_dict_smolvla_requires_head_dim(monkeypatch):
+    """SmolVLA's build_expert_stack signature requires the VLM head_dim;
+    the head dispatcher passes it through."""
+    # Patch the lazy builder import so we don't actually run smolvla build.
+    captured = {}
+
+    def fake_build(state_dict, head_dim):
+        captured["called"] = True
+        captured["head_dim"] = head_dim
+        return _make_stub_expert_stack(), {}
+
+    import reflex.exporters.smolvla_exporter as smolvla_mod
+    monkeypatch.setattr(smolvla_mod, "build_expert_stack", fake_build)
+
+    with pytest.raises(ValueError, match="head_dim required"):
+        FlowMatchingHead(state_dict={}, vla_family="smolvla")  # no head_dim
+
+    # With head_dim — succeeds + forwards the value
+    head = FlowMatchingHead(state_dict={}, vla_family="smolvla", head_dim=64)
+    assert captured["called"] is True
+    assert captured["head_dim"] == 64
+    assert isinstance(head, FlowMatchingHead)
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────
+
+
+def _make_stub_expert_stack() -> nn.Module:
+    """Minimal ExpertStack-shaped stub that records its last forward kwargs.
+
+    Returns the noisy_actions tensor unchanged so shape-preservation tests
+    can verify the call path.
+    """
+
+    class _StubStack(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.action_in_proj = nn.Linear(7, 8)
+            self.last_call: dict = {}
+
+        def forward(
+            self,
+            noisy_actions,
+            timestep=None,
+            position_ids=None,
+            vlm_k=None,
+            vlm_v=None,
+            prefix_offset=None,
+            kv_mask=None,
+        ):
+            self.last_call = dict(
+                noisy_actions=noisy_actions,
+                timestep=timestep,
+                position_ids=position_ids,
+                vlm_k=vlm_k,
+                vlm_v=vlm_v,
+                prefix_offset=prefix_offset,
+                kv_mask=kv_mask,
+            )
+            return noisy_actions
+
+    return _StubStack()


### PR DESCRIPTION
Per the design revision in Day 4c PR description: standalone GemmaExpertBackbone (originally planned Day 4d) folded into the head. Day 4d skipped; this Day 4e ships both.

Thin wrapper around the existing `src/reflex/exporters/smolvla_exporter.ExpertStack` shared by pi0/pi05/smolvla. Wrapping not reimplementing preserves bit-identical behavior. Construction paths: pre-built expert_stack= (the Pi0VLA composition path) or state_dict= + vla_family= + head_dim (smolvla only).

11 unit tests cover registration, ABC subclass, construction validation (5 cases incl. SmolVLA head_dim requirement), forward delegation (3 cases), prepare_triton.

TODO(Day 4g cleanup): move ExpertStack from `exporters/smolvla_exporter.py` to `models/heads/expert_stack.py`. Deferred to the OLD-exporter sunset commit.

Pre-merge validation: syntax ✓ AST sweep ✓ live import + registration ✓.

Day 4f next: Pi0VLA composition class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)