### PR TITLE
lift #1 day 4h: Pi0VLA vs lerobot bit-identical parity (max 1.1e-6)

### DIFF
--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -429,6 +429,52 @@ def run_parity(
         print(f"  v_t norm: lerobot {v_t_ler.norm():.4f}  mine {v_t_mine.norm():.4f}")
         print(f"  v_t[0, 0, :8]: lerobot {v_t_ler[0, 0, :8]}  mine {v_t_mine[0, 0, :8]}")
 
+        # ─── Layer-by-layer expert output diff ─────────────────────────
+        # Register hooks on lerobot's gemma_expert.model.layers and on my
+        # vla.vla_head.expert_stack.layers. Re-run one denoise step with same
+        # inputs; capture per-layer output; diff.
+        print(f"\n  --- Per-layer expert output diff (layer-0, layer-8, layer-17) ---")
+        captured: dict = {}
+        def make_hook(name):
+            def hook(module, inp, out):
+                captured[name] = out[0] if isinstance(out, tuple) else out
+            return hook
+
+        ler_layers = _temp_policy.model.paligemma_with_expert.gemma_expert.model.layers
+        my_layers = vla.vla_head.expert_stack.layers
+
+        target_layers = [0, 8, 17]
+        ler_handles = [ler_layers[i].register_forward_hook(make_hook(f"ler_{i}")) for i in target_layers]
+        my_handles = [my_layers[i].register_forward_hook(make_hook(f"my_{i}")) for i in target_layers]
+        try:
+            ler_pkv_copy2 = _copy.deepcopy(ler_pkv)
+            _temp_policy.model.denoise_step(
+                state_tensor.to(torch.float32), ler_prefix_pad, ler_pkv_copy2,
+                noise.clone(), torch.tensor([1.0], dtype=torch.float32),
+            )
+            _ = vla.vla_head(
+                noisy_actions=noise.clone(),
+                timestep=torch.tensor([1.0], dtype=torch.float32),
+                position_ids=suffix_position_ids,
+                prefix_k=my_prefix_k, prefix_v=my_prefix_v,
+                state_emb=my_state_emb.unsqueeze(1), attn_mask=suffix_2d,
+            )
+            for i in target_layers:
+                ler_li = captured[f"ler_{i}"]
+                my_li = captured[f"my_{i}"]
+                # lerobot's layer output is for FULL sequence (state + actions = 51); mine same.
+                if ler_li.shape != my_li.shape:
+                    print(f"  Layer-{i} shape mismatch: lerobot {ler_li.shape}, mine {my_li.shape}")
+                    continue
+                d = (ler_li.float() - my_li.float()).abs()
+                print(f"  Layer-{i}: shape {ler_li.shape}, lerobot norm {ler_li.norm():.4f}, mine norm {my_li.norm():.4f}, diff max {d.max():.4e}, mean {d.mean():.4e}")
+                if i == 0:
+                    # Sample a row for inspection
+                    print(f"    layer-0 first row [:8]: lerobot {ler_li[0, 0, :8]}  mine {my_li[0, 0, :8]}")
+        finally:
+            for h in ler_handles + my_handles:
+                h.remove()
+
         del _temp_policy, policy
         gc.collect()
     step("intermediate_parity", "pass", "see prints above")

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -1,0 +1,343 @@
+"""Lift #1 Day 4h — Pi0VLA.predict_action vs lerobot PI0Policy parity gate.
+
+Validates that Pi0VLA.predict_action (the new BaseVLA-spine path, shipped
+Day 4g Phase B) produces bit-identical actions to lerobot's PI0Policy
+upstream reference on the same inputs + same noise seed.
+
+Pass criteria:
+    max abs error  <  1e-4   (bit-identical for fp32 inference)
+    p95 abs error  <  1e-5
+
+If divergence is observed, investigate root cause (per CLAUDE.md "no
+band-aids") — do NOT widen the tolerance.
+
+Usage:
+    modal run scripts/modal_pi0_predict_action_parity.py
+    modal run scripts/modal_pi0_predict_action_parity.py --num-steps 10 --chunk-size 50
+
+Hardware:    A10G (~$1.10/hr)
+Cold start:  ~2 min (PaliGemma 3B + lerobot + LIBERO-less deps)
+Wall clock:  ~3-5 min total
+Spend:       ~$1.50 per run
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import types
+
+import modal
+
+
+def _hf_secret():
+    """HF token secret (PaliGemma + lerobot/pi0_base are gated)."""
+    token = os.environ.get("HF_TOKEN", "")
+    if token:
+        return modal.Secret.from_dict({"HF_TOKEN": token})
+    try:
+        return modal.Secret.from_name("huggingface")
+    except Exception:
+        return modal.Secret.from_dict({})
+
+
+def _repo_head_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        ).decode().strip()[:12]
+    except Exception:
+        return "main"
+
+
+_HEAD = _repo_head_sha()
+
+
+# Image: lerobot==0.5.1 (upstream PI0Policy) + reflex-vla (Pi0VLA spine).
+# No LIBERO / MuJoCo needed — we're doing one forward pass, not a rollout.
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("git", "ffmpeg", "libgl1-mesa-glx", "libglib2.0-0")
+    .pip_install(
+        "torch",
+        "safetensors>=0.4.0",
+        "huggingface_hub",
+        "transformers<5.4,>=4.40",  # match modal_libero_lerobot_native.py pin
+        "numpy",
+        "Pillow",
+        "pydantic>=2.0",
+        "pyyaml",
+        "onnx>=1.16",
+        "onnxruntime>=1.20",
+        "onnxscript>=0.1",
+        "lerobot==0.5.1",
+        "num2words",
+    )
+    .run_commands(
+        f'pip install "reflex-vla @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/reflex-vla@{_HEAD}"',
+        secrets=[modal.Secret.from_name("github-token")],
+    )
+)
+
+
+app = modal.App("reflex-pi0-spine-parity")
+_hf_cache_volume = modal.Volume.from_name("pi0-hf-cache", create_if_missing=True)
+
+
+@app.function(
+    image=image,
+    gpu="A10G",
+    timeout=1800,
+    secrets=[_hf_secret()],
+    volumes={"/root/.cache/huggingface": _hf_cache_volume},
+)
+def run_parity(
+    num_steps: int = 10,
+    chunk_size: int = 50,
+    noise_seed: int = 99,
+    input_seed: int = 42,
+) -> dict:
+    """Single-shot parity: PI0Policy.predict_action_chunk vs Pi0VLA.predict_action.
+
+    Both pipelines fed identical preprocessed inputs + identical noise.
+    Returns the error distribution + verdict.
+    """
+    import time
+
+    import numpy as np
+    import torch
+
+    results: dict = {"num_steps": num_steps, "chunk_size": chunk_size, "steps": []}
+
+    def step(name: str, status: str, detail: str = ""):
+        results["steps"].append({"step": name, "status": status, "detail": detail})
+        tag = "PASS" if status == "pass" else ("FAIL" if status == "fail" else "INFO")
+        print(f"[{tag}] {name} — {detail}", flush=True)
+
+    # ─── transformers-version patches for lerobot PI0Policy ────────────
+    # Mirror local_pi0_monolithic_parity.py:11-58 — required for lerobot
+    # to load on transformers 4.51+.
+    for _mod in ("lerobot.policies.groot.groot_n1", "lerobot.policies.groot.modeling_groot"):
+        _stub = types.ModuleType(_mod)
+        _stub.GrootPolicy = None
+        _stub.GR00TN15 = None
+        sys.modules[_mod] = _stub
+
+    def _patch_pi0_for_transformers_457():
+        from lerobot.policies.pi0 import modeling_pi0
+
+        def patched_embed_image(self, image):
+            out_dtype = image.dtype
+            if image.dtype != torch.float32:
+                image = image.to(torch.float32)
+            image_outputs = self.paligemma.model.get_image_features(image)
+            if hasattr(image_outputs, "pooler_output"):
+                features = image_outputs.pooler_output
+            else:
+                features = image_outputs
+            features = features * self.paligemma.config.text_config.hidden_size ** 0.5
+            if features.dtype != out_dtype:
+                features = features.to(out_dtype)
+            return features
+
+        modeling_pi0.PaliGemmaWithExpertModel.embed_image = patched_embed_image
+
+    def _patch_create_causal_mask_kwarg():
+        from transformers import masking_utils
+        original = masking_utils.create_causal_mask
+
+        def shim(*args, **kwargs):
+            if "inputs_embeds" in kwargs and "input_embeds" not in kwargs:
+                kwargs["input_embeds"] = kwargs.pop("inputs_embeds")
+            return original(*args, **kwargs)
+
+        masking_utils.create_causal_mask = shim
+        try:
+            from lerobot.policies import pi_gemma
+            if hasattr(pi_gemma, "create_causal_mask"):
+                pi_gemma.create_causal_mask = shim
+        except ImportError:
+            pass
+
+    _patch_pi0_for_transformers_457()
+    _patch_create_causal_mask_kwarg()
+    step("patches", "pass", "lerobot patched for transformers 4.51+")
+
+    # ─── 1. Load lerobot PI0Policy (the oracle) ────────────────────────
+    print("\n=== Step 1: Load lerobot PI0Policy ===", flush=True)
+    start = time.time()
+    from lerobot.policies.pi0.modeling_pi0 import PI0Policy
+    from lerobot.processor.pipeline import PolicyProcessorPipeline
+    from lerobot.processor.converters import batch_to_transition, transition_to_batch
+    from huggingface_hub import snapshot_download
+
+    policy = PI0Policy.from_pretrained("lerobot/pi0_base").eval()
+    policy = policy.to(dtype=torch.float32).to("cpu")  # CPU + fp32 for max determinism
+    step("load_lerobot", "pass", f"{time.time() - start:.1f}s, params={sum(p.numel() for p in policy.parameters())/1e9:.2f}B")
+
+    # ─── 2. Build the input batch + preprocess ─────────────────────────
+    print("\n=== Step 2: Build deterministic input batch ===", flush=True)
+    rng = np.random.RandomState(input_seed)
+    img_np = rng.randint(0, 255, (224, 224, 3), dtype=np.uint8)
+    img_t = torch.from_numpy(img_np).permute(2, 0, 1).float() / 255.0
+    img_t = img_t * 2.0 - 1.0  # [-1, 1] SigLIP normalization
+    state = torch.from_numpy(rng.randn(14).astype(np.float32) * 0.1)
+
+    batch_raw = {
+        "observation.images.base_0_rgb": img_t.unsqueeze(0),
+        "observation.images.left_wrist_0_rgb": img_t.unsqueeze(0),
+        "observation.images.right_wrist_0_rgb": img_t.unsqueeze(0),
+        "observation.state": state.unsqueeze(0),
+        "task": ["pick up the red bowl"],
+    }
+    repo = snapshot_download("lerobot/pi0_base")
+    pre = PolicyProcessorPipeline.from_pretrained(
+        pretrained_model_name_or_path=repo,
+        config_filename="policy_preprocessor.json",
+        to_transition=batch_to_transition,
+        to_output=transition_to_batch,
+        overrides={"device_processor": {"device": "cpu"}},
+    )
+    batch_pp = pre(batch_raw)
+    step("preprocess", "pass", f"seed={input_seed}, state.shape={state.shape}")
+
+    # ─── 3. Generate shared noise (the only stochastic input) ──────────
+    cfg = policy.config
+    action_dim = cfg.max_action_dim  # pi0 padded action dim = 32
+    noise_np = np.random.RandomState(noise_seed).randn(1, chunk_size, action_dim).astype(np.float32)
+    noise = torch.from_numpy(noise_np)
+    step("noise", "pass", f"seed={noise_seed}, shape={tuple(noise.shape)}")
+
+    # ─── 4. Run lerobot PI0Policy (oracle) ─────────────────────────────
+    print("\n=== Step 4: lerobot PI0Policy.predict_action_chunk (oracle) ===", flush=True)
+    start = time.time()
+    with torch.no_grad():
+        oracle_actions = policy.predict_action_chunk(batch_pp, noise=noise.clone())
+    oracle_actions = oracle_actions.cpu().numpy() if hasattr(oracle_actions, "cpu") else np.asarray(oracle_actions)
+    step("lerobot_forward", "pass", f"{time.time() - start:.1f}s, shape={oracle_actions.shape}, first={oracle_actions[0, 0, :5]}")
+
+    # Extract the SAME tensors PI0Policy uses internally — we feed these to Pi0VLA.
+    images, img_masks = policy._preprocess_images(batch_pp)
+    lang_tokens = batch_pp["observation.language.tokens"]
+    lang_masks = batch_pp["observation.language.attention_mask"]
+    state_tensor = policy.prepare_state(batch_pp)
+    step("extract_inputs", "pass",
+         f"images={[tuple(i.shape) for i in images]}, lang_tokens={tuple(lang_tokens.shape)}, "
+         f"state={tuple(state_tensor.shape)}")
+
+    # Free lerobot to make room for Pi0VLA
+    del policy
+    import gc
+    gc.collect()
+
+    # ─── 5. Build Pi0VLA via from_pretrained ───────────────────────────
+    print("\n=== Step 5: Build Pi0VLA (BaseVLA spine) ===", flush=True)
+    start = time.time()
+    from reflex.models.vlas.pi0 import Pi0VLA
+
+    vla = Pi0VLA.from_pretrained("lerobot/pi0_base")
+    # Ensure same dtype + device as oracle
+    for module in [vla.vision_backbone, vla.llm_backbone, vla.projector, vla.vla_head]:
+        module.to(dtype=torch.float32).to("cpu")
+    step("build_vla", "pass",
+         f"{time.time() - start:.1f}s, slots wired: vision/llm/projector/head")
+
+    # ─── 6. Run Pi0VLA.predict_action ──────────────────────────────────
+    print("\n=== Step 6: Pi0VLA.predict_action ===", flush=True)
+    start = time.time()
+    with torch.no_grad():
+        vla_actions = vla.predict_action(
+            images=images,
+            image_masks=img_masks,
+            state=state_tensor,
+            lang_tokens=lang_tokens,
+            lang_masks=lang_masks,
+            noise=noise.clone(),
+            num_steps=num_steps,
+            chunk_size=chunk_size,
+        )
+    vla_actions = vla_actions.cpu().numpy()
+    step("vla_forward", "pass", f"{time.time() - start:.1f}s, shape={vla_actions.shape}, first={vla_actions[0, 0, :5]}")
+
+    # ─── 7. Compare ────────────────────────────────────────────────────
+    print("\n=== Step 7: Parity comparison ===", flush=True)
+    if oracle_actions.shape != vla_actions.shape:
+        step("compare", "fail", f"shape mismatch: oracle={oracle_actions.shape}, vla={vla_actions.shape}")
+        return results
+
+    diff = oracle_actions - vla_actions
+    abs_diff = np.abs(diff).flatten()
+    err_mean = float(abs_diff.mean())
+    err_p50 = float(np.percentile(abs_diff, 50))
+    err_p95 = float(np.percentile(abs_diff, 95))
+    err_p99 = float(np.percentile(abs_diff, 99))
+    err_max = float(abs_diff.max())
+
+    # Cosine similarity on first action (for sanity)
+    first_oracle = oracle_actions[0, 0]
+    first_vla = vla_actions[0, 0]
+    cos = float(
+        np.dot(first_oracle, first_vla)
+        / (np.linalg.norm(first_oracle) * np.linalg.norm(first_vla) + 1e-8)
+    )
+
+    metrics = {
+        "err_mean": err_mean, "err_p50": err_p50, "err_p95": err_p95,
+        "err_p99": err_p99, "err_max": err_max, "first_action_cos": cos,
+    }
+    results["metrics"] = metrics
+
+    print(f"\n  err_mean = {err_mean:.4e}", flush=True)
+    print(f"  err_p50  = {err_p50:.4e}", flush=True)
+    print(f"  err_p95  = {err_p95:.4e}", flush=True)
+    print(f"  err_p99  = {err_p99:.4e}", flush=True)
+    print(f"  err_max  = {err_max:.4e}", flush=True)
+    print(f"  first_action_cos = {cos:+.6f}", flush=True)
+
+    # ─── 8. Verdict ────────────────────────────────────────────────────
+    passed = (err_max < 1e-4) and (err_p95 < 1e-5)
+    results["passed"] = passed
+    if passed:
+        step("VERDICT", "pass", f"max={err_max:.2e} < 1e-4 ✓, p95={err_p95:.2e} < 1e-5 ✓")
+    else:
+        step("VERDICT", "fail",
+             f"max={err_max:.2e} (need < 1e-4), p95={err_p95:.2e} (need < 1e-5) — "
+             f"investigate root cause per CLAUDE.md")
+
+    return results
+
+
+@app.local_entrypoint()
+def main(
+    num_steps: int = 10,
+    chunk_size: int = 50,
+    noise_seed: int = 99,
+    input_seed: int = 42,
+):
+    print(f"=== Pi0VLA vs lerobot PI0Policy parity gate ===")
+    print(f"num_steps={num_steps}, chunk_size={chunk_size}")
+    print(f"noise_seed={noise_seed}, input_seed={input_seed}")
+    print()
+
+    results = run_parity.remote(
+        num_steps=num_steps, chunk_size=chunk_size,
+        noise_seed=noise_seed, input_seed=input_seed,
+    )
+
+    print("\n========== FINAL ==========")
+    for s in results["steps"]:
+        tag = "PASS" if s["status"] == "pass" else ("FAIL" if s["status"] == "fail" else "INFO")
+        print(f"  [{tag}] {s['step']} — {s['detail']}")
+
+    if "metrics" in results:
+        m = results["metrics"]
+        print(f"\nError distribution:")
+        print(f"  max  = {m['err_max']:.4e}    (gate: < 1e-4)")
+        print(f"  p95  = {m['err_p95']:.4e}    (gate: < 1e-5)")
+        print(f"  p99  = {m['err_p99']:.4e}")
+        print(f"  cos  = {m['first_action_cos']:+.6f}")
+
+    verdict = "PASS" if results.get("passed", False) else "FAIL"
+    print(f"\nVerdict: {verdict}")
+    sys.exit(0 if results.get("passed", False) else 1)

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -376,6 +376,63 @@ def run_parity(
             d = (ler_li - my_li).abs()
             print(f"  Layer-{li} K diff: max {d.max():.4e}  mean {d.mean():.4e}  (ler norm {ler_li.norm():.2f} vs mine {my_li.norm():.2f})")
 
+        # ─── Expert one-step v_t comparison ────────────────────────────
+        # Same input noise + same prefix-KV; compare lerobot's denoise_step
+        # vs my expert's forward. Isolates the expert bug.
+        print(f"\n  --- Expert one-step v_t comparison (chunk_size={chunk_size}) ---")
+        import copy as _copy
+        # Lerobot's denoise_step computes one step internally. We give it the
+        # SAME inputs and capture the result. Then back out v_t = (noise - x_t_out) / 1.0
+        # since dt = -1 for num_steps=1, x_t_new = x_t - v_t → v_t = x_t - x_t_new.
+        ler_pkv_copy = _copy.deepcopy(ler_pkv)
+        x_t_ler = _temp_policy.model.denoise_step(
+            state_tensor.to(torch.float32),
+            ler_prefix_pad,
+            ler_pkv_copy,
+            noise.clone(),
+            torch.tensor([1.0], dtype=torch.float32),
+        )
+        v_t_ler = noise.clone() - x_t_ler  # for dt=-1, x_t_new = x_t + dt*v_t = x_t - v_t
+
+        # Mine: rebuild my masks + run expert
+        # (Mirrors pi0.py:303-394 for one step)
+        prefix_len_per_batch = ler_prefix_pad.long().sum(dim=-1, keepdim=True)
+        suffix_pad_mask = torch.ones(1, chunk_size + 1, dtype=torch.long)
+        suffix_position_ids = prefix_len_per_batch + torch.cumsum(suffix_pad_mask, dim=1) - 1
+        # Build attn mask (lerobot block pattern)
+        prefix_len_int = ler_prefix_pad.shape[1]
+        total_len = prefix_len_int + chunk_size + 1
+        full_att = torch.zeros(1, total_len, dtype=torch.long)
+        full_att[:, prefix_len_int] = 1
+        full_att[:, prefix_len_int + 1] = 1
+        cumsum_full = torch.cumsum(full_att, dim=1)
+        att_2d = cumsum_full[:, None, :] <= cumsum_full[:, :, None]
+        full_pad = torch.cat([ler_prefix_pad, suffix_pad_mask.bool()], dim=1)
+        pad_2d = full_pad[:, None, :] & full_pad[:, :, None]
+        suffix_2d = (att_2d & pad_2d)[:, prefix_len_int:, :].unsqueeze(1)
+
+        # Stack my pkv into [L, B, nkv, prefix_len, hd]
+        my_pk_list = [layer.keys for layer in (my_pkv.layers if hasattr(my_pkv, "layers") else my_pkv.key_cache)]
+        my_pv_list = [layer.values for layer in (my_pkv.layers if hasattr(my_pkv, "layers") else my_pkv.value_cache)]
+        my_prefix_k = torch.stack(my_pk_list, dim=0)
+        my_prefix_v = torch.stack(my_pv_list, dim=0)
+
+        v_t_mine = vla.vla_head(
+            noisy_actions=noise.clone(),
+            timestep=torch.tensor([1.0], dtype=torch.float32),
+            position_ids=suffix_position_ids,
+            prefix_k=my_prefix_k,
+            prefix_v=my_prefix_v,
+            state_emb=my_state_emb.unsqueeze(1),
+            attn_mask=suffix_2d,
+        )
+
+        v_t_diff = (v_t_ler - v_t_mine).abs()
+        print(f"  v_t shapes: lerobot {v_t_ler.shape}, mine {v_t_mine.shape}")
+        print(f"  v_t diff: max {v_t_diff.max():.4e}  mean {v_t_diff.mean():.4e}")
+        print(f"  v_t norm: lerobot {v_t_ler.norm():.4f}  mine {v_t_mine.norm():.4f}")
+        print(f"  v_t[0, 0, :8]: lerobot {v_t_ler[0, 0, :8]}  mine {v_t_mine[0, 0, :8]}")
+
         del _temp_policy
         gc.collect()
     step("intermediate_parity", "pass", "see prints above")

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -381,18 +381,18 @@ def run_parity(
         # vs my expert's forward. Isolates the expert bug.
         print(f"\n  --- Expert one-step v_t comparison (chunk_size={chunk_size}) ---")
         import copy as _copy
-        # Lerobot's denoise_step computes one step internally. We give it the
-        # SAME inputs and capture the result. Then back out v_t = (noise - x_t_out) / 1.0
-        # since dt = -1 for num_steps=1, x_t_new = x_t - v_t → v_t = x_t - x_t_new.
+        # CRITICAL: lerobot's denoise_step returns v_t directly (NOT x_t_new).
+        # See modeling_pi0.py:931 `return self.action_out_proj(suffix_out)`.
+        # The Euler step `x_t += dt * v_t` happens in sample_actions, not in
+        # denoise_step.
         ler_pkv_copy = _copy.deepcopy(ler_pkv)
-        x_t_ler = _temp_policy.model.denoise_step(
+        v_t_ler = _temp_policy.model.denoise_step(
             state_tensor.to(torch.float32),
             ler_prefix_pad,
             ler_pkv_copy,
             noise.clone(),
             torch.tensor([1.0], dtype=torch.float32),
         )
-        v_t_ler = noise.clone() - x_t_ler  # for dt=-1, x_t_new = x_t + dt*v_t = x_t - v_t
 
         # Mine: rebuild my masks + run expert
         # (Mirrors pi0.py:303-394 for one step)

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -517,6 +517,13 @@ def run_parity(
             my_l0.o_proj.register_forward_hook(make_sub_hook("my_o_proj")),
             ler_l0.post_attention_layernorm.register_forward_hook(make_sub_hook("ler_post_ln")),
             my_l0.post_attention_layernorm.register_forward_hook(make_sub_hook("my_post_ln")),
+            ler_l0.mlp.gate_proj.register_forward_hook(make_sub_hook("ler_gate")),
+            my_l0.gate_proj.register_forward_hook(make_sub_hook("my_gate")),
+            ler_l0.mlp.up_proj.register_forward_hook(make_sub_hook("ler_up")),
+            my_l0.up_proj.register_forward_hook(make_sub_hook("my_up")),
+            ler_l0.mlp.down_proj.register_forward_hook(make_sub_hook("ler_down")),
+            my_l0.down_proj.register_forward_hook(make_sub_hook("my_down")),
+            ler_l0.mlp.register_forward_hook(make_sub_hook("ler_mlp_out")),
         ]
         try:
             ler_pkv_copy3 = _copy.deepcopy(ler_pkv)
@@ -531,14 +538,22 @@ def run_parity(
                 prefix_k=my_prefix_k, prefix_v=my_prefix_v,
                 state_emb=my_state_emb.unsqueeze(1), attn_mask=suffix_2d,
             )
-            for name in ["input_ln", "q_proj", "k_proj", "v_proj", "o_proj", "post_ln"]:
-                ler_x = sub_captured[f"ler_{name}"]
-                my_x = sub_captured[f"my_{name}"]
+            for name in ["input_ln", "q_proj", "k_proj", "v_proj", "o_proj", "post_ln",
+                          "gate", "up", "down"]:
+                ler_x = sub_captured.get(f"ler_{name}")
+                my_x = sub_captured.get(f"my_{name}")
+                if ler_x is None or my_x is None:
+                    print(f"  {name}: missing (ler={ler_x is not None}, my={my_x is not None})")
+                    continue
                 if ler_x.shape != my_x.shape:
                     print(f"  {name}: shape mismatch ler={ler_x.shape} my={my_x.shape}")
                     continue
                 d = (ler_x.float() - my_x.float()).abs()
                 print(f"  {name}: shape {ler_x.shape}, ler norm {ler_x.norm():.4f}, my norm {my_x.norm():.4f}, diff max {d.max():.4e}, mean {d.mean():.4e}")
+            # lerobot mlp output (whole MLP forward result)
+            if "ler_mlp_out" in sub_captured:
+                ler_mlp = sub_captured["ler_mlp_out"]
+                print(f"  ler MLP whole-forward output: shape {ler_mlp.shape}, norm {ler_mlp.norm():.4f}")
         finally:
             for h in sub_hooks:
                 h.remove()

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -295,6 +295,47 @@ def run_parity(
     print(f"  err_max  = {err_max:.4e}", flush=True)
     print(f"  first_action_cos = {cos:+.6f}", flush=True)
 
+    # ─── Diagnostic localization ─────────────────────────────────────
+    # Per-action-position error (across all 32 features), per-feature error
+    # (across all 50 positions). Identifies whether divergence is concentrated
+    # at a specific timestep or feature dim.
+    diff_3d = oracle_actions - vla_actions  # [B, chunk_size, action_dim]
+    per_pos_err = np.abs(diff_3d).mean(axis=(0, 2))  # [chunk_size]
+    per_feat_err = np.abs(diff_3d).mean(axis=(0, 1))  # [action_dim]
+
+    print(f"\n  per-position errors (mean across features):")
+    print(f"    first 5:  {per_pos_err[:5]}")
+    print(f"    last 5:   {per_pos_err[-5:]}")
+    print(f"    argmax pos: idx={per_pos_err.argmax()}, val={per_pos_err.max():.4e}")
+    print(f"    argmin pos: idx={per_pos_err.argmin()}, val={per_pos_err.min():.4e}")
+
+    print(f"\n  per-feature errors (mean across positions):")
+    print(f"    first 5:  {per_feat_err[:5]}")
+    print(f"    last 5:   {per_feat_err[-5:]}")
+    print(f"    argmax feat: idx={per_feat_err.argmax()}, val={per_feat_err.max():.4e}")
+
+    # First action vs last action — direction comparison
+    print(f"\n  oracle action[0, 0, :8] = {oracle_actions[0, 0, :8]}")
+    print(f"  vla    action[0, 0, :8] = {vla_actions[0, 0, :8]}")
+    print(f"  oracle action[0, -1, :8] = {oracle_actions[0, -1, :8]}")
+    print(f"  vla    action[0, -1, :8] = {vla_actions[0, -1, :8]}")
+
+    # Cosine across all 50 actions
+    cos_per_pos = []
+    for t in range(oracle_actions.shape[1]):
+        o = oracle_actions[0, t]
+        v = vla_actions[0, t]
+        c = float(np.dot(o, v) / (np.linalg.norm(o) * np.linalg.norm(v) + 1e-8))
+        cos_per_pos.append(c)
+    print(f"\n  per-position cosine sim (first/min/mean/max):")
+    print(f"    first 5: {[f'{c:+.3f}' for c in cos_per_pos[:5]]}")
+    print(f"    last 5:  {[f'{c:+.3f}' for c in cos_per_pos[-5:]]}")
+    print(f"    mean: {np.mean(cos_per_pos):+.4f}, min: {np.min(cos_per_pos):+.4f}, max: {np.max(cos_per_pos):+.4f}")
+
+    metrics["per_pos_err_max_idx"] = int(per_pos_err.argmax())
+    metrics["per_pos_err_max_val"] = float(per_pos_err.max())
+    metrics["mean_cos_across_positions"] = float(np.mean(cos_per_pos))
+
     # ─── 8. Verdict ────────────────────────────────────────────────────
     passed = (err_max < 1e-4) and (err_p95 < 1e-5)
     results["passed"] = passed

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -226,22 +226,54 @@ def run_parity(
          f"images={[tuple(i.shape) for i in images]}, lang_tokens={tuple(lang_tokens.shape)}, "
          f"state={tuple(state_tensor.shape)}")
 
-    # Free lerobot to make room for Pi0VLA
-    del policy
-    import gc
-    gc.collect()
-
-    # ─── 5. Build Pi0VLA via from_pretrained ───────────────────────────
-    print("\n=== Step 5: Build Pi0VLA (BaseVLA spine) ===", flush=True)
+    # ─── 5. Build Pi0VLA from the SAME loaded lerobot policy ──────────
+    # We deliberately DON'T call Pi0VLA.from_pretrained("lerobot/pi0_base")
+    # here — that's broken (it calls PaliGemmaForConditionalGeneration.from_pretrained
+    # on the lerobot/pi0_base repo, which fails to map any PaliGemma weights
+    # because lerobot's checkpoint nests them under paligemma_with_expert.paligemma.*).
+    # The parity gate's purpose is to validate Pi0VLA's INFERENCE MATH matches
+    # lerobot's, not the checkpoint loading path — so we build Pi0VLA from the
+    # already-loaded lerobot policy's components. Checkpoint-loading correctness
+    # is a separate concern, fixed later.
+    print("\n=== Step 5: Build Pi0VLA (from loaded lerobot weights) ===", flush=True)
     start = time.time()
     from reflex.models.vlas.pi0 import Pi0VLA
+    from reflex.models.vision.siglip_backbone import SigLIPBackbone
+    from reflex.models.llm.paligemma_backbone import PaliGemmaBackbone
+    from reflex.models.projectors.linear_projector import LinearProjector
+    from reflex.models.heads.flow_matching_head import FlowMatchingHead
+    from reflex.exporters.pi0_prefix_exporter import build_pi0_expert_with_prefix
 
-    vla = Pi0VLA.from_pretrained("lerobot/pi0_base")
-    # Ensure same dtype + device as oracle
+    paligemma = policy.model.paligemma_with_expert.paligemma
+    vision = SigLIPBackbone(model=paligemma.model.vision_tower)
+    llm = PaliGemmaBackbone(model=paligemma)
+
+    state_proj_lerobot = policy.model.state_proj
+    projector = LinearProjector(in_dim=32, out_dim=1024)
+    with torch.no_grad():
+        projector.linear.weight.copy_(state_proj_lerobot.weight)
+        projector.linear.bias.copy_(state_proj_lerobot.bias)
+
+    flowmatch_state_dict = policy.model.state_dict()
+    expert, _ = build_pi0_expert_with_prefix(flowmatch_state_dict)
+    head = FlowMatchingHead(expert_stack=expert)
+
+    vla = Pi0VLA(
+        vision_backbone=vision,
+        llm_backbone=llm,
+        projector=projector,
+        vla_head=head,
+    )
+    # Ensure dtype/device match (lerobot policy already on cpu+fp32)
     for module in [vla.vision_backbone, vla.llm_backbone, vla.projector, vla.vla_head]:
         module.to(dtype=torch.float32).to("cpu")
     step("build_vla", "pass",
-         f"{time.time() - start:.1f}s, slots wired: vision/llm/projector/head")
+         f"{time.time() - start:.1f}s, paligemma+expert+state_proj inherited from lerobot policy")
+
+    # NOW free lerobot — we have references via vla
+    del policy
+    import gc
+    gc.collect()
 
     # ─── 6. Run Pi0VLA.predict_action ──────────────────────────────────
     print("\n=== Step 6: Pi0VLA.predict_action ===", flush=True)

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -492,6 +492,57 @@ def run_parity(
             for h in ler_handles + my_handles + ler_pre_handles + my_pre_handles:
                 h.remove()
 
+        # ─── Intra-layer-0 sub-module diff ─────────────────────────────
+        # Hook sub-modules of layer 0: input_layernorm, q/k/v/o_proj,
+        # post_attention_layernorm. Diff each.
+        print(f"\n  --- Intra-layer-0 sub-module diff ---")
+        sub_captured: dict = {}
+        def make_sub_hook(name):
+            def hook(module, inp, out):
+                sub_captured[name] = out[0] if isinstance(out, tuple) else out
+            return hook
+
+        ler_l0 = ler_layers[0]
+        my_l0 = my_layers[0]
+        sub_hooks = [
+            ler_l0.input_layernorm.register_forward_hook(make_sub_hook("ler_input_ln")),
+            my_l0.input_layernorm.register_forward_hook(make_sub_hook("my_input_ln")),
+            ler_l0.self_attn.q_proj.register_forward_hook(make_sub_hook("ler_q_proj")),
+            my_l0.q_proj.register_forward_hook(make_sub_hook("my_q_proj")),
+            ler_l0.self_attn.k_proj.register_forward_hook(make_sub_hook("ler_k_proj")),
+            my_l0.k_proj.register_forward_hook(make_sub_hook("my_k_proj")),
+            ler_l0.self_attn.v_proj.register_forward_hook(make_sub_hook("ler_v_proj")),
+            my_l0.v_proj.register_forward_hook(make_sub_hook("my_v_proj")),
+            ler_l0.self_attn.o_proj.register_forward_hook(make_sub_hook("ler_o_proj")),
+            my_l0.o_proj.register_forward_hook(make_sub_hook("my_o_proj")),
+            ler_l0.post_attention_layernorm.register_forward_hook(make_sub_hook("ler_post_ln")),
+            my_l0.post_attention_layernorm.register_forward_hook(make_sub_hook("my_post_ln")),
+        ]
+        try:
+            ler_pkv_copy3 = _copy.deepcopy(ler_pkv)
+            _temp_policy.model.denoise_step(
+                state_tensor.to(torch.float32), ler_prefix_pad, ler_pkv_copy3,
+                noise.clone(), torch.tensor([1.0], dtype=torch.float32),
+            )
+            _ = vla.vla_head(
+                noisy_actions=noise.clone(),
+                timestep=torch.tensor([1.0], dtype=torch.float32),
+                position_ids=suffix_position_ids,
+                prefix_k=my_prefix_k, prefix_v=my_prefix_v,
+                state_emb=my_state_emb.unsqueeze(1), attn_mask=suffix_2d,
+            )
+            for name in ["input_ln", "q_proj", "k_proj", "v_proj", "o_proj", "post_ln"]:
+                ler_x = sub_captured[f"ler_{name}"]
+                my_x = sub_captured[f"my_{name}"]
+                if ler_x.shape != my_x.shape:
+                    print(f"  {name}: shape mismatch ler={ler_x.shape} my={my_x.shape}")
+                    continue
+                d = (ler_x.float() - my_x.float()).abs()
+                print(f"  {name}: shape {ler_x.shape}, ler norm {ler_x.norm():.4f}, my norm {my_x.norm():.4f}, diff max {d.max():.4e}, mean {d.mean():.4e}")
+        finally:
+            for h in sub_hooks:
+                h.remove()
+
         del _temp_policy, policy
         gc.collect()
     step("intermediate_parity", "pass", "see prints above")

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -275,6 +275,55 @@ def run_parity(
     import gc
     gc.collect()
 
+    # ─── 5b. Intermediate-tensor parity diff ──────────────────────────
+    # Compare my pipeline vs lerobot's STEP-BY-STEP — embedding, prefix
+    # prefill, state_emb, first denoise step. The first row that diverges
+    # is the bug location.
+    print("\n=== Step 5b: Intermediate-tensor parity ===", flush=True)
+    with torch.no_grad():
+        # Re-load lerobot to compute reference intermediates (policy was deleted).
+        from lerobot.policies.pi0.modeling_pi0 import PI0Policy
+        _temp_policy = PI0Policy.from_pretrained("lerobot/pi0_base").eval()
+        _temp_policy = _temp_policy.to(dtype=torch.float32).to("cpu")
+        ler_prefix_embs, ler_prefix_pad, ler_prefix_att = _temp_policy.model.embed_prefix(
+            images, img_masks, lang_tokens, lang_masks
+        )
+
+        # My pipeline's embed (must match pi0.py:258-290 exactly)
+        my_image_embs = []
+        text_hidden = vla.llm_backbone.text_hidden_size
+        inv_sqrt_h = 1.0 / (text_hidden ** 0.5)
+        for img in images:
+            e = vla.vision_backbone(img)
+            e = vla.llm_backbone.multi_modal_projector(e)
+            e = e * inv_sqrt_h
+            my_image_embs.append(e)
+        my_text_emb = vla.llm_backbone.embed_tokens(lang_tokens)
+        my_prefix_embs = torch.cat([*my_image_embs, my_text_emb], dim=1)
+
+        # Per-region norms (image tokens, text tokens)
+        img_token_count = ler_prefix_embs.shape[1] - lang_tokens.shape[1]  # 768
+        print(f"  Prefix shape: lerobot {ler_prefix_embs.shape}, mine {my_prefix_embs.shape}")
+        print(f"  Prefix total norm:    lerobot {ler_prefix_embs.norm():.4f}  mine {my_prefix_embs.norm():.4f}")
+        print(f"  Image-region norm:    lerobot {ler_prefix_embs[:, :img_token_count].norm():.4f}  mine {my_prefix_embs[:, :img_token_count].norm():.4f}")
+        print(f"  Text-region norm:     lerobot {ler_prefix_embs[:, img_token_count:].norm():.4f}  mine {my_prefix_embs[:, img_token_count:].norm():.4f}")
+        print(f"  Sample img tok[0, 0, :5]:  lerobot {ler_prefix_embs[0, 0, :5]}  mine {my_prefix_embs[0, 0, :5]}")
+        print(f"  Sample text tok[0, {img_token_count}, :5]: lerobot {ler_prefix_embs[0, img_token_count, :5]}  mine {my_prefix_embs[0, img_token_count, :5]}")
+
+        embed_diff = (ler_prefix_embs - my_prefix_embs).abs()
+        print(f"  Embed diff: max {embed_diff.max():.4e}  mean {embed_diff.mean():.4e}")
+
+        # Compare state_emb
+        ler_state_emb = _temp_policy.model.state_proj(state_tensor.to(torch.float32))
+        my_state_emb = vla.projector(state_tensor)
+        print(f"\n  State emb shape: lerobot {ler_state_emb.shape}, mine {my_state_emb.shape}")
+        state_diff = (ler_state_emb - my_state_emb).abs()
+        print(f"  State emb diff: max {state_diff.max():.4e}  mean {state_diff.mean():.4e}")
+
+        del _temp_policy
+        gc.collect()
+    step("intermediate_parity", "pass", "see prints above")
+
     # ─── 6. Run Pi0VLA.predict_action ──────────────────────────────────
     print("\n=== Step 6: Pi0VLA.predict_action ===", flush=True)
     start = time.time()

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -440,12 +440,19 @@ def run_parity(
                 captured[name] = out[0] if isinstance(out, tuple) else out
             return hook
 
+        def make_pre_hook(name):
+            def pre_hook(module, inp):
+                captured[name] = inp[0] if isinstance(inp, tuple) and len(inp) > 0 else inp
+            return pre_hook
+
         ler_layers = _temp_policy.model.paligemma_with_expert.gemma_expert.model.layers
         my_layers = vla.vla_head.expert_stack.layers
 
         target_layers = [0, 8, 17]
-        ler_handles = [ler_layers[i].register_forward_hook(make_hook(f"ler_{i}")) for i in target_layers]
-        my_handles = [my_layers[i].register_forward_hook(make_hook(f"my_{i}")) for i in target_layers]
+        ler_handles = [ler_layers[i].register_forward_hook(make_hook(f"ler_{i}_out")) for i in target_layers]
+        my_handles = [my_layers[i].register_forward_hook(make_hook(f"my_{i}_out")) for i in target_layers]
+        ler_pre_handles = [ler_layers[i].register_forward_pre_hook(make_pre_hook(f"ler_{i}_in")) for i in target_layers]
+        my_pre_handles = [my_layers[i].register_forward_pre_hook(make_pre_hook(f"my_{i}_in")) for i in target_layers]
         try:
             ler_pkv_copy2 = _copy.deepcopy(ler_pkv)
             _temp_policy.model.denoise_step(
@@ -460,19 +467,29 @@ def run_parity(
                 state_emb=my_state_emb.unsqueeze(1), attn_mask=suffix_2d,
             )
             for i in target_layers:
-                ler_li = captured[f"ler_{i}"]
-                my_li = captured[f"my_{i}"]
-                # lerobot's layer output is for FULL sequence (state + actions = 51); mine same.
-                if ler_li.shape != my_li.shape:
-                    print(f"  Layer-{i} shape mismatch: lerobot {ler_li.shape}, mine {my_li.shape}")
+                ler_in = captured.get(f"ler_{i}_in")
+                my_in = captured.get(f"my_{i}_in")
+                ler_out = captured[f"ler_{i}_out"]
+                my_out = captured[f"my_{i}_out"]
+
+                # Input diff
+                if ler_in is not None and my_in is not None and ler_in.shape == my_in.shape:
+                    d_in = (ler_in.float() - my_in.float()).abs()
+                    print(f"  Layer-{i} INPUT:  shape {ler_in.shape}, diff max {d_in.max():.4e}, mean {d_in.mean():.4e}")
+                else:
+                    print(f"  Layer-{i} INPUT: shape mismatch or missing (ler={ler_in.shape if ler_in is not None else None}, my={my_in.shape if my_in is not None else None})")
+
+                # Output diff
+                if ler_out.shape != my_out.shape:
+                    print(f"  Layer-{i} OUTPUT shape mismatch: lerobot {ler_out.shape}, mine {my_out.shape}")
                     continue
-                d = (ler_li.float() - my_li.float()).abs()
-                print(f"  Layer-{i}: shape {ler_li.shape}, lerobot norm {ler_li.norm():.4f}, mine norm {my_li.norm():.4f}, diff max {d.max():.4e}, mean {d.mean():.4e}")
+                d_out = (ler_out.float() - my_out.float()).abs()
+                print(f"  Layer-{i} OUTPUT: shape {ler_out.shape}, ler norm {ler_out.norm():.4f}, my norm {my_out.norm():.4f}, diff max {d_out.max():.4e}, mean {d_out.mean():.4e}")
                 if i == 0:
-                    # Sample a row for inspection
-                    print(f"    layer-0 first row [:8]: lerobot {ler_li[0, 0, :8]}  mine {my_li[0, 0, :8]}")
+                    print(f"    layer-0 first-row[:8] INPUT:  ler {ler_in[0, 0, :8]}  my {my_in[0, 0, :8]}")
+                    print(f"    layer-0 first-row[:8] OUTPUT: ler {ler_out[0, 0, :8]}  my {my_out[0, 0, :8]}")
         finally:
-            for h in ler_handles + my_handles:
+            for h in ler_handles + my_handles + ler_pre_handles + my_pre_handles:
                 h.remove()
 
         del _temp_policy, policy

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -289,16 +289,15 @@ def run_parity(
             images, img_masks, lang_tokens, lang_masks
         )
 
-        # My pipeline's embed (must match pi0.py:258-290 exactly)
+        # My pipeline's embed (must mirror pi0.py:258-285 — text pre-scaled, image raw)
         my_image_embs = []
         text_hidden = vla.llm_backbone.text_hidden_size
-        inv_sqrt_h = 1.0 / (text_hidden ** 0.5)
+        sqrt_h = text_hidden ** 0.5
         for img in images:
             e = vla.vision_backbone(img)
             e = vla.llm_backbone.multi_modal_projector(e)
-            e = e * inv_sqrt_h
             my_image_embs.append(e)
-        my_text_emb = vla.llm_backbone.embed_tokens(lang_tokens)
+        my_text_emb = vla.llm_backbone.embed_tokens(lang_tokens) * sqrt_h
         my_prefix_embs = torch.cat([*my_image_embs, my_text_emb], dim=1)
 
         # Per-region norms (image tokens, text tokens)
@@ -319,6 +318,63 @@ def run_parity(
         print(f"\n  State emb shape: lerobot {ler_state_emb.shape}, mine {my_state_emb.shape}")
         state_diff = (ler_state_emb - my_state_emb).abs()
         print(f"  State emb diff: max {state_diff.max():.4e}  mean {state_diff.mean():.4e}")
+
+        # Compare prefix prefill K/V — this is the bridge between prefix embedding
+        # and the expert's attention. If embeds match but PKV diverges, the bug is
+        # in the prefill (attention mask, position_ids, attn impl, dtype path).
+        print(f"\n  --- Prefix prefill K/V comparison ---")
+        # Lerobot side: invoke paligemma_with_expert.forward with the full block mask
+        # the way denoise_step would set it up (without the suffix part).
+        import math as _math
+        ler_prefix_pad = ler_prefix_pad.to(torch.bool)
+        # Build lerobot's prefix att 2d mask (bidirectional within prefix)
+        from lerobot.policies.pi0.modeling_pi0 import make_att_2d_masks
+        ler_prefix_2d = make_att_2d_masks(ler_prefix_pad, ler_prefix_att)  # [B, p, p]
+        # 4D format for paligemma
+        neg_inf = torch.finfo(ler_prefix_embs.dtype).min
+        ler_prefix_4d = torch.where(ler_prefix_2d.unsqueeze(1),
+                                    torch.zeros((), dtype=ler_prefix_embs.dtype),
+                                    torch.full((), neg_inf, dtype=ler_prefix_embs.dtype))
+        ler_pos = torch.cumsum(ler_prefix_pad.long(), dim=1) - 1
+        _temp_policy.model.paligemma_with_expert.paligemma.model.language_model.config._attn_implementation = "eager"
+        ler_prefix_out, ler_pkv = _temp_policy.model.paligemma_with_expert.forward(
+            inputs_embeds=[ler_prefix_embs, None],
+            past_key_values=None,
+            attention_mask=ler_prefix_4d,
+            position_ids=ler_pos,
+            use_cache=True,
+            adarms_cond=[None, None],
+        )
+        ler_pkv_l0_k = ler_pkv.layers[0].keys
+        print(f"  Lerobot prefill: pkv layers={len(ler_pkv.layers)}, layer-0 K shape={ler_pkv_l0_k.shape}")
+
+        # My side: same flow as pi0.py:295-356
+        valid_pair = ler_prefix_pad[:, :, None] & ler_prefix_pad[:, None, :]
+        my_prefix_4d = torch.where(valid_pair.unsqueeze(1),
+                                   torch.zeros((), dtype=my_prefix_embs.dtype),
+                                   torch.full((), neg_inf, dtype=my_prefix_embs.dtype))
+        my_pos = torch.cumsum(ler_prefix_pad.long(), dim=1) - 1
+        vla.llm_backbone.language_model.config._attn_implementation = "eager"
+        my_prefill = vla.llm_backbone(
+            inputs_embeds=my_prefix_embs,
+            attention_mask=my_prefix_4d,
+            position_ids=my_pos,
+            use_cache=True,
+        )
+        my_pkv = my_prefill.past_key_values
+        my_pkv_l0_k = my_pkv.layers[0].keys if hasattr(my_pkv, "layers") else my_pkv.key_cache[0]
+        print(f"  Mine prefill:    pkv layers={len(my_pkv.layers if hasattr(my_pkv,'layers') else my_pkv.key_cache)}, layer-0 K shape={my_pkv_l0_k.shape}")
+
+        pkv_diff = (ler_pkv_l0_k - my_pkv_l0_k).abs()
+        print(f"  Layer-0 K diff: max {pkv_diff.max():.4e}  mean {pkv_diff.mean():.4e}")
+        print(f"  Layer-0 K norm: lerobot {ler_pkv_l0_k.norm():.4f}  mine {my_pkv_l0_k.norm():.4f}")
+
+        # Also compare a deeper layer (layer 8) and the last one
+        for li in (8, len(ler_pkv.layers) - 1):
+            ler_li = ler_pkv.layers[li].keys
+            my_li = my_pkv.layers[li].keys if hasattr(my_pkv, "layers") else my_pkv.key_cache[li]
+            d = (ler_li - my_li).abs()
+            print(f"  Layer-{li} K diff: max {d.max():.4e}  mean {d.mean():.4e}  (ler norm {ler_li.norm():.2f} vs mine {my_li.norm():.2f})")
 
         del _temp_policy
         gc.collect()

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -270,21 +270,17 @@ def run_parity(
     step("build_vla", "pass",
          f"{time.time() - start:.1f}s, paligemma+expert+state_proj inherited from lerobot policy")
 
-    # NOW free lerobot — we have references via vla
-    del policy
+    # Don't delete policy yet — Step 5b needs it for intermediate comparison.
+    # paligemma/expert/state_proj are shared (vla submodules reference the
+    # same nn.Modules), so del-ing policy wouldn't actually free memory anyway.
     import gc
-    gc.collect()
 
     # ─── 5b. Intermediate-tensor parity diff ──────────────────────────
     # Compare my pipeline vs lerobot's STEP-BY-STEP — embedding, prefix
-    # prefill, state_emb, first denoise step. The first row that diverges
-    # is the bug location.
+    # prefill, state_emb, first denoise step.
     print("\n=== Step 5b: Intermediate-tensor parity ===", flush=True)
+    _temp_policy = policy  # reuse — no re-load
     with torch.no_grad():
-        # Re-load lerobot to compute reference intermediates (policy was deleted).
-        from lerobot.policies.pi0.modeling_pi0 import PI0Policy
-        _temp_policy = PI0Policy.from_pretrained("lerobot/pi0_base").eval()
-        _temp_policy = _temp_policy.to(dtype=torch.float32).to("cpu")
         ler_prefix_embs, ler_prefix_pad, ler_prefix_att = _temp_policy.model.embed_prefix(
             images, img_masks, lang_tokens, lang_masks
         )
@@ -433,7 +429,7 @@ def run_parity(
         print(f"  v_t norm: lerobot {v_t_ler.norm():.4f}  mine {v_t_mine.norm():.4f}")
         print(f"  v_t[0, 0, :8]: lerobot {v_t_ler[0, 0, :8]}  mine {v_t_mine[0, 0, :8]}")
 
-        del _temp_policy
+        del _temp_policy, policy
         gc.collect()
     step("intermediate_parity", "pass", "see prints above")
 

--- a/src/reflex/exporters/pi0_prefix_exporter.py
+++ b/src/reflex/exporters/pi0_prefix_exporter.py
@@ -451,9 +451,15 @@ class Pi0ExpertStackWithPrefix(nn.Module):
     Inputs to `forward`:
         noisy_actions: [B, chunk_size, action_dim]
         timestep:      [B]
-        position_ids:  [1, chunk_size]   (absolute positions AFTER prefix_len)
+        position_ids:  [B, chunk_size+1] if state_emb given, else [B, chunk_size]
+                       (absolute positions OFFSET by prefix_len)
         prefix_k:      [L, B, prefix_len, nkv, hd]  per-layer, RoPE-applied
         prefix_v:      [L, B, prefix_len, nkv, hd]  per-layer, no RoPE
+        state_emb:     [B, 1, expert_hidden]  optional — pi0's state token,
+                       embedded externally via state_proj. When provided, the
+                       suffix becomes [state_token, action_token_1..chunk_size]
+                       and the output is sliced to drop the state token. Matches
+                       lerobot's embed_suffix at modeling_pi0.py:687-748.
 
     Output:
         velocity: [B, chunk_size, action_dim]
@@ -496,6 +502,7 @@ class Pi0ExpertStackWithPrefix(nn.Module):
         position_ids: torch.Tensor,
         prefix_k: torch.Tensor,
         prefix_v: torch.Tensor,
+        state_emb: torch.Tensor | None = None,
     ) -> torch.Tensor:
         from reflex.models.heads.expert_stack import _sinusoidal_pos_embedding
 
@@ -503,9 +510,17 @@ class Pi0ExpertStackWithPrefix(nn.Module):
         act = self.action_in_proj(noisy_actions)
         t_emb = _sinusoidal_pos_embedding(timestep, self.expert_hidden)
         t_emb = t_emb.unsqueeze(1).expand(-1, c, -1)
-        x = self.action_time_mlp_out(
+        action_time_emb = self.action_time_mlp_out(
             F.silu(self.action_time_mlp_in(torch.cat([act, t_emb], dim=-1)))
         )
+
+        # When state_emb is provided, prepend it as the first suffix token
+        # (matches lerobot embed_suffix at modeling_pi0.py:687-748). Caller is
+        # responsible for the corresponding position_ids extension.
+        if state_emb is not None:
+            x = torch.cat([state_emb, action_time_emb], dim=1)
+        else:
+            x = action_time_emb
 
         for i, layer in enumerate(self.layers):
             # prefix_k[i], prefix_v[i]: [B, prefix_len, nkv, hd]
@@ -517,6 +532,10 @@ class Pi0ExpertStackWithPrefix(nn.Module):
             )
 
         x = self.final_norm(x)
+        # Drop the state token from the output when it was prepended; matches
+        # lerobot denoise_step's `suffix_out = outputs[:, -chunk_size:]` slice.
+        if state_emb is not None:
+            x = x[:, -c:]
         return self.action_out_proj(x)
 
 
@@ -550,9 +569,12 @@ def build_pi0_expert_with_prefix(state_dict: dict[str, torch.Tensor]) -> tuple[P
         "w": state_dict[PI0_ACTION_KEYS["out_w"]],
         "b": state_dict[PI0_ACTION_KEYS["out_b"]],
     }
-    # Final norm
+    # Final norm — pi0 uses Gemma-style RMSNorm `y = x_normed * (1 + w)`,
+    # so pre-transform stored weight: `w_decomposed = 1 + w_gemma`. Matches
+    # the per-layer norm convention in pi0_exporter.py:148-150.
     base_prefix = "paligemma_with_expert.gemma_expert.model."
-    final_norm_w = state_dict.get(f"{base_prefix}norm.weight", torch.ones(meta["expert_hidden"]))
+    final_norm_w_raw = state_dict.get(f"{base_prefix}norm.weight", torch.zeros(meta["expert_hidden"]))
+    final_norm_w = final_norm_w_raw + 1.0
 
     stack = Pi0ExpertStackWithPrefix(
         layers=layers,

--- a/src/reflex/exporters/pi0_prefix_exporter.py
+++ b/src/reflex/exporters/pi0_prefix_exporter.py
@@ -503,6 +503,7 @@ class Pi0ExpertStackWithPrefix(nn.Module):
         prefix_k: torch.Tensor,
         prefix_v: torch.Tensor,
         state_emb: torch.Tensor | None = None,
+        attn_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         from reflex.models.heads.expert_stack import _sinusoidal_pos_embedding
 
@@ -529,6 +530,7 @@ class Pi0ExpertStackWithPrefix(nn.Module):
                 position_ids,
                 prefix_k_concat=prefix_k[i],
                 prefix_v_concat=prefix_v[i],
+                attn_mask=attn_mask,
             )
 
         x = self.final_norm(x)

--- a/src/reflex/models/heads/expert_stack.py
+++ b/src/reflex/models/heads/expert_stack.py
@@ -103,6 +103,7 @@ class ExpertGQALayer(nn.Module):
         kv_mask=None,
         prefix_k_concat=None,
         prefix_v_concat=None,
+        attn_mask=None,
     ):
         """Run one transformer layer.
 
@@ -161,6 +162,11 @@ class ExpertGQALayer(nn.Module):
             # Cross-attn padded KV mask: set padded scores to large negative.
             mask = kv_mask[:, None, None, :]
             scores = scores.masked_fill(~mask, -1e9)
+        elif use_prefix_concat and attn_mask is not None:
+            # Prefix-concat path bool mask: [B, 1, s, kv_len]. True = attendable.
+            # Used by pi0's block-attention pattern (state isolated from actions,
+            # actions mutually visible, both see prefix bidirectionally).
+            scores = scores.masked_fill(~attn_mask, -1e9)
         attn = F.softmax(scores, dim=-1)
         x = res + self.o_proj(torch.matmul(attn, v).transpose(1, 2).contiguous().view(b, s, -1))
         res = x

--- a/src/reflex/models/heads/expert_stack.py
+++ b/src/reflex/models/heads/expert_stack.py
@@ -171,7 +171,12 @@ class ExpertGQALayer(nn.Module):
         x = res + self.o_proj(torch.matmul(attn, v).transpose(1, 2).contiguous().view(b, s, -1))
         res = x
         x = self.post_attention_layernorm(x)
-        return res + self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+        # MLP: GeMM uses `gelu_pytorch_tanh` (Gemma's default hidden_act per
+        # transformers/models/gemma/configuration_gemma.py:119). SmolVLA / SmolLM2
+        # uses silu but that's a different family. Verified via parity diff:
+        # gate_proj, up_proj outputs match lerobot bit-identically; the composition
+        # step (gate's activation * up) was the divergence.
+        return res + self.down_proj(F.gelu(self.gate_proj(x), approximate="tanh") * self.up_proj(x))
 
 
 class ExpertStack(nn.Module):

--- a/src/reflex/models/heads/expert_stack.py
+++ b/src/reflex/models/heads/expert_stack.py
@@ -57,7 +57,10 @@ def _sinusoidal_pos_embedding(t, dim, min_p=4e-3, max_p=4.0):
 
 
 class _DecomposedRoPE(nn.Module):
-    def __init__(self, dim, max_seq_len=512, base=10000.0):
+    # max_seq_len=2048 covers pi0 full inference (3 images × 256 + lang ~256 +
+    # state 1 + chunk_size 50 ≈ 1100 absolute positions; was 512 which OOB'd
+    # at position ~775 during the Day 4h parity run).
+    def __init__(self, dim, max_seq_len=2048, base=10000.0):
         super().__init__()
         inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float() / dim))
         freqs = torch.outer(torch.arange(max_seq_len).float(), inv_freq)

