### PR TITLE
lift #1 day 5 phase a: Pi05VLA composition class on BaseVLA spine

### DIFF
--- a/src/reflex/models/vlas/pi05.py
+++ b/src/reflex/models/vlas/pi05.py
@@ -1,0 +1,184 @@
+"""Pi05VLA — pi0.5 composition class on the BaseVLA spine.
+
+Lift #1 Day 5 per `features/03_export/basevla-spine_plan.md`. Mirrors Day 4's
+Pi0VLA but for pi0.5. The flow-matching head + most components are shared;
+pi0.5's divergence from pi0:
+
+- **AdaRMSNorm time conditioning** (vs pi0's plain RMSNorm). Time embedding
+  becomes per-layer norm conditioning, NOT a suffix token.
+- **State-in-language** — no state_proj projector slot used. State info is
+  encoded by lerobot's tokenizer into the language prompt itself.
+- **Suffix is action-only** — no state token prepended; suffix = action_emb
+  for `chunk_size` tokens (vs pi0's `state + action_emb` for chunk_size+1).
+
+Wires:
+
+    Pi05VLA = BaseVLA(
+        vision_backbone = SigLIPBackbone (extracted from paligemma.vision_tower)
+        llm_backbone    = PaliGemmaBackbone (PaliGemma minus vision_tower)
+        vla_head        = FlowMatchingHead (wraps Pi05ExpertStackWithPrefix)
+    )
+
+Registered under VLAS per decision S-3.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import torch
+
+from reflex.models.base_vla import BaseVLA
+from reflex.registry.components import VLAS
+
+if TYPE_CHECKING:
+    pass
+
+
+@VLAS.register
+class Pi05VLA(BaseVLA):
+    """pi0.5 spine composition — PaliGemma (vision split out) + AdaRMSNorm expert.
+
+    Slots:
+
+    - vision_backbone: SigLIPBackbone (REQUIRED) — extracted from PaliGemma
+    - llm_backbone:    PaliGemmaBackbone (REQUIRED) — PaliGemma minus vision_tower
+    - vla_head:        FlowMatchingHead (REQUIRED) — wraps Pi05ExpertStack
+                       (the AdaRMSNorm-conditioned variant)
+    - projector:       not used (None) — state encoded in language tokens
+    - vlm_backbone:    not used (None)
+    - text_encoder:    not used (None)
+
+    NAME_MAPPING: empty per decision S-1 — pi0.5 checkpoint keys map directly
+    to component slots via the spine's default routing.
+    """
+
+    REQUIRED_SLOTS: ClassVar[tuple[str, ...]] = (
+        "vision_backbone",
+        "llm_backbone",
+        "vla_head",
+    )
+    OPTIONAL_SLOTS: ClassVar[tuple[str, ...]] = ()
+    NAME_MAPPING: ClassVar[dict[str, str]] = {}
+
+    # ── Construction helpers ────────────────────────────────────────────
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        hf_id: str = "lerobot/pi05_libero_finetuned_v044",
+        *,
+        dtype: torch.dtype | None = None,
+        state_dict: dict[str, torch.Tensor] | None = None,
+    ) -> "Pi05VLA":
+        """Build Pi05VLA from a HuggingFace pi0.5 checkpoint.
+
+        IMPORTANT: like Pi0VLA.from_pretrained, this naive path is broken for
+        lerobot pi0.5 checkpoints because they nest PaliGemma weights under
+        `paligemma_with_expert.paligemma.*` — stock PaliGemma's loader sets
+        all weights to random init. Use the parity-script pattern (build from
+        a loaded lerobot policy) until a proper key-remap loader is shipped.
+
+        Args:
+            hf_id: HuggingFace repo (default lerobot/pi05_libero_finetuned_v044)
+            dtype: cast loaded model to this dtype (e.g. torch.bfloat16)
+            state_dict: pre-loaded raw state_dict for the expert build.
+
+        Returns:
+            Pi05VLA instance ready for forward() + (Phase B) predict_action().
+        """
+        from transformers import PaliGemmaForConditionalGeneration
+
+        from reflex.models.heads.flow_matching_head import FlowMatchingHead
+        from reflex.models.llm.paligemma_backbone import PaliGemmaBackbone
+        from reflex.models.vision.siglip_backbone import SigLIPBackbone
+
+        # 1. Load PaliGemma — full model, cast if requested.
+        paligemma = PaliGemmaForConditionalGeneration.from_pretrained(hf_id)
+        if dtype is not None:
+            paligemma = paligemma.to(dtype=dtype)
+
+        # 2. Vision: extract vision_tower
+        vision = SigLIPBackbone(model=paligemma.model.vision_tower)
+
+        # 3. Language: wrap the rest of PaliGemma
+        llm = PaliGemmaBackbone(model=paligemma)
+
+        # 4. State_dict for expert build
+        if state_dict is None:
+            from huggingface_hub import hf_hub_download
+            from safetensors.torch import load_file
+            try:
+                safetensors_path = hf_hub_download(
+                    repo_id=hf_id, filename="model.safetensors",
+                )
+                state_dict = load_file(safetensors_path)
+            except Exception:
+                state_dict = {}
+
+        # 5. Head: build the prefix-aware pi0.5 expert (with AdaRMSNorm).
+        from reflex.exporters.pi0_prefix_exporter import build_pi05_expert_with_prefix
+        expert_with_prefix, _meta = build_pi05_expert_with_prefix(state_dict)
+        head = FlowMatchingHead(expert_stack=expert_with_prefix)
+
+        return cls(
+            vision_backbone=vision,
+            llm_backbone=llm,
+            vla_head=head,
+        )
+
+    # ── ABC contract ────────────────────────────────────────────────────
+
+    def forward(self, batch: dict[str, Any]) -> Any:
+        """Minimum-viable forward — runs the language path on
+        already-merged inputs_embeds. Phase B will add the full pipeline.
+
+        Args:
+            batch: dict with keys:
+                - "inputs_embeds": pre-merged image+text embeddings
+                - "attention_mask": [batch, seq]
+                - "past_key_values": optional
+        """
+        return self.llm_backbone(
+            inputs_embeds=batch["inputs_embeds"],
+            attention_mask=batch.get("attention_mask"),
+            past_key_values=batch.get("past_key_values"),
+        )
+
+    def predict_action(
+        self,
+        *,
+        images: list[torch.Tensor],
+        image_masks: list[torch.Tensor] | None = None,
+        lang_tokens: torch.Tensor,
+        lang_masks: torch.Tensor,
+        noise: torch.Tensor | None = None,
+        num_steps: int = 10,
+        chunk_size: int = 50,
+    ) -> torch.Tensor:
+        """Full pi0.5 inference. NOT YET IMPLEMENTED — Day 5 Phase B.
+
+        Mirrors Pi0VLA.predict_action but with pi0.5 specifics:
+
+        1. SigLIPBackbone encodes each camera image
+        2. PaliGemmaBackbone.multi_modal_projector projects vision → text_hidden
+        3. PaliGemmaBackbone.embed_tokens embeds language tokens (state IS
+           encoded in lang_tokens via lerobot's processor — see knowledge
+           insulation paper / arxiv 2505.23705)
+        4. Concat [img_embs..., lang] → prefix_embs
+        5. PaliGemmaBackbone.language_model prefill with use_cache=True
+           → per-layer past_key_values
+        6. Flow-matching denoise loop with AdaRMSNorm time conditioning:
+           a. Build action_emb = action_in_proj(noisy_actions)
+           b. Build adarms_cond = time_mlp_in→silu→time_mlp_out→silu(time_emb)
+           c. vla_head (Pi05ExpertStackWithPrefix) ingests action_emb +
+              per-layer prefix_k/prefix_v + adarms_cond
+           d. Euler update: x_t = x_t + dt * v_t where dt = -1/num_steps
+        7. Return [B, chunk_size, action_dim] denoised actions
+        """
+        raise NotImplementedError(
+            "Pi05VLA.predict_action lands in Day 5 Phase B. See "
+            "features/03_export/basevla-spine_plan.md."
+        )
+
+
+__all__ = ["Pi05VLA"]

--- a/tests/test_pi05_vla.py
+++ b/tests/test_pi05_vla.py
@@ -1,0 +1,175 @@
+"""Tests for Pi05VLA — pi0.5 composition class on the BaseVLA spine.
+
+Lift #1 Day 5 Phase A per `features/03_export/basevla-spine_plan.md`. Validates
+the composition shape (mirroring Pi0VLA tests):
+
+- registration on the VLAS registry
+- slot declarations (REQUIRED_SLOTS, OPTIONAL_SLOTS, NAME_MAPPING)
+- construction via from_config (the spine's primary path)
+- predict_action raises NotImplementedError (Phase B will land it)
+- forward routes to llm_backbone
+
+Phase B adds the full inference pipeline + parity test vs lerobot PI05Policy.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from reflex.models.base_vla import BaseVLA
+from reflex.models.heads import VLAHead
+from reflex.models.llm import LLMBackbone
+from reflex.models.vision import VisionBackbone
+from reflex.models.vlas.pi05 import Pi05VLA
+from reflex.registry.components import VLAS
+
+
+# ─── Registration + slot declarations ───────────────────────────────────
+
+
+def test_pi05_vla_registered():
+    assert "Pi05VLA" in VLAS
+    assert VLAS.get("Pi05VLA") is Pi05VLA
+
+
+def test_pi05_vla_is_basevla_subclass():
+    assert issubclass(Pi05VLA, BaseVLA)
+
+
+def test_pi05_vla_required_slots():
+    """Pi05VLA declares 3 required slots: vision/llm/head.
+    projector + vlm_backbone + text_encoder unused (state-in-language)."""
+    assert Pi05VLA.REQUIRED_SLOTS == ("vision_backbone", "llm_backbone", "vla_head")
+    assert Pi05VLA.OPTIONAL_SLOTS == ()
+
+
+def test_pi05_vla_name_mapping_default_empty():
+    """Decision S-1 — empty NAME_MAPPING is the v1 default."""
+    assert Pi05VLA.NAME_MAPPING == {}
+
+
+# ─── Construction via direct kwargs (the test path) ─────────────────────
+
+
+def test_pi05_vla_constructs_with_3_stub_components():
+    vla = Pi05VLA(
+        vision_backbone=_StubVision(),
+        llm_backbone=_StubLLM(),
+        vla_head=_StubHead(),
+    )
+    assert isinstance(vla.vision_backbone, _StubVision)
+    assert isinstance(vla.llm_backbone, _StubLLM)
+    assert isinstance(vla.vla_head, _StubHead)
+    # Unused slots stay None
+    assert vla.projector is None
+    assert vla.vlm_backbone is None
+    assert vla.text_encoder is None
+
+
+def test_pi05_vla_missing_required_slot_raises():
+    with pytest.raises(ValueError, match="missing required slot"):
+        Pi05VLA(
+            vision_backbone=_StubVision(),
+            llm_backbone=_StubLLM(),
+            # vla_head missing
+        )
+
+
+def test_pi05_vla_undeclared_slot_raises():
+    """Per BaseVLA — passing vlm_backbone (not in REQUIRED + OPTIONAL) raises."""
+    with pytest.raises(ValueError, match="undeclared"):
+        Pi05VLA(
+            vision_backbone=_StubVision(),
+            llm_backbone=_StubLLM(),
+            vla_head=_StubHead(),
+            vlm_backbone=_StubVision(),
+        )
+
+
+# ─── Construction via from_config ───────────────────────────────────────
+
+
+def test_pi05_vla_from_config_with_prebuilt_instances():
+    vla = Pi05VLA.from_config({
+        "vision_backbone": _StubVision(),
+        "llm_backbone": _StubLLM(),
+        "vla_head": _StubHead(),
+    })
+    assert isinstance(vla, Pi05VLA)
+    assert vla.vision_backbone is not None
+
+
+# ─── Forward routing ────────────────────────────────────────────────────
+
+
+def test_forward_routes_to_llm_backbone():
+    stub_llm = _StubLLM()
+    vla = Pi05VLA(
+        vision_backbone=_StubVision(),
+        llm_backbone=stub_llm,
+        vla_head=_StubHead(),
+    )
+    embeds = torch.randn(1, 5, 8)
+    mask = torch.ones(1, 5, dtype=torch.bool)
+    out = vla.forward({
+        "inputs_embeds": embeds,
+        "attention_mask": mask,
+        "past_key_values": None,
+    })
+    assert stub_llm.last_call["inputs_embeds"] is embeds
+    assert out.last_hidden_state.shape == (1, 5, 8)
+
+
+# ─── predict_action — Phase B deferred ─────────────────────────────────
+
+
+def test_predict_action_raises_not_implemented():
+    """Day 5 Phase A scope — predict_action is the Phase B deliverable."""
+    vla = Pi05VLA(
+        vision_backbone=_StubVision(),
+        llm_backbone=_StubLLM(),
+        vla_head=_StubHead(),
+    )
+    with pytest.raises(NotImplementedError, match="Day 5 Phase B"):
+        vla.predict_action(
+            images=[torch.randn(1, 3, 224, 224)],
+            lang_tokens=torch.zeros(1, 4, dtype=torch.long),
+            lang_masks=torch.ones(1, 4, dtype=torch.bool),
+        )
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────
+
+
+class _StubVision(VisionBackbone):
+    def forward(self, images): return images
+
+
+class _StubLLM(LLMBackbone, nn.Module):
+    def __init__(self):
+        nn.Module.__init__(self)
+        self.last_call: dict = {}
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        *args,
+        inputs_embeds=None,
+        past_key_values=None,
+        **kwargs,
+    ):
+        self.last_call = dict(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            past_key_values=past_key_values,
+        )
+        return SimpleNamespace(last_hidden_state=inputs_embeds)
+
+
+class _StubHead(VLAHead):
+    def forward(self, context, *args, **kwargs): return context


