### PR TITLE
chore(release): bump version to v0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "reflex-vla"
-version = "0.9.6"
+version = "0.10.0"
 description = "Deploy any VLA model to any edge hardware. Now with reflex chat — natural-language CLI."
 readme = "README.md"
 license = "BUSL-1.1"

--- a/src/reflex/__init__.py
+++ b/src/reflex/__init__.py
@@ -1,6 +1,6 @@
 """Reflex — Deploy any VLA model to any edge hardware. One command."""
 
-__version__ = "0.9.6"
+__version__ = "0.10.0"
 
 # Heavy submodules (validate_roundtrip pulls in torch) are lazy-loaded so that
 # `reflex --version`, `reflex --help`, `reflex chat`, etc. don't pay the


### PR DESCRIPTION
## Summary

Bumps version from 0.9.6 → 0.10.0 in `pyproject.toml` + `src/reflex/__init__.py`. Lift #1 BaseVLA spine refactor (PRs #152, #154-#164) is fully merged. The v0.10.0 CHANGELOG entry landed at Day 12 (PR #163).

This PR is **source-only**. Tag + PyPI publish is a separate workflow that needs the user's explicit go-ahead (CLAUDE.md "Hard-to-reverse operations: ... publication"). After this PR merges, the version string is ready; the maintainer chooses when to `git tag v0.10.0` + push the tag.

## Test plan

- [x] `PYTHONPATH=src python3 -c "import reflex; print(reflex.__version__)"` reports `0.10.0`
- [x] 86 spine + CLI tests pass locally (no regression)
- [ ] CI full suite (in flight)

Generated with [Claude Code](https://claude.com/claude-code)