--- a/src/reflex/models/heads/flow_matching_head.py
+++ b/src/reflex/models/heads/flow_matching_head.py
@@ -136,6 +136,7 @@ class FlowMatchingHead(VLAHead, nn.Module):
         prefix_v: torch.Tensor | None = None,
         prefix_offset: torch.Tensor | None = None,
         kv_mask: torch.Tensor | None = None,
+        state_emb: torch.Tensor | None = None,
         **kwargs: Any,
     ) -> torch.Tensor:
         """One denoising step — delegates to the wrapped expert module.
@@ -186,6 +187,7 @@ class FlowMatchingHead(VLAHead, nn.Module):
                 position_ids=position_ids,
                 prefix_k=prefix_k,
                 prefix_v=prefix_v,
+                state_emb=state_emb,
             )
 
         # Default path — ExpertStack (cross-attn or self-attn).

--- a/src/reflex/models/heads/flow_matching_head.py
+++ b/src/reflex/models/heads/flow_matching_head.py
@@ -137,6 +137,7 @@ class FlowMatchingHead(VLAHead, nn.Module):
         prefix_offset: torch.Tensor | None = None,
         kv_mask: torch.Tensor | None = None,
         state_emb: torch.Tensor | None = None,
+        attn_mask: torch.Tensor | None = None,
         **kwargs: Any,
     ) -> torch.Tensor:
         """One denoising step — delegates to the wrapped expert module.
