### PR TITLE
lift #1 day 10: spec dict CLI integration + vla_type column

### DIFF
--- a/src/reflex/cli.py
+++ b/src/reflex/cli.py
@@ -311,9 +311,12 @@ def export(
 
     # Full export — auto-dispatch to the right exporter based on model type
     from reflex.checkpoint import load_checkpoint, detect_model_type
-    from reflex.exporters.smolvla_exporter import export_smolvla
+    # Spine-based exporters (lift #1 Days 6 + 7) for smolvla + groot.
+    # pi0/pi05 still use the legacy pi0_exporter direct-build until their
+    # spine exporters land (Day 11 sunset rewrites this dispatch).
+    from reflex.exporters.smolvla import export_smolvla
     from reflex.exporters.pi0_exporter import export_pi0, export_pi05
-    from reflex.exporters.gr00t_exporter import export_gr00t
+    from reflex.exporters.gr00t import export_gr00t
 
     # Load once, detect, then pass state_dict to the exporter (avoids double-load)
     console.print("[dim]Loading checkpoint...[/dim]")
@@ -335,8 +338,9 @@ def export(
     start = time.perf_counter()
     if model_type == "gr00t":
         # Use the full-stack exporter (wraps action_encoder + DiT + action_decoder)
-        # so `reflex serve` can run the standard denoising loop.
-        from reflex.exporters.gr00t_exporter import export_gr00t_full
+        # so `reflex serve` can run the standard denoising loop. Spine-based
+        # version from lift #1 Day 7 (src/reflex/exporters/gr00t.py).
+        from reflex.exporters.gr00t import export_gr00t_full
         result = export_gr00t_full(export_config, state_dict=state_dict)
     elif model_type == "openvla":
         from reflex.exporters.openvla import export_openvla
@@ -3373,6 +3377,7 @@ def models_list(
                 "model_id": e.model_id,
                 "hf_repo": e.hf_repo,
                 "family": e.family,
+                "vla_type": e.resolved_vla_type,
                 "action_dim": e.action_dim,
                 "size_mb": e.size_mb,
                 "supported_embodiments": list(e.supported_embodiments),
@@ -3397,6 +3402,7 @@ def models_list(
     table = Table(title=f"Reflex Model Registry ({len(entries)} of {len(REGISTRY)})")
     table.add_column("model_id", style="cyan", no_wrap=True)
     table.add_column("family", no_wrap=True)
+    table.add_column("vla_type", no_wrap=True)
     table.add_column("a_dim", justify="right")
     table.add_column("size", justify="right")
     table.add_column("embodiments")
@@ -3405,7 +3411,7 @@ def models_list(
     for e in entries:
         size_str = f"{e.size_mb / 1000:.1f}GB" if e.size_mb >= 1000 else f"{e.size_mb}MB"
         table.add_row(
-            e.model_id, e.family, str(e.action_dim), size_str,
+            e.model_id, e.family, e.resolved_vla_type, str(e.action_dim), size_str,
             ", ".join(e.supported_embodiments), ", ".join(e.supported_devices),
             e.description[:60] + ("..." if len(e.description) > 60 else ""),
         )
@@ -3517,6 +3523,7 @@ def models_info(
             "hf_repo": entry.hf_repo,
             "hf_revision": entry.hf_revision,
             "family": entry.family,
+            "vla_type": entry.resolved_vla_type,
             "action_dim": entry.action_dim,
             "size_mb": entry.size_mb,
             "supported_embodiments": list(entry.supported_embodiments),
@@ -3535,6 +3542,7 @@ def models_info(
 
     console.print(f"[bold cyan]{entry.model_id}[/bold cyan] ([dim]{entry.hf_repo}[/dim])")
     console.print(f"  family:        {entry.family}")
+    console.print(f"  vla_type:      {entry.resolved_vla_type}")
     console.print(f"  action_dim:    {entry.action_dim}")
     console.print(f"  size:          {entry.size_mb}MB")
     console.print(f"  license:       {entry.license}")

--- a/src/reflex/registry/models.py
+++ b/src/reflex/registry/models.py
@@ -83,6 +83,27 @@ class ModelEntry:
                 return b
         return None
 
+    @property
+    def resolved_vla_type(self) -> str:
+        """Resolve this entry's vla_type for display + dispatch.
+
+        - If ``vla_type`` is set (e.g., ``_openvla_shim``), return it verbatim.
+        - Otherwise, derive from ``family``: pi0 → Pi0VLA, pi05 → Pi05VLA,
+          smolvla → SmolVLA, groot → GR00TVLA. The returned name matches
+          the spine ``VLAS`` registry key for that family.
+
+        Added lift #1 Day 10 for ``reflex models list`` + ``reflex models info``
+        + ``reflex export <model_id>`` dispatch.
+        """
+        if self.vla_type is not None:
+            return self.vla_type
+        return {
+            "pi0": "Pi0VLA",
+            "pi05": "Pi05VLA",
+            "smolvla": "SmolVLA",
+            "groot": "GR00TVLA",
+        }.get(self.family, self.family)
+
 
 # Lazy import — keeps `import reflex.registry` cheap if data.py grows large
 def _load_registry() -> list[ModelEntry]:

--- a/tests/test_day10_cli_vla_type.py
+++ b/tests/test_day10_cli_vla_type.py
@@ -1,0 +1,127 @@
+"""Tests for lift #1 Day 10 — Spec dict CLI + reflex models list integration.
+
+Validates the vla_type resolution + display + dispatch wiring per the plan:
+
+- ``ModelEntry.resolved_vla_type`` returns spine class name for known families,
+  shim marker for non-spine entries.
+- ``reflex models list`` JSON output includes ``vla_type`` field.
+- ``reflex models info`` JSON output includes ``vla_type`` field.
+- ``reflex export <model_id>`` for smolvla / groot families routes through
+  the Day 6 / Day 7 spine-based exporters (``exporters/smolvla.py`` and
+  ``exporters/gr00t.py``), not the legacy direct-build paths.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reflex.registry import by_id
+from reflex.registry.data import REGISTRY
+from reflex.registry.models import ModelEntry
+
+
+# ─── ModelEntry.resolved_vla_type ───────────────────────────────────────
+
+
+def test_resolved_vla_type_pi0_family():
+    """Family pi0 resolves to Pi0VLA spine class name."""
+    entry = ModelEntry(
+        model_id="test-pi0", hf_repo="x/y", family="pi0",
+        action_dim=7, size_mb=1,
+    )
+    assert entry.resolved_vla_type == "Pi0VLA"
+
+
+def test_resolved_vla_type_pi05_family():
+    """Family pi05 resolves to Pi05VLA."""
+    entry = ModelEntry(
+        model_id="test-pi05", hf_repo="x/y", family="pi05",
+        action_dim=32, size_mb=1,
+    )
+    assert entry.resolved_vla_type == "Pi05VLA"
+
+
+def test_resolved_vla_type_smolvla_family():
+    entry = ModelEntry(
+        model_id="test-smolvla", hf_repo="x/y", family="smolvla",
+        action_dim=32, size_mb=1,
+    )
+    assert entry.resolved_vla_type == "SmolVLA"
+
+
+def test_resolved_vla_type_groot_family():
+    entry = ModelEntry(
+        model_id="test-groot", hf_repo="x/y", family="groot",
+        action_dim=128, size_mb=1,
+    )
+    assert entry.resolved_vla_type == "GR00TVLA"
+
+
+def test_resolved_vla_type_openvla_shim():
+    """OpenVLA's _openvla_shim marker takes precedence over family derivation."""
+    entry = ModelEntry(
+        model_id="test-openvla", hf_repo="x/y", family="openvla",
+        action_dim=7, size_mb=1, vla_type="_openvla_shim",
+    )
+    assert entry.resolved_vla_type == "_openvla_shim"
+
+
+def test_resolved_vla_type_explicit_marker_overrides_family():
+    """When vla_type is explicitly set, family derivation is bypassed."""
+    entry = ModelEntry(
+        model_id="test-override", hf_repo="x/y", family="pi0",
+        action_dim=7, size_mb=1, vla_type="_custom_marker",
+    )
+    assert entry.resolved_vla_type == "_custom_marker"
+
+
+# ─── Real registry entries ─────────────────────────────────────────────
+
+
+def test_registry_each_entry_resolves_to_valid_marker():
+    """Every entry in REGISTRY resolves to either a known spine class
+    or a shim marker."""
+    KNOWN_SPINE = {"Pi0VLA", "Pi05VLA", "SmolVLA", "GR00TVLA"}
+    for entry in REGISTRY:
+        resolved = entry.resolved_vla_type
+        assert resolved is not None
+        # Either a spine class name OR a marker (starts with _) OR a family
+        # we don't yet have a spine class for.
+        assert (
+            resolved in KNOWN_SPINE
+            or resolved.startswith("_")
+            or resolved == entry.family  # fallback for unknown families
+        ), f"{entry.model_id} resolved to unexpected vla_type: {resolved!r}"
+
+
+def test_openvla_7b_resolves_to_shim():
+    entry = by_id("openvla-7b")
+    assert entry is not None
+    assert entry.resolved_vla_type == "_openvla_shim"
+
+
+# ─── CLI export dispatch wiring (Day 6+7 spine paths) ──────────────────
+
+
+def test_cli_imports_spine_smolvla_exporter():
+    """`reflex export` for smolvla family uses src/reflex/exporters/smolvla.py
+    (the Day 6 spine-based exporter), NOT the legacy smolvla_exporter."""
+    import reflex.cli as cli_module
+    import inspect
+    src = inspect.getsource(cli_module)
+    # The export function should import from the spine module.
+    assert "from reflex.exporters.smolvla import export_smolvla" in src
+    # And NOT from the legacy module (smolvla_exporter) on the same import line.
+    assert "from reflex.exporters.smolvla_exporter import export_smolvla" not in src
+
+
+def test_cli_imports_spine_gr00t_exporter():
+    """`reflex export` for groot family uses src/reflex/exporters/gr00t.py
+    (the Day 7 spine-based exporter), NOT the legacy gr00t_exporter."""
+    import reflex.cli as cli_module
+    import inspect
+    src = inspect.getsource(cli_module)
+    assert "from reflex.exporters.gr00t import export_gr00t" in src
+    assert "from reflex.exporters.gr00t_exporter import export_gr00t" not in src or \
+        "from reflex.exporters.gr00t_exporter import export_gr00t_full" not in src


### PR DESCRIPTION
## Summary

Day 10: wire the spec-dict registry into the CLI surface. `reflex models list` + `reflex models info` now show the `vla_type` (spine class name or shim marker). `reflex export <model_id>` for smolvla + groot families routes through the Day 6 / Day 7 spine-based exporters.

## Changes

| Change | Where |
|---|---|
| `ModelEntry.resolved_vla_type` property — explicit marker if set, else derive from family (pi0 → Pi0VLA, pi05 → Pi05VLA, smolvla → SmolVLA, groot → GR00TVLA) | `src/reflex/registry/models.py` |
| `reflex models list` — adds `vla_type` column (table + JSON) | `src/reflex/cli.py` |
| `reflex models info` — adds `vla_type:` line (human + JSON) | `src/reflex/cli.py` |
| `reflex export` for smolvla → `reflex.exporters.smolvla.export_smolvla` (Day 6 spine path, not legacy) | `src/reflex/cli.py` |
| `reflex export` for groot → `reflex.exporters.gr00t.export_gr00t_full` (Day 7 spine path) | `src/reflex/cli.py` |
| 10 new tests pinning the resolution + dispatch | `tests/test_day10_cli_vla_type.py` |

pi0/pi05 still use the legacy `pi0_exporter` direct-build path — Day 11 sunsets that with the rest of the OLD exporters.

## Test plan

- [x] `tests/test_day10_cli_vla_type.py` — 10/10
- [x] `tests/test_pi0_vla.py` + `test_pi05_vla.py` + `test_smolvla_spine.py` + `test_gr00t_spine.py` + `test_openvla_shim.py` + `test_pi0_prefix_module_rename.py` — 57/57 (no regression on Days 4-9)
- [x] `tests/test_flow_matching_head.py` — 13/13
- [x] `tests/test_registry_completeness.py` — 4/4
- [ ] CI full suite (in flight)

Generated with [Claude Code](https://claude.com/claude-code)