### PR DESCRIPTION
## Summary

Mirror Day 4f for pi0.5 — composition class on the BaseVLA spine, no inference yet.

```
Pi05VLA = BaseVLA(
    vision_backbone = SigLIPBackbone  (from paligemma.vision_tower)
    llm_backbone    = PaliGemmaBackbone (PaliGemma minus vision_tower)
    vla_head        = FlowMatchingHead   (wraps Pi05ExpertStackWithPrefix)
)
```

## What pi0.5 differs from pi0

| Aspect | pi0 | pi0.5 |
|---|---|---|
| REQUIRED_SLOTS | 4 (incl. projector) | **3** (no projector) |
| State handling | `state_proj(state)` → first suffix token | **Encoded in lang tokens** (knowledge insulation, arxiv 2505.23705) |
| Suffix length | `chunk_size + 1` (state + actions) | **`chunk_size`** (actions only) |
| Time | concat'd with action_emb in suffix | **AdaRMSNorm conditioning** (no suffix token) |
| Per-layer norm | plain RMSNorm with `(1+w)` | **AdaRMSNorm** (time-conditioned scale + shift + gate) |

## Test plan

- [x] `tests/test_pi05_vla.py` — 10/10 (registration, slots, construction, forward routing, NotImplementedError on predict_action)
- [x] Full suite — 2639 passed, 24 skipped, **0 regressions**

## Deferred to Phase B

- `build_pi05_expert_with_prefix` in `pi0_prefix_exporter.py` (AdaRMSNorm-aware variant of `build_pi0_expert_with_prefix`)
- `Pi05VLA.predict_action` full pipeline
- Modal parity gate vs lerobot `PI05Policy` on `lerobot/pi05_libero_finetuned_v044`

Generated with [Claude Code](https://claude.com/claude-code)