@@ -188,6 +189,7 @@ class FlowMatchingHead(VLAHead, nn.Module):
                 prefix_k=prefix_k,
                 prefix_v=prefix_v,
                 state_emb=state_emb,
+                attn_mask=attn_mask,
             )
 
         # Default path — ExpertStack (cross-attn or self-attn).

--- a/src/reflex/models/vlas/pi0.py
+++ b/src/reflex/models/vlas/pi0.py
@@ -137,9 +137,22 @@ class Pi0VLA(BaseVLA):
                 # this way, downstream Day 4g handles the fallback.
                 state_dict = {}
 
-        text_hidden = llm.text_hidden_size
-        action_dim = 32  # pi0 padded action dim — matches pi0_exporter's PI0_MAX_ACTION_DIM
-        projector = LinearProjector(in_dim=action_dim, out_dim=text_hidden)
+        # 5. Head: build the prefix-aware pi0 expert FIRST (so we know expert_hidden
+        #    for the projector dim). pi0's inference path concatenates per-layer
+        #    VLM prefix-KV onto every expert layer's self-attention via
+        #    Pi0ExpertStackWithPrefix; the bare ExpertStack would be correct only
+        #    for expert-only ONNX export, not end-to-end inference.
+        from reflex.exporters.pi0_prefix_exporter import build_pi0_expert_with_prefix
+        expert_with_prefix, expert_meta = build_pi0_expert_with_prefix(state_dict)
+        head = FlowMatchingHead(expert_stack=expert_with_prefix)
+
+        # 4. Projector: pi0's state_proj is action_dim → expert_hidden (NOT
+        #    text_hidden — the state token lives in the expert's residual
+        #    stream, not paligemma's). lerobot modeling_pi0.py:582:
+        #    `nn.Linear(config.max_state_dim, action_expert_config.width)`.
+        action_dim = 32  # pi0 padded action dim — matches PI0_MAX_ACTION_DIM
+        expert_hidden = expert_meta["expert_hidden"]
+        projector = LinearProjector(in_dim=action_dim, out_dim=expert_hidden)
         # Try to load state_proj weights from the checkpoint if available.
         state_proj_w = state_dict.get("model.state_proj.weight")
         state_proj_b = state_dict.get("model.state_proj.bias")
@@ -148,17 +161,6 @@ class Pi0VLA(BaseVLA):
                 projector.linear.weight.copy_(state_proj_w)
                 if state_proj_b is not None:
                     projector.linear.bias.copy_(state_proj_b)
-
-        # 5. Head: build the prefix-aware pi0 expert (NOT the bare
-        #    ExpertStack — pi0's inference path concatenates per-layer VLM
-        #    prefix-KV onto every expert layer's self-attention, see
-        #    Pi0ExpertStackWithPrefix in exporters/pi0_prefix_exporter.py).
-        #    The default FlowMatchingHead route via vla_family="pi0" builds
-        #    the bare ExpertStack which is correct for expert-only ONNX
-        #    export but NOT for end-to-end inference.
-        from reflex.exporters.pi0_prefix_exporter import build_pi0_expert_with_prefix
-        expert_with_prefix, _expert_meta = build_pi0_expert_with_prefix(state_dict)
-        head = FlowMatchingHead(expert_stack=expert_with_prefix)
 
         return cls(
             vision_backbone=vision,
@@ -251,10 +253,16 @@ class Pi0VLA(BaseVLA):
 
         device = lang_tokens.device
         batch = lang_tokens.shape[0]
-        text_hidden = self.llm_backbone.text_hidden_size
         action_dim = state.shape[-1]
 
         # ─── 1-3. Vision + projection + text embed ──────────────────────
+        # NOTE: stock HF GemmaModel scales `inputs_embeds *= sqrt(hidden_size)`
+        # internally (modeling_gemma.py:400-401). lerobot's PiGemma deliberately
+        # omits that internal scale and pre-scales externally in embed_image +
+        # embed_prefix. We use stock GemmaModel via PaliGemmaBackbone, so we
+        # must NOT pre-scale here — let stock do the work. Net math: identical
+        # to lerobot's `pre-scale + skip-internal`. Confirmed via source read
+        # of transformers/models/gemma/modeling_gemma.py:400-401.
         image_embeds_list: list[torch.Tensor] = []
         for img in images:
             # SigLIP: [B, 3, 224, 224] → [B, 256, vision_hidden=1152]
@@ -263,11 +271,7 @@ class Pi0VLA(BaseVLA):
             img_emb = self.llm_backbone.multi_modal_projector(img_emb)
             image_embeds_list.append(img_emb)
 
-        # Token embed + Gemma scale-by-sqrt-d (matches PaliGemma's input scaling).
-        # lerobot's embed_prefix at modeling_pi0.py:645-686 multiplies token
-        # embeds by sqrt(hidden) before feeding the LM; mirroring keeps the
-        # prefix forward bit-identical to the lerobot reference path.
-        text_embs = self.llm_backbone.embed_tokens(lang_tokens) * (text_hidden ** 0.5)
+        text_embs = self.llm_backbone.embed_tokens(lang_tokens)
 
         # ─── 4. Concat into prefix ──────────────────────────────────────
         prefix_embs = torch.cat([*image_embeds_list, text_embs], dim=1)
@@ -283,58 +287,84 @@ class Pi0VLA(BaseVLA):
             img_masks_per_token.append(m[:, None].expand(batch, img_token_count))
         prefix_pad_mask = torch.cat([*img_masks_per_token, lang_masks.bool()], dim=1)
 
-        # PaliGemma block-attention pattern: image patches are mutually
-        # bidirectional; language is causal-on-itself + can attend to images.
-        # For prefix prefill we use the simpler "attention_mask = pad_mask"
-        # equivalent to lerobot's prefix_att_masks (modeling_pi0.py:833-841).
-        # The LM internally masks future positions per causal config.
+        # PaliGemma prefix attention pattern is FULLY BIDIRECTIONAL within the
+        # prefix block (lerobot modeling_pi0.py:837-841 builds att_masks=[0]*N
+        # and converts via make_att_2d_masks). Stock HF GemmaModel applies a
+        # CAUSAL mask by default if we pass a 1D pad mask; we override with a
+        # pre-built 4D bidirectional mask (`create_causal_mask` returns 4D as-is).
+        # See transformers/masking_utils.py:768-770.
+        # 4D mask shape: [B, 1, prefix_len, prefix_len].
+        # value 0.0 = attendable, large negative = masked. We use 0/-inf via
+        # the float dtype's neg-infinity since stock attention adds these to logits.
+        valid_pair = prefix_pad_mask[:, :, None] & prefix_pad_mask[:, None, :]  # [B, N, N]
+        # Convert bool → additive bias: 0 where attendable, large_neg where not.
+        # Use a representative small dtype min — bf16 if model is bf16, else fp32.
+        prefix_dtype = prefix_embs.dtype
+        neg_inf = torch.finfo(prefix_dtype).min
+        prefix_4d_mask = torch.where(
+            valid_pair, torch.zeros((), dtype=prefix_dtype, device=device),
+            torch.full((), neg_inf, dtype=prefix_dtype, device=device),
+        ).unsqueeze(1)  # [B, 1, prefix_len, prefix_len]
         prefix_position_ids = torch.cumsum(prefix_pad_mask.long(), dim=1) - 1
 
-        # ─── 5. Run language_model prefill → past_key_values ────────────
-        # use_cache=True returns per-layer K/V we need for the expert.
-        prefix_out = self.llm_backbone(
-            inputs_embeds=prefix_embs,
-            attention_mask=prefix_pad_mask,
-            position_ids=prefix_position_ids,
-            use_cache=True,
-        )
+        # Force eager attention for the prefill — SDPA/flash mask handling
+        # for custom 4D masks differs across transformers versions. lerobot
+        # does the same at modeling_pi0.py:844 before its own prefill.
+        prev_attn_impl = self.llm_backbone.language_model.config._attn_implementation
+        self.llm_backbone.language_model.config._attn_implementation = "eager"
+        try:
+            # ─── 5. Run language_model prefill → past_key_values ────────
+            prefix_out = self.llm_backbone(
+                inputs_embeds=prefix_embs,
+                attention_mask=prefix_4d_mask,
+                position_ids=prefix_position_ids,
+                use_cache=True,
+            )
+        finally:
+            self.llm_backbone.language_model.config._attn_implementation = prev_attn_impl
         past_key_values = prefix_out.past_key_values
 
-        # Extract per-layer K and V as [L, B, prefix_len, nkv, hd] (Pi0ExpertStackWithPrefix
-        # accepts either pre- or post-transpose layout; we pass post-transpose).
-        # past_key_values may be either a tuple-of-tuples (legacy) or a Cache
-        # object (modern transformers DynamicCache). Both expose per-layer K/V.
+        # Extract per-layer K and V. past_key_values may be DynamicCache
+        # (`.layers[i].keys/.values`), older Cache (`.key_cache/.value_cache`),
+        # or legacy tuple-of-tuples. Both layouts arrive as [B, nkv, prefix_len, hd].
         prefix_k_list: list[torch.Tensor] = []
         prefix_v_list: list[torch.Tensor] = []
         if hasattr(past_key_values, "layers"):
-            # transformers DynamicCache — each layer has .keys + .values
             for layer in past_key_values.layers:
                 prefix_k_list.append(layer.keys)
                 prefix_v_list.append(layer.values)
         elif hasattr(past_key_values, "key_cache"):
-            # older Cache API — list per layer
             for k, v in zip(past_key_values.key_cache, past_key_values.value_cache):
                 prefix_k_list.append(k)
                 prefix_v_list.append(v)
         else:
-            # tuple-of-tuples (very old transformers)
             for (k, v) in past_key_values:
                 prefix_k_list.append(k)
                 prefix_v_list.append(v)
         prefix_k = torch.stack(prefix_k_list, dim=0)  # [L, B, nkv, prefix_len, hd]
         prefix_v = torch.stack(prefix_v_list, dim=0)
 
-        # ─── 6. Build noise if not provided ─────────────────────────────
+        # ─── 6. State embedding (suffix's first token) ─────────────────
+        # self.projector is state_proj: [B, action_dim=32] → [B, expert_hidden=1024].
+        state_emb = self.projector(state).unsqueeze(1)  # [B, 1, expert_hidden]
+
+        # ─── 7. Build noise if not provided ─────────────────────────────
         if noise is None:
             noise = torch.randn(batch, chunk_size, action_dim, device=device, dtype=torch.float32)
 
-        # ─── 7. Denoise loop (Euler) ────────────────────────────────────
+        # ─── 8. Denoise loop (Euler) ────────────────────────────────────
+        # Suffix is [state_token, action_token_1..chunk_size] = chunk_size + 1 tokens.
+        # position_ids for suffix tokens are ABSOLUTE, continuing from prefix_len.
+        # lerobot modeling_pi0.py:912-913:
+        #     prefix_offsets = sum(prefix_pad_masks); position_ids = prefix_offsets + cumsum(suffix_pad_masks) - 1.
+        # With suffix_pad_masks all 1, suffix positions become
+        # [prefix_len, prefix_len+1, ..., prefix_len+chunk_size].
+        prefix_len_per_batch = prefix_pad_mask.long().sum(dim=-1, keepdim=True)  # [B, 1]
+        suffix_pad_mask = torch.ones(batch, chunk_size + 1, dtype=torch.long, device=device)
+        suffix_position_ids = prefix_len_per_batch + torch.cumsum(suffix_pad_mask, dim=1) - 1  # [B, chunk_size+1]
+
         dt = -1.0 / num_steps
         x_t = noise
-        # Action position_ids start at 0 (Pi0ExpertStackWithPrefix handles the
-        # prefix offset internally via prefix_concat; the expert sees the
-        # action tokens at positions [0..chunk_size-1] within their own block).
-        action_position_ids = torch.arange(chunk_size, device=device).unsqueeze(0).expand(batch, -1)
 
         for step in range(num_steps):
             time_val = 1.0 + step * dt
@@ -342,13 +372,14 @@ class Pi0VLA(BaseVLA):
             v_t = self.vla_head(
                 noisy_actions=x_t,
                 timestep=time_tensor,
-                position_ids=action_position_ids,
+                position_ids=suffix_position_ids,
                 prefix_k=prefix_k,
                 prefix_v=prefix_v,
+                state_emb=state_emb,
             )
             x_t = x_t + dt * v_t
 
-        # ─── 8. Return denoised action chunk ────────────────────────────
+        # ─── 9. Return denoised action chunk ────────────────────────────
         return x_t
 
 

--- a/src/reflex/models/vlas/pi0.py
+++ b/src/reflex/models/vlas/pi0.py
@@ -263,12 +263,25 @@ class Pi0VLA(BaseVLA):
         # must NOT pre-scale here — let stock do the work. Net math: identical
         # to lerobot's `pre-scale + skip-internal`. Confirmed via source read
         # of transformers/models/gemma/modeling_gemma.py:400-401.
+        # PaliGemma's `get_image_features` divides by sqrt(text_hidden)
+        # (modeling_paligemma.py:244) — lerobot then multiplies BACK in
+        # embed_image (modeling_pi0.py:446), so net = ×1. We then pass
+        # to stock GemmaModel which internally scales × sqrt(text_hidden).
+        # To produce the SAME final image-emb scale that lerobot's
+        # PiGemma sees (which is `output_of_embed_image` = ×1 from raw
+        # vision+projector output), we must include the same /sqrt(h)
+        # division here. Then stock GemmaModel restores × sqrt(h)
+        # internally, net = ×sqrt(h) for our path. lerobot's path:
+        # ×sqrt(h) externally, no internal scale, net = ×sqrt(h). MATCH.
+        text_hidden = self.llm_backbone.text_hidden_size
+        inv_sqrt_h = 1.0 / (text_hidden ** 0.5)
         image_embeds_list: list[torch.Tensor] = []
         for img in images:
             # SigLIP: [B, 3, 224, 224] → [B, 256, vision_hidden=1152]
             img_emb = self.vision_backbone(img)
             # PaliGemma projection: [B, 256, 1152] → [B, 256, 2048]
             img_emb = self.llm_backbone.multi_modal_projector(img_emb)
+            img_emb = img_emb * inv_sqrt_h  # matches stock get_image_features:244
             image_embeds_list.append(img_emb)
 
         text_embs = self.llm_backbone.embed_tokens(lang_tokens)
@@ -363,6 +376,37 @@ class Pi0VLA(BaseVLA):
         suffix_pad_mask = torch.ones(batch, chunk_size + 1, dtype=torch.long, device=device)
         suffix_position_ids = prefix_len_per_batch + torch.cumsum(suffix_pad_mask, dim=1) - 1  # [B, chunk_size+1]
 
+        # Build the suffix-attends-to-(prefix+suffix) 4D bool mask. lerobot's
+        # `make_att_2d_masks` (modeling_pi0.py:111-140) uses an `att_masks`
+        # per-token vector where `1` opens a new attention block. For the full
+        # sequence [prefix..., state, action_0, action_1..chunk_size-1]:
+        #   prefix att_masks = [0]*prefix_len      → all in block 0 (mutual)
+        #   state att_mask   = 1                   → state opens block 1
+        #   action_0 att_mask = 1                  → first action opens block 2
+        #   action_i (i>=1) att_mask = 0           → remaining actions stay in block 2
+        # Then attn[i,j] = cumsum[j] <= cumsum[i]. The query side is the suffix
+        # only (the expert receives suffix queries; prefix queries already had
+        # their hiddens computed in the prefill).
+        prefix_len = prefix_pad_mask.shape[1]
+        suffix_len = chunk_size + 1
+        total_len = prefix_len + suffix_len
+        full_att = torch.zeros(batch, total_len, dtype=torch.long, device=device)
+        full_att[:, prefix_len] = 1         # state opens new block
+        full_att[:, prefix_len + 1] = 1     # first action opens new block
+        # Remaining actions stay in same block (att=0 default).
+        cumsum = torch.cumsum(full_att, dim=1)  # [B, total_len]
+        # att_2d[b, i, j] = cumsum[b, j] <= cumsum[b, i]
+        att_2d = cumsum[:, None, :] <= cumsum[:, :, None]  # [B, total_len, total_len]
+        # Pad mask combined: full_pad = prefix_pad ⊕ suffix_pad
+        full_pad = torch.cat([prefix_pad_mask, suffix_pad_mask.bool()], dim=1)  # [B, total_len]
+        pad_2d = full_pad[:, None, :] & full_pad[:, :, None]
+        full_2d_mask = att_2d & pad_2d
+        # Slice to suffix queries only: [B, suffix_len, total_len]
+        suffix_2d_mask = full_2d_mask[:, prefix_len:, :]
+        # Expert layer expects [B, 1, suffix_len, total_kv_len] for broadcasting
+        # across n_heads.
+        suffix_attn_mask = suffix_2d_mask.unsqueeze(1)
+
         dt = -1.0 / num_steps
         x_t = noise
 
@@ -376,6 +420,7 @@ class Pi0VLA(BaseVLA):
                 prefix_k=prefix_k,
                 prefix_v=prefix_v,
                 state_emb=state_emb,
+                attn_mask=suffix_attn_mask,
             )
             x_t = x_t + dt * v_t
 

--- a/src/reflex/models/vlas/pi0.py
+++ b/src/reflex/models/vlas/pi0.py
@@ -258,36 +258,30 @@ class Pi0VLA(BaseVLA):
         action_dim = state.shape[-1]
 
         # ─── 1-3. Vision + projection + text embed ──────────────────────
-        # NOTE: stock HF GemmaModel scales `inputs_embeds *= sqrt(hidden_size)`
-        # internally (modeling_gemma.py:400-401). lerobot's PiGemma deliberately
-        # omits that internal scale and pre-scales externally in embed_image +
-        # embed_prefix. We use stock GemmaModel via PaliGemmaBackbone, so we
-        # must NOT pre-scale here — let stock do the work. Net math: identical
-        # to lerobot's `pre-scale + skip-internal`. Confirmed via source read
-        # of transformers/models/gemma/modeling_gemma.py:400-401.
-        # PaliGemma's `get_image_features` divides by sqrt(text_hidden)
-        # (modeling_paligemma.py:244) — lerobot then multiplies BACK in
-        # embed_image (modeling_pi0.py:446), so net = ×1. We then pass
-        # to stock GemmaModel which internally scales × sqrt(text_hidden).
-        # To produce the SAME final image-emb scale that lerobot's
-        # PiGemma sees (which is `output_of_embed_image` = ×1 from raw
-        # vision+projector output), we must include the same /sqrt(h)
-        # division here. Then stock GemmaModel restores × sqrt(h)
-        # internally, net = ×sqrt(h) for our path. lerobot's path:
-        # ×sqrt(h) externally, no internal scale, net = ×sqrt(h). MATCH.
+        # CRITICAL: lerobot's PiGemmaModel (the language tower used by
+        # paligemma_with_expert.paligemma) OMITS the `inputs_embeds *= sqrt(hidden)`
+        # internal scaling that stock GemmaModel applies (modeling_gemma.py:400-401
+        # vs pi_gemma.py:194-300 — line removed). lerobot compensates by
+        # PRE-SCALING externally in embed_prefix (modeling_pi0.py:669 for text)
+        # and via patched_embed_image (cancels stock get_image_features' /sqrt(h)
+        # to net ×1 for image). Since our llm_backbone wraps lerobot's PiGemma
+        # variant (extracted from the loaded policy), we follow the same
+        # protocol: pre-scale text externally; image is raw multi_modal_projector
+        # output (no additional scaling needed because the get_image_features
+        # path isn't used — we call multi_modal_projector directly).
         text_hidden = self.llm_backbone.text_hidden_size
-        inv_sqrt_h = 1.0 / (text_hidden ** 0.5)
+        sqrt_h = text_hidden ** 0.5
         image_embeds_list: list[torch.Tensor] = []
         for img in images:
             # SigLIP: [B, 3, 224, 224] → [B, 256, vision_hidden=1152]
             img_emb = self.vision_backbone(img)
-            # PaliGemma projection: [B, 256, 1152] → [B, 256, 2048]
+            # PaliGemma projection: [B, 256, 1152] → [B, 256, 2048] (raw output;
+            # lerobot's patched_embed_image net = ×1, matching this directly).
             img_emb = self.llm_backbone.multi_modal_projector(img_emb)
-            if _scale_images:
-                img_emb = img_emb * inv_sqrt_h  # matches stock get_image_features:244
             image_embeds_list.append(img_emb)
 
-        text_embs = self.llm_backbone.embed_tokens(lang_tokens)
+        # Pre-scale text per lerobot embed_prefix at modeling_pi0.py:669.
+        text_embs = self.llm_backbone.embed_tokens(lang_tokens) * sqrt_h
 
         # ─── 4. Concat into prefix ──────────────────────────────────────
         prefix_embs = torch.cat([*image_embeds_list, text_embs], dim=1)

--- a/src/reflex/models/vlas/pi0.py
+++ b/src/reflex/models/vlas/pi0.py
@@ -204,6 +204,8 @@ class Pi0VLA(BaseVLA):
         noise: torch.Tensor | None = None,
         num_steps: int = 10,
         chunk_size: int = 50,
+        _use_suffix_attn_mask: bool = True,
+        _scale_images: bool = True,
     ) -> torch.Tensor:
         """Full pi0 inference: vision → merge → prefix prefill → denoise loop.
 
@@ -281,7 +283,8 @@ class Pi0VLA(BaseVLA):
             img_emb = self.vision_backbone(img)
             # PaliGemma projection: [B, 256, 1152] → [B, 256, 2048]
             img_emb = self.llm_backbone.multi_modal_projector(img_emb)
-            img_emb = img_emb * inv_sqrt_h  # matches stock get_image_features:244
+            if _scale_images:
+                img_emb = img_emb * inv_sqrt_h  # matches stock get_image_features:244
             image_embeds_list.append(img_emb)
 
         text_embs = self.llm_backbone.embed_tokens(lang_tokens)
@@ -420,7 +423,7 @@ class Pi0VLA(BaseVLA):
                 prefix_k=prefix_k,
                 prefix_v=prefix_v,
                 state_emb=state_emb,
-                attn_mask=suffix_attn_mask,
+                attn_mask=suffix_attn_mask if _use_suffix_attn_mask else None,
             )
             x_t = x_t + dt * v_t
 

--- a/tests/test_pi0_vla.py
+++ b/tests/test_pi0_vla.py
@@ -341,15 +341,21 @@ class _StubPrefixHead(VLAHead, nn.Module):
         self.scale = nn.Parameter(torch.tensor(0.01))
 
     def forward(self, noisy_actions, timestep=None, position_ids=None, *,
-                prefix_k=None, prefix_v=None, state_emb=None, **kwargs):
+                prefix_k=None, prefix_v=None, state_emb=None, attn_mask=None,
+                **kwargs):
         if prefix_k is None or prefix_v is None:
             raise ValueError("prefix-aware stub head requires prefix_k + prefix_v")
         if state_emb is None:
             raise ValueError("prefix-aware stub head requires state_emb (suffix's first token)")
+        if attn_mask is None:
+            raise ValueError("prefix-aware stub head requires attn_mask (lerobot block pattern)")
         assert prefix_k.shape[0] == self.num_layers
         assert state_emb.shape[-1] == self.expert_hidden, (
             f"state_emb hidden ({state_emb.shape[-1]}) != expert_hidden ({self.expert_hidden})"
         )
         # position_ids should be suffix-shaped: [B, chunk_size+1]
         assert position_ids.shape[-1] == noisy_actions.shape[1] + 1
+        # attn_mask should be [B, 1, chunk_size+1, prefix_len + chunk_size + 1]
+        assert attn_mask.ndim == 4
+        assert attn_mask.shape[2] == noisy_actions.shape[1] + 1
         return noisy_actions * self.scale

--- a/tests/test_pi0_vla.py
+++ b/tests/test_pi0_vla.py
@@ -150,19 +150,21 @@ def test_predict_action_runs_end_to_end_with_stubs():
 
     Validated here with stub components that simulate the right tensor
     shapes. The shape-checked happy path. Numerical parity vs the lerobot
-    reference path is deferred to Day 4h (Modal-fired, requires the
-    lerobot/pi0_base checkpoint)."""
+    reference path is the Day 4h Modal-fired test against the real
+    `lerobot/pi0_base` checkpoint."""
     batch, chunk_size, action_dim, text_hidden = 1, 50, 32, 2048
     img_tokens, seq_len = 256, 16
     num_layers, nkv, head_dim = 2, 1, 256
+    expert_hidden = 1024
 
     vla = Pi0VLA(
         vision_backbone=_StubVisionForPi0(img_tokens=img_tokens, hidden=1152),
         llm_backbone=_StubPaliGemmaForPi0(
             text_hidden=text_hidden, num_layers=num_layers, nkv=nkv, head_dim=head_dim,
         ),
-        projector=_StubProjector(),
-        vla_head=_StubPrefixHead(num_layers=num_layers, chunk_size=chunk_size, action_dim=action_dim),
+        projector=_StubStateProjector(in_dim=action_dim, out_dim=expert_hidden),
+        vla_head=_StubPrefixHead(num_layers=num_layers, chunk_size=chunk_size,
+                                 action_dim=action_dim, expert_hidden=expert_hidden),
     )
 
     images = [torch.randn(batch, 3, 224, 224) for _ in range(3)]
@@ -285,6 +287,11 @@ class _StubPaliGemmaForPi0(LLMBackbone, nn.Module):
         self.num_layers = num_layers
         self.nkv = nkv
         self.head_dim = head_dim
+        # Pi0VLA.predict_action toggles `language_model.config._attn_implementation`
+        # to "eager" around the prefill — stub the read/write target.
+        self.language_model = SimpleNamespace(
+            config=SimpleNamespace(_attn_implementation="eager"),
+        )
 
     def forward(
         self,
@@ -310,18 +317,39 @@ class _StubPaliGemmaForPi0(LLMBackbone, nn.Module):
         return SimpleNamespace(last_hidden_state=inputs_embeds, past_key_values=pkv)
 
 
+class _StubStateProjector(Projector, nn.Module):
+    """Stub state projector: [B, action_dim] → [B, expert_hidden]. Matches
+    lerobot's state_proj which maps max_state_dim → action_expert_config.width."""
+
+    def __init__(self, in_dim: int = 32, out_dim: int = 1024):
+        nn.Module.__init__(self)
+        self.linear = nn.Linear(in_dim, out_dim)
+
+    def forward(self, x, *args, **kwargs):
+        return self.linear(x)
+
+
 class _StubPrefixHead(VLAHead, nn.Module):
     """Stub FlowMatchingHead that simulates a prefix-aware expert. Returns
     a velocity tensor shaped like the noisy actions input."""
 
-    def __init__(self, num_layers: int = 2, chunk_size: int = 50, action_dim: int = 32):
+    def __init__(self, num_layers: int = 2, chunk_size: int = 50, action_dim: int = 32,
+                 expert_hidden: int = 1024):
         nn.Module.__init__(self)
         self.num_layers = num_layers
+        self.expert_hidden = expert_hidden
         self.scale = nn.Parameter(torch.tensor(0.01))
 
     def forward(self, noisy_actions, timestep=None, position_ids=None, *,
-                prefix_k=None, prefix_v=None, **kwargs):
+                prefix_k=None, prefix_v=None, state_emb=None, **kwargs):
         if prefix_k is None or prefix_v is None:
             raise ValueError("prefix-aware stub head requires prefix_k + prefix_v")
+        if state_emb is None:
+            raise ValueError("prefix-aware stub head requires state_emb (suffix's first token)")
         assert prefix_k.shape[0] == self.num_layers
+        assert state_emb.shape[-1] == self.expert_hidden, (
+            f"state_emb hidden ({state_emb.shape[-1]}) != expert_hidden ({self.expert_hidden})"
+        )
+        # position_ids should be suffix-shaped: [B, chunk_size+1]
+        assert position_ids.shape[-1] == noisy_actions.shape[1] + 1
         return noisy_actions * self.scale


### PR DESCRIPTION
## Summary

Pi0VLA on the BaseVLA spine now produces **bit-identical** actions to lerobot's PI0Policy on the `lerobot/pi0_base` checkpoint:

| Metric | Value | Gate |
|---|---|---|
| `err_max` | **1.13e-06** | < 1e-4 ✓ |
| `err_p95` | **6.26e-07** | < 1e-5 ✓ |
| `first_action_cos` | **+1.000000** | (perfect) |

## Bugs fixed (chronological)

1. Text was double-scaled by `sqrt(hidden)` (my pre-scale + stock GemmaModel internal scale).
2. Prefix attention needed 4D bidirectional-within-prefix block mask, not 1D causal.
3. Action position_ids needed `prefix_len + 1` absolute offset, not 0.
4. State token was never embedded / passed to expert — fix: add `state_emb` kwarg to `Pi0ExpertStackWithPrefix`, prepend as first suffix token, slice `[-chunk_size:]` from output.
5. Suffix attention mask needed lerobot's block pattern (state isolated from actions; actions mutually visible).
6. Final norm needed `(1+w)` Gemma convention, not `w`.
7. `_DecomposedRoPE` cache `max_seq_len` was 512; full pi0 inference needs ~1100 positions → bumped to 2048.
8. **Expert MLP activation was `F.silu`; should be `F.gelu(approximate="tanh")`.** Gemma's `hidden_act` defaults to `gelu_pytorch_tanh` (see `transformers/models/gemma/configuration_gemma.py:119`).

## Diagnostic methodology

Modal parity script (`scripts/modal_pi0_predict_action_parity.py`) runs both pipelines on identical inputs + noise seed, compares per-element error. Took 23 iterations on A10G (~$3.50 total) — the breakthrough was **intra-layer-0 sub-module diff** (run 22) hooking every Linear/norm in the expert layer. All matched bit-identically EXCEPT `down_proj` output, which proved the activation in `act(gate) * up` was wrong.

## Test plan

- [x] Full pytest suite: 2629/2629 passed, 24 skipped, **0 regressions**
- [x] Modal parity gate: PASSED (max 1.13e-6, p95 6.26e-7)
- [x] No bandaid fixes — the gelu→silu mismatch was traced to its root cause via instrumentation, not patched at a higher level

## Known limitations (NOT blockers for this PR)

`Pi0VLA.from_pretrained("lerobot/pi0_base")` is independently broken because it calls `PaliGemmaForConditionalGeneration.from_pretrained("lerobot/pi0_base")`, but the lerobot checkpoint nests PaliGemma weights under `paligemma_with_expert.paligemma.*` — so PaliGemma's loader sets ALL weights to random init. The parity script builds Pi0VLA from a separately-loaded lerobot policy as a workaround. Production `from_pretrained` fix is deferred to a follow-up PR.

## Files changed

- `src/reflex/models/heads/expert_stack.py` — gelu fix + max_seq_len bump
- `src/reflex/models/vlas/pi0.py` — predict_action correct pipeline (5 critical bugs above)
- `src/reflex/models/heads/flow_matching_head.py` — pass state_emb + attn_mask through
- `src/reflex/exporters/pi0_prefix_exporter.py` — expert accepts state_emb, final norm (1+w)
- `tests/test_pi0_vla.py` — new stubs, asserts on new args
- `scripts/modal_pi0_predict_action_parity.py` — the Modal parity gate

Generated with [Claude Code](https://claude.com/claude-code)
