### PR TITLE
chore: post-v0.10 polish (docstring fix + stderr sweep + migration guide)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The decomposition exposed 6 silent correctness bugs in production export paths t
 | `reflex.exporters.openvla_exporter` | `reflex.exporters.openvla` | 8 |
 | `reflex.exporters.pi0_prefix_exporter` | `reflex.exporters.pi0_prefix` | 9 |
 
-External callers must update import statements. The `from reflex.exporters.smolvla_exporter import ...` pattern raises `ModuleNotFoundError` after this release. `tests/test_day10_cli_vla_type.py::test_legacy_exporter_modules_deleted` pins this.
+External callers must update import statements. The `from reflex.exporters.smolvla_exporter import ...` pattern raises `ModuleNotFoundError` after this release. `tests/test_day10_cli_vla_type.py::test_legacy_exporter_modules_deleted` pins this. See [`docs/migration_v0.9_to_v0.10.md`](docs/migration_v0.9_to_v0.10.md) for the full rename table + a bulk-sed snippet.
 
 ### CLI additions
 

--- a/docs/migration_v0.9_to_v0.10.md
+++ b/docs/migration_v0.9_to_v0.10.md
@@ -1,0 +1,95 @@
+# Migration guide: v0.9 → v0.10
+
+> If you only use `reflex` as a CLI, you don't need to change anything — `reflex export`, `reflex models *`, `reflex serve`, `reflex chat` all keep working. This guide is for **library users** who import from `reflex.exporters.*`.
+
+## TL;DR
+
+v0.10.0 lands the **BaseVLA spine refactor** (lift #1). Several exporter modules were renamed or deleted as part of the cleanup. Update your imports as below.
+
+## The 5 import renames
+
+| v0.9 import path | v0.10 path | Day |
+|---|---|---|
+| `reflex.exporters.pi0_exporter` | `reflex.exporters.pi0` | 11 |
+| `reflex.exporters.smolvla_exporter` | `reflex.exporters.smolvla` | 11 |
+| `reflex.exporters.gr00t_exporter` | `reflex.exporters.gr00t` | 11 |
+| `reflex.exporters.openvla_exporter` | `reflex.exporters.openvla` | 8 |
+| `reflex.exporters.pi0_prefix_exporter` | `reflex.exporters.pi0_prefix` | 9 |
+
+The legacy modules are **gone** — they raise `ModuleNotFoundError`. No compat aliases. The test `tests/test_day10_cli_vla_type.py::test_legacy_exporter_modules_deleted` pins this so future regressions are caught.
+
+## What stayed the same
+
+- `build_pi0_expert_stack` / `build_pi05_expert_stack` / `build_expert_stack` (SmolVLA) / `build_gr00t_expert_stack` / `build_gr00t_full_stack` — same builders, just in the renamed modules
+- `export_pi0` / `export_pi05` / `export_smolvla` / `export_gr00t` / `export_gr00t_full` — same export functions, same I/O shapes, same ONNX bytes byte-for-byte
+- `Pi0ExpertStackWithPrefix` / `Pi05ExpertStackWithPrefix` / `ExpertStack` classes — same classes, exposed from their new home modules
+
+The numerics didn't change. The PRs that landed the rename also passed bit-identical parity vs the reference checkpoints — pi0 max 1.13e-6, pi0.5 max 2.74e-6, SmolVLA max 0.0, GR00T N1.6 max 0.0.
+
+## Two examples
+
+**Before (v0.9):**
+
+```python
+from reflex.exporters.smolvla_exporter import build_expert_stack
+from reflex.exporters.pi0_exporter import build_pi0_expert_stack, PI0_ACTION_KEYS
+from reflex.exporters.gr00t_exporter import build_gr00t_full_stack
+
+# ...your code unchanged
+```
+
+**After (v0.10):**
+
+```python
+from reflex.exporters.smolvla import build_expert_stack
+from reflex.exporters.pi0 import build_pi0_expert_stack, PI0_ACTION_KEYS
+from reflex.exporters.gr00t import build_gr00t_full_stack
+
+# ...your code unchanged
+```
+
+A bulk `sed` covers it:
+
+```bash
+find . -name '*.py' -exec sed -i \
+    -e 's|reflex\.exporters\.pi0_exporter|reflex.exporters.pi0|g' \
+    -e 's|reflex\.exporters\.smolvla_exporter|reflex.exporters.smolvla|g' \
+    -e 's|reflex\.exporters\.gr00t_exporter|reflex.exporters.gr00t|g' \
+    -e 's|reflex\.exporters\.openvla_exporter|reflex.exporters.openvla|g' \
+    -e 's|reflex\.exporters\.pi0_prefix_exporter|reflex.exporters.pi0_prefix|g' \
+    {} +
+```
+
+## What's new
+
+If you want to build VLAs through the new spine composition (rather than the legacy direct-build path), see `src/reflex/models/vlas/` for the worked examples and [`docs/adding_a_vla.md`](./adding_a_vla.md) for the cookbook. The TL;DR is:
+
+```python
+from reflex.models.vlas.pi05 import Pi05VLA
+
+vla = Pi05VLA.from_pretrained("lerobot/pi05_libero_finetuned_v044")
+actions = vla.predict_action(
+    images=[...], lang_tokens=..., lang_masks=...,
+)
+```
+
+`predict_action` is bit-identical to lerobot's `PI05Policy.predict_action` on the same checkpoint + inputs (max diff 2.74e-6 measured on Modal A10G).
+
+## Why the rename
+
+The legacy `*_exporter.py` modules grew to host both **builders** (load checkpoint → reconstruct the action expert as a PyTorch module) and **exporters** (build expert → write ONNX). The spine refactor split these concerns:
+
+- **Builders** stay in `reflex.exporters.<family>` (renamed from `<family>_exporter` for brevity).
+- **Composition classes** live in `reflex.models.vlas.<family>`. They wrap the builders behind a uniform `BaseVLA` 6-slot interface.
+
+The drop of the `_exporter` suffix reflects this: the module is no longer JUST an exporter. It's the family's source of truth for builders + classes + constants.
+
+## Help
+
+If something else broke that isn't on this list, the rename is mechanical — the change is in the import path, not the API. Open an issue with the failing import + we'll add it here.
+
+## See also
+
+- [`CHANGELOG.md`](../CHANGELOG.md#v0100--2026-05-22) — full v0.10.0 release notes
+- [`docs/adding_a_vla.md`](./adding_a_vla.md) — cookbook for adding a new VLA to the spine
+- `reflex_context/features/03_export/basevla-spine_plan.md` — the lift #1 12-day plan that landed this refactor (in the design vault)

--- a/src/reflex/cli.py
+++ b/src/reflex/cli.py
@@ -248,7 +248,7 @@ def export(
         # Check memory fit
         weight_gb = total_params * 2 / 1e9  # FP16
         if weight_gb > hardware.memory_gb * 0.7:
-            console.print(f"  [red]Model ({weight_gb:.1f}GB) may not fit on {hardware.name} ({hardware.memory_gb}GB)[/red]")
+            err_console.print(f"  [red]Model ({weight_gb:.1f}GB) may not fit on {hardware.name} ({hardware.memory_gb}GB)[/red]")
         else:
             console.print(f"  [green]Model ({weight_gb:.1f}GB) fits on {hardware.name} ({hardware.memory_gb}GB)[/green]")
 
@@ -313,7 +313,7 @@ def export(
         raise typer.Exit(0)
 
     if requested_export_mode != ExportMode.AUTO:
-        console.print(
+        err_console.print(
             "[red]--export-mode is only implemented for pi0.5 decomposed exports "
             "handled by the vlm_prefix/expert_denoise exporter. Re-run with "
             "--export-mode auto, or use a pi0.5 model ref.[/red]"
@@ -542,16 +542,16 @@ def validate(
         try:
             emit_ci_template(out, reflex_version=__version__)
         except FileExistsError as exc:
-            console.print(f"[red]{exc}[/red]")
+            err_console.print(f"[red]{exc}[/red]")
             raise typer.Exit(2)
         except Exception as exc:
-            console.print(f"[red]Failed to emit CI template: {exc}[/red]")
+            err_console.print(f"[red]Failed to emit CI template: {exc}[/red]")
             raise typer.Exit(2)
         console.print(f"[green]Wrote CI template:[/green] {out}")
         raise typer.Exit(0)
 
     if not target:
-        console.print("[red]Export directory or model ID is required (unless --init-ci).[/red]")
+        err_console.print("[red]Export directory or model ID is required (unless --init-ci).[/red]")
         raise typer.Exit(2)
 
     # --pre-export: check a raw checkpoint (replaces old `reflex check`)
@@ -637,7 +637,7 @@ def validate(
     export_dir = target  # rename for legacy code paths below
 
     if device not in ("cpu", "cuda"):
-        console.print(f"[red]--device must be 'cpu' or 'cuda', got: {device}[/red]")
+        err_console.print(f"[red]--device must be 'cpu' or 'cuda', got: {device}[/red]")
         raise typer.Exit(2)
 
     from reflex.validate_roundtrip import ValidateRoundTrip
@@ -652,10 +652,10 @@ def validate(
             device=device,
         )
     except FileNotFoundError as exc:
-        console.print(f"[red]{exc}[/red]")
+        err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(2)
     except ValueError as exc:
-        console.print(f"[red]{exc}[/red]")
+        err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(2)
 
     try:
@@ -664,16 +664,16 @@ def validate(
         console.print("\n[yellow]Validation interrupted by user.[/yellow]")
         raise typer.Exit(130)
     except FileNotFoundError as exc:
-        console.print(f"[red]Missing required file: {exc}[/red]")
+        err_console.print(f"[red]Missing required file: {exc}[/red]")
         raise typer.Exit(2)
     except ValueError as exc:
-        console.print(f"[red]{exc}[/red]")
+        err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(2)
     except Exception as exc:
         if verbose:
             import traceback
             traceback.print_exc()
-        console.print(f"[red]Validation failed with unexpected error: {exc}[/red]")
+        err_console.print(f"[red]Validation failed with unexpected error: {exc}[/red]")
         console.print("[yellow]Re-run with --verbose for the full traceback.[/yellow]")
         raise typer.Exit(2)
 
@@ -781,12 +781,12 @@ def benchmark_cmd(
 
     export_path = Path(export_dir)
     if not export_path.exists():
-        console.print(f"[red]Export directory not found: {export_dir}[/red]")
+        err_console.print(f"[red]Export directory not found: {export_dir}[/red]")
         raise typer.Exit(1)
 
     onnx_files = list(export_path.glob("*.onnx"))
     if not onnx_files:
-        console.print(f"[red]No ONNX file in {export_dir}[/red]")
+        err_console.print(f"[red]No ONNX file in {export_dir}[/red]")
         raise typer.Exit(1)
 
     # If --benchmark was requested, gate on the eval extra being installed
@@ -803,7 +803,7 @@ def benchmark_cmd(
             raise typer.Exit(2)
         valid = ("simpler", "maniskill")
         if benchmark not in valid:
-            console.print(f"[red]Unknown benchmark '{benchmark}'. Try one of: {', '.join(valid)}[/red]")
+            err_console.print(f"[red]Unknown benchmark '{benchmark}'. Try one of: {', '.join(valid)}[/red]")
             raise typer.Exit(2)
 
     console.print(f"\n[bold]Reflex Benchmark[/bold]")
@@ -821,7 +821,7 @@ def benchmark_cmd(
     server.load()
     load_s = _t.perf_counter() - t0
     if not server.ready:
-        console.print("[red]Model failed to load.[/red]")
+        err_console.print("[red]Model failed to load.[/red]")
         raise typer.Exit(1)
     console.print(
         f"  Loaded:    {load_s:.1f}s  (mode={server._inference_mode})"
@@ -908,7 +908,7 @@ def benchmark_cmd(
         try:
             from reflex.eval import run_task_benchmark
         except ImportError as exc:
-            console.print(
+            err_console.print(
                 f"[red]reflex.eval module missing: {exc}[/red]\n"
                 f"  The benchmark-plugin framework ships in v0.2 — see GOALS.yaml."
             )
@@ -1023,18 +1023,18 @@ def eval_cmd(
     # ---- Validate inputs at the CLI layer (fail loud) ----
     export_path = Path(export_dir)
     if not export_path.exists():
-        console.print(f"[red]Export directory not found: {export_dir}[/red]")
+        err_console.print(f"[red]Export directory not found: {export_dir}[/red]")
         raise typer.Exit(1)
 
     if suite != "libero":
-        console.print(
+        err_console.print(
             f"[red]Unknown suite: {suite!r}. Phase 1 ships LIBERO only.[/red]\n"
             f"  Phase 2 will add: simpler, customer."
         )
         raise typer.Exit(2)
 
     if runtime not in ALL_RUNTIMES:
-        console.print(
+        err_console.print(
             f"[red]Unknown runtime: {runtime!r}. "
             f"Choose one of: {', '.join(ALL_RUNTIMES)}[/red]"
         )
@@ -1058,7 +1058,7 @@ def eval_cmd(
             cost_preview=cost_preview,
         )
     except ValueError as exc:
-        console.print(f"[red]Invalid configuration: {exc}[/red]")
+        err_console.print(f"[red]Invalid configuration: {exc}[/red]")
         raise typer.Exit(2)
 
     # ---- Banner echo ----
@@ -1099,7 +1099,7 @@ def eval_cmd(
         )
         console.print(f"  {cost_estimate.notes}")
         if cost_estimate.exceeds_guardrail:
-            console.print(
+            err_console.print(
                 f"\n[red]Estimate exceeds ${COST_PREVIEW_GUARDRAIL_USD:.0f} "
                 f"guardrail.[/red] Run with smaller --num-episodes "
                 f"or fewer --tasks to lower the cost."
@@ -1113,7 +1113,7 @@ def eval_cmd(
     )
     preflight_result = PreflightSmokeTest.run(timeout_s=preflight_timeout)
     if not preflight_result.passed:
-        console.print(
+        err_console.print(
             f"\n[red]Pre-flight FAILED[/red] "
             f"({preflight_result.failure_mode}, "
             f"{preflight_result.elapsed_s:.1f}s)\n"
@@ -1153,7 +1153,7 @@ def eval_cmd(
         try:
             report = suite_runner(runtime_config, export_path)
         except ModalNotInstalledError as exc:
-            console.print(f"\n[red]{exc}[/red]")
+            err_console.print(f"\n[red]{exc}[/red]")
             raise typer.Exit(6)
     else:
         # local
@@ -1292,7 +1292,7 @@ def guard(
                 console.print(f"    {v}")
 
     else:
-        console.print(f"[red]Unknown action: {action}. Use 'init' or 'check'.[/red]")
+        err_console.print(f"[red]Unknown action: {action}. Use 'init' or 'check'.[/red]")
         raise typer.Exit(1)
 
 
@@ -1730,13 +1730,13 @@ def serve(
 
     export_path = Path(export_dir)
     if not export_path.exists():
-        console.print(f"[red]Export directory not found: {export_dir}[/red]")
+        err_console.print(f"[red]Export directory not found: {export_dir}[/red]")
         console.print(f"[dim]Run 'reflex export' first to create an export.[/dim]")
         raise typer.Exit(1)
 
     onnx_files = list(export_path.glob("*.onnx"))
     if not onnx_files:
-        console.print(f"[red]No ONNX files found in {export_dir}[/red]")
+        err_console.print(f"[red]No ONNX files found in {export_dir}[/red]")
         raise typer.Exit(1)
 
     # ---- Policy-versioning Day 5 validation ----
@@ -1744,7 +1744,7 @@ def serve(
     # exclusive with --shadow-policy. --no-rtc enforced in 2-policy mode.
     two_policy_mode = bool(policy_a or policy_b)
     if two_policy_mode and not (policy_a and policy_b):
-        console.print(
+        err_console.print(
             "[red]--policy-a and --policy-b must be set together for "
             "2-policy mode.[/red]\n"
             "[dim]To roll out a single policy, drop both flags and pass "
@@ -1752,7 +1752,7 @@ def serve(
         )
         raise typer.Exit(1)
     if two_policy_mode and shadow_policy:
-        console.print(
+        err_console.print(
             "[red]--policy-b and --shadow-policy are mutually exclusive.[/red]\n"
             "[dim]Pick A/B for production rollout, OR shadow for risk-free "
             "comparison.[/dim]"
@@ -1763,12 +1763,12 @@ def serve(
         try:
             validate_split_and_no_rtc(split_a_percent=split, no_rtc=no_rtc)
         except ValueError as exc:
-            console.print(f"[red]{exc}[/red]")
+            err_console.print(f"[red]{exc}[/red]")
             raise typer.Exit(1)
         # Verify both policy paths exist before attempting to load
         for label, path in (("--policy-a", policy_a), ("--policy-b", policy_b)):
             if not Path(path).exists():
-                console.print(
+                err_console.print(
                     f"[red]{label} export not found: {path}[/red]"
                 )
                 raise typer.Exit(1)
@@ -1812,7 +1812,7 @@ def serve(
             else:
                 embodiment_cfg = EmbodimentConfig.load_preset(embodiment)
         except (FileNotFoundError, ValueError) as exc:
-            console.print(f"[red]Failed to load embodiment config: {exc}[/red]")
+            err_console.print(f"[red]Failed to load embodiment config: {exc}[/red]")
             console.print(
                 f"[dim]Available presets: {list_presets() or '(none)'}[/dim]"
             )
@@ -1820,7 +1820,7 @@ def serve(
 
         ok, errs = validate_embodiment_config(embodiment_cfg)
         if not ok:
-            console.print(
+            err_console.print(
                 f"[red]Embodiment config '{embodiment_cfg.embodiment}' failed "
                 f"validation:[/red]"
             )
@@ -1851,7 +1851,7 @@ def serve(
                 debug=rtc_debug,
             )
         except ValueError as exc:
-            console.print(f"[red]Invalid RTC config: {exc}[/red]")
+            err_console.print(f"[red]Invalid RTC config: {exc}[/red]")
             raise typer.Exit(1)
 
     # ROS2 mode short-circuits the HTTP path — hand off to the bridge.
@@ -1859,7 +1859,7 @@ def serve(
         try:
             from reflex.runtime.ros2_bridge import run_ros2_bridge
         except ImportError as exc:
-            console.print(f"[red]ros2 bridge unavailable: {exc}[/red]")
+            err_console.print(f"[red]ros2 bridge unavailable: {exc}[/red]")
             raise typer.Exit(2)
         console.print(f"[bold green]reflex serve --ros2[/bold green]")
         console.print(f"  export:   {export_dir}")
@@ -1889,7 +1889,7 @@ def serve(
         import onnxruntime as ort
         available = ort.get_available_providers()
     except ImportError:
-        console.print(
+        err_console.print(
             "[red]onnxruntime is not installed.[/red]\n"
             "For GPU: [cyan]pip install onnxruntime-gpu[/cyan]\n"
             "For CPU: [cyan]pip install onnxruntime[/cyan]"
@@ -1938,7 +1938,7 @@ def serve(
         console.print(f"  Wedges:  {' · '.join(composed)}")
 
     if cuda_requested and not cuda_available_in_ort:
-        console.print(
+        err_console.print(
             "\n[red]⚠ CUDAExecutionProvider not available in this ORT install.[/red]\n"
             "  Likely cause: you installed `onnxruntime` (CPU-only).\n"
             "  Fix:   [cyan]pip uninstall onnxruntime && pip install onnxruntime-gpu[/cyan]\n"
@@ -1964,20 +1964,20 @@ def serve(
         raise typer.Exit(1)
 
     if replan_hz > 0 and execute_hz <= 0:
-        console.print(
+        err_console.print(
             "[red]--replan-hz requires --execute-hz > 0 (the robot's pop rate).[/red]"
         )
         raise typer.Exit(1)
 
     if not (0.0 <= otel_sample <= 1.0):
-        console.print(
+        err_console.print(
             f"[red]--otel-sample must be in [0.0, 1.0], got {otel_sample}[/red]"
         )
         raise typer.Exit(1)
 
     # chunk-budget-batching CLI validation + --max-batch deprecation
     if not (10.0 <= max_batch_cost_ms <= 500.0):
-        console.print(
+        err_console.print(
             f"[red]--max-batch-cost-ms must be in [10, 500], got {max_batch_cost_ms}[/red]"
         )
         raise typer.Exit(1)
@@ -1991,7 +1991,7 @@ def serve(
 
     # auto-calibration mutual-exclusion validation
     if calibrate_force and not auto_calibrate:
-        console.print(
+        err_console.print(
             "[red]--calibrate-force requires --auto-calibrate.[/red]"
         )
         raise typer.Exit(1)
@@ -2002,7 +2002,7 @@ def serve(
         try:
             _calib_cache_path.parent.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
-            console.print(
+            err_console.print(
                 f"[red]--calibration-cache parent dir not writable: "
                 f"{_calib_cache_path.parent} — {exc}[/red]"
             )
@@ -2018,7 +2018,7 @@ def serve(
             _slo_mode_validated = validate_slo_mode(slo_mode)
             slo_tracker = SLOTracker(_slo_spec)
         except ValueError as exc:
-            console.print(f"[red]SLO config invalid: {exc}[/red]")
+            err_console.print(f"[red]SLO config invalid: {exc}[/red]")
             raise typer.Exit(1)
         composed.append(f"[cyan]slo={slo}/{slo_mode}[/cyan]")
     else:
@@ -2102,7 +2102,7 @@ def serve(
     # no --mcp: FastAPI only (legacy behavior).
     if mcp:
         if mcp_transport not in ("stdio", "http"):
-            console.print(
+            err_console.print(
                 f"[red]Invalid --mcp-transport {mcp_transport!r}; expected 'stdio' or 'http'.[/red]"
             )
             raise typer.Exit(1)
@@ -2118,7 +2118,7 @@ def serve(
         # Pull the live ReflexServer out of the FastAPI app's state
         reflex_srv = getattr(app_instance.state, "reflex_server", None)
         if reflex_srv is None:
-            console.print(
+            err_console.print(
                 "[red]Could not find ReflexServer on the app state; MCP needs a live "
                 "inference engine. Report this at github.com/FastCrest/reflex-vla/issues.[/red]"
             )
@@ -2221,11 +2221,11 @@ def ros2_serve(
     try:
         from reflex.runtime.ros2_bridge import run_ros2_bridge
     except ImportError as exc:
-        console.print(f"[red]{exc}[/red]")
+        err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(2)
 
     if mcp and mcp_transport not in ("stdio", "http"):
-        console.print(
+        err_console.print(
             f"[red]Invalid --mcp-transport {mcp_transport!r}; "
             f"expected 'stdio' or 'http'.[/red]"
         )
@@ -2258,10 +2258,10 @@ def ros2_serve(
     except ValueError as exc:
         # _resolve_state_msg_class / create_ros2_bridge_node raise ValueError
         # for unknown --state-msg-type values.
-        console.print(f"[red]{exc}[/red]")
+        err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1)
     except ImportError as exc:
-        console.print(f"[red]{exc}[/red]")
+        err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(2)
 
 
@@ -2310,7 +2310,7 @@ def replay(
     from reflex.replay.cli import run_replay
 
     if not no_replay and not model:
-        console.print(
+        err_console.print(
             "[red]--model is required (or pass --no-replay to inspect the trace "
             "without loading a model).[/red]"
         )
@@ -2675,7 +2675,7 @@ def doctor(
     import sys
 
     if output_format not in ("human", "json"):
-        console.print(
+        err_console.print(
             f"[red]--format must be 'human' or 'json', got {output_format!r}[/red]"
         )
         raise typer.Exit(2)
@@ -2704,7 +2704,7 @@ def doctor(
         try:
             cache = CalibrationCache.load(cache_path)
         except Exception as exc:
-            console.print(f"[red]Failed to load cache: {exc}[/red]")
+            err_console.print(f"[red]Failed to load cache: {exc}[/red]")
             raise typer.Exit(1)
 
         current_fp = HardwareFingerprint.current()
@@ -3308,12 +3308,12 @@ def validate_dataset(
     )
 
     if output_format not in ("human", "json"):
-        console.print(f"[red]--format must be 'human' or 'json', got {output_format!r}[/red]")
+        err_console.print(f"[red]--format must be 'human' or 'json', got {output_format!r}[/red]")
         raise typer.Exit(2)
 
     dataset_path = Path(path)
     if not dataset_path.exists():
-        console.print(f"[red]Dataset path does not exist: {dataset_path}[/red]")
+        err_console.print(f"[red]Dataset path does not exist: {dataset_path}[/red]")
         raise typer.Exit(2)
 
     embodiment_cfg = None
@@ -3374,7 +3374,7 @@ def models_list(
     from reflex.registry import REGISTRY, filter_models
 
     if output_format not in ("human", "json"):
-        console.print(f"[red]--format must be 'human' or 'json', got {output_format!r}[/red]")
+        err_console.print(f"[red]--format must be 'human' or 'json', got {output_format!r}[/red]")
         raise typer.Exit(2)
 
     entries = filter_models(
@@ -3461,7 +3461,7 @@ def models_pull(
                 break
     if entry is None:
         available = sorted(e.model_id for e in REGISTRY)
-        console.print(f"[red]Unknown model_id: {model_id!r}[/red]")
+        err_console.print(f"[red]Unknown model_id: {model_id!r}[/red]")
         console.print(f"Available registry ids: {', '.join(available)}")
         console.print("Tip: you can also pass the HuggingFace repo id (e.g. lerobot/smolvla_base).")
         raise typer.Exit(2)
@@ -3481,7 +3481,7 @@ def models_pull(
     try:
         from huggingface_hub import snapshot_download
     except ImportError:
-        console.print("[red]huggingface_hub not installed. pip install reflex-vla[/red]")
+        err_console.print("[red]huggingface_hub not installed. pip install reflex-vla[/red]")
         raise typer.Exit(2)
 
     try:
@@ -3492,7 +3492,7 @@ def models_pull(
             local_dir_use_symlinks=False,
         )
     except Exception as e:
-        console.print(f"[red]Download failed: {type(e).__name__}: {e}[/red]")
+        err_console.print(f"[red]Download failed: {type(e).__name__}: {e}[/red]")
         raise typer.Exit(1)
 
     if not no_verify:
@@ -3524,7 +3524,7 @@ def models_info(
 
     entry = by_id(model_id)
     if entry is None:
-        console.print(f"[red]Unknown model_id: {model_id!r}[/red]")
+        err_console.print(f"[red]Unknown model_id: {model_id!r}[/red]")
         raise typer.Exit(2)
 
     if output_format == "json":
@@ -3640,12 +3640,12 @@ def go(
     )
 
     if not model:
-        console.print("[red]--model is required (e.g. --model pi05-libero).[/red]")
+        err_console.print("[red]--model is required (e.g. --model pi05-libero).[/red]")
         console.print("Run [cyan]reflex models list[/cyan] to browse.")
         raise typer.Exit(2)
 
     if device_class and device_class not in CANONICAL_DEVICE_CLASSES:
-        console.print(
+        err_console.print(
             f"[red]--device-class {device_class!r} not in {CANONICAL_DEVICE_CLASSES}[/red]"
         )
         raise typer.Exit(2)
@@ -3661,7 +3661,7 @@ def go(
     try:
         resolution = resolve_model(model=model, device_class=probe.device_class, embodiment=embodiment)
     except ModelResolverError as e:
-        console.print(f"[red]{e}[/red]")
+        err_console.print(f"[red]{e}[/red]")
         raise typer.Exit(2)
     entry = resolution.entry
     console.print(f"[bold cyan]model:[/bold cyan]    {entry.model_id} "
@@ -3688,7 +3688,7 @@ def go(
         try:
             from huggingface_hub import snapshot_download
         except ImportError:
-            console.print("[red]huggingface_hub not installed.[/red]")
+            err_console.print("[red]huggingface_hub not installed.[/red]")
             raise typer.Exit(2)
         try:
             snapshot_download(
@@ -3698,7 +3698,7 @@ def go(
                 local_dir_use_symlinks=False,
             )
         except Exception as e:
-            console.print(f"[red]Download failed: {type(e).__name__}: {e}[/red]")
+            err_console.print(f"[red]Download failed: {type(e).__name__}: {e}[/red]")
             raise typer.Exit(1)
 
     # Step 5: if model ships as raw weights, export inline before serving.
@@ -4100,7 +4100,7 @@ def traces_query(
     try:
         records = query_traces(dirs, filter_=flt)
     except ValueError as exc:
-        console.print(f"[red]Invalid filter: {exc}[/red]")
+        err_console.print(f"[red]Invalid filter: {exc}[/red]")
         raise typer.Exit(1)
 
     if not records:
@@ -4238,7 +4238,7 @@ def traces_summary(
             dirs, filter_=flt, by=cast("Any", by),
         )
     except ValueError as exc:
-        console.print(f"[red]Invalid filter: {exc}[/red]")
+        err_console.print(f"[red]Invalid filter: {exc}[/red]")
         raise typer.Exit(1)
 
     if not summaries:
@@ -4327,17 +4327,17 @@ def pro_activate(
     try:
         license = activate_license(code, endpoint=endpoint)
     except ActivationCodeError as exc:
-        console.print(f"[red]Activation failed:[/red] {exc}")
+        err_console.print(f"[red]Activation failed:[/red] {exc}")
         raise typer.Exit(1)
     except ActivationNetworkError as exc:
-        console.print(f"[red]Network error:[/red] {exc}")
+        err_console.print(f"[red]Network error:[/red] {exc}")
         raise typer.Exit(2)
     except LicenseSignatureError as exc:
-        console.print(f"[red]Signature verification failed:[/red] {exc}")
-        console.print("[red]Refusing to write a license that didn't verify.[/red]")
+        err_console.print(f"[red]Signature verification failed:[/red] {exc}")
+        err_console.print("[red]Refusing to write a license that didn't verify.[/red]")
         raise typer.Exit(3)
     except ActivationError as exc:
-        console.print(f"[red]Activation error:[/red] {exc}")
+        err_console.print(f"[red]Activation error:[/red] {exc}")
         raise typer.Exit(4)
 
     console.print("[green]✓[/green] License fetched, signature verified, written to ~/.reflex/pro.license")
@@ -4371,7 +4371,7 @@ def pro_status(
     try:
         data = _json.loads(path.read_text())
     except Exception as exc:  # noqa: BLE001
-        console.print(f"[red]License file is corrupt:[/red] {exc}")
+        err_console.print(f"[red]License file is corrupt:[/red] {exc}")
         raise typer.Exit(2)
 
     expires_at = data.get("expires_at", "")
@@ -4681,7 +4681,7 @@ def curate_convert(
     )
 
     if format not in CONVERTER_REGISTRY:
-        console.print(
+        err_console.print(
             f"[red]Unknown format[/red] [cyan]{format}[/cyan]; available: "
             f"[cyan]{', '.join(sorted(CONVERTER_REGISTRY.keys()))}[/cyan]"
         )
@@ -4697,7 +4697,7 @@ def curate_convert(
         else:
             converter = CONVERTER_REGISTRY[format]()
     except Exception as exc:  # noqa: BLE001
-        console.print(f"[red]Failed to construct converter:[/red] {exc}")
+        err_console.print(f"[red]Failed to construct converter:[/red] {exc}")
         raise typer.Exit(2)
 
     try:
@@ -4708,13 +4708,13 @@ def curate_convert(
             canonical_only=canonical_only,
         )
     except ImportError as exc:
-        console.print(f"[red]Missing dependency:[/red] {exc}")
+        err_console.print(f"[red]Missing dependency:[/red] {exc}")
         raise typer.Exit(3)
     except NotImplementedError as exc:
         console.print(f"[yellow]Not yet implemented:[/yellow] {exc}")
         raise typer.Exit(4)
     except Exception as exc:  # noqa: BLE001
-        console.print(f"[red]Conversion failed:[/red] {exc}")
+        err_console.print(f"[red]Conversion failed:[/red] {exc}")
         raise typer.Exit(5)
 
     # Render summary table

--- a/src/reflex/models/vlas/pi0.py
+++ b/src/reflex/models/vlas/pi0.py
@@ -6,7 +6,10 @@ Lift #1 Day 4f per `features/03_export/basevla-spine_plan.md`. Wires:
         vision_backbone = SigLIPBackbone (extracted from paligemma.vision_tower)
         llm_backbone    = PaliGemmaBackbone (PaliGemma minus vision_tower)
         projector       = LinearProjector (state_proj)
-        vla_head        = FlowMatchingHead (wraps ExpertStack from build_pi0_expert_stack)
+        vla_head        = FlowMatchingHead (wraps Pi0ExpertStackWithPrefix from
+                          build_pi0_expert_with_prefix in exporters/pi0_prefix.py
+                          — prefix-concat variant used for inference, NOT the
+                          cross-attn build_pi0_expert_stack used by export_pi0)
     )
 
 The 4 component classes were added in Days 4a-e. This file wires them
@@ -88,8 +91,13 @@ class Pi0VLA(BaseVLA):
            it's no longer called at runtime) → PaliGemmaBackbone
         3. Builds projector from PaliGemma's `state_proj` weights if present,
            else random-init (parity tests will validate against checkpoint)
-        4. Builds the ExpertStack via `build_pi0_expert_stack(state_dict)`
-           → wraps as FlowMatchingHead
+        4. Builds the Pi0ExpertStackWithPrefix via
+           `build_pi0_expert_with_prefix(state_dict)` (from exporters/pi0_prefix.py)
+           → wraps as FlowMatchingHead. Note: this is the **prefix-concat**
+           variant used for end-to-end inference, distinct from the
+           cross-attn ExpertStack that `export_pi0` consumes via
+           `build_pi0_expert_stack`. The two share weights but differ in
+           attention pattern (every-layer prefix-K/V concat vs cross-attn).
         5. Returns Pi0VLA composed of the 4 components
 
         Args:

--- a/tests/test_cli_verb_noun.py
+++ b/tests/test_cli_verb_noun.py
@@ -33,13 +33,13 @@ class TestVisibleTopLevel:
     @pytest.mark.parametrize("cmd", ["serve", "doctor", "models", "train", "validate", "inspect"])
     def test_visible_top_level_command_exists(self, runner, cli_app, cmd):
         result = runner.invoke(cli_app, [cmd, "--help"])
-        assert result.exit_code == 0, f"{cmd} --help failed: {result.stdout}"
+        assert result.exit_code == 0, f"{cmd} --help failed: {result.output}"
 
     def test_help_lists_six_visible_commands(self, runner, cli_app):
         result = runner.invoke(cli_app, ["--help"])
         assert result.exit_code == 0
         for cmd in ("serve", "doctor", "models", "train", "validate", "inspect"):
-            assert cmd in result.stdout
+            assert cmd in result.output
 
     @pytest.mark.parametrize("hidden_cmd", [
         "export", "validate-legacy", "bench", "guard", "ros2-serve",
@@ -51,8 +51,8 @@ class TestVisibleTopLevel:
         # appear as natural-language words inside subgroup descriptions.
         import re
         result = runner.invoke(cli_app, ["--help"])
-        if "Commands" in result.stdout:
-            commands_section = result.stdout.split("Commands")[1].split("╰")[0]
+        if "Commands" in result.output:
+            commands_section = result.output.split("Commands")[1].split("╰")[0]
             row_pattern = re.compile(rf"│\s+{re.escape(hidden_cmd)}\s")
             assert not row_pattern.search(commands_section), (
                 f"{hidden_cmd!r} should be hidden but appears as a command row in --help"
@@ -63,28 +63,28 @@ class TestModelsSubgroup:
     @pytest.mark.parametrize("sub", ["list", "pull", "info", "export"])
     def test_models_subcommand_exists(self, runner, cli_app, sub):
         result = runner.invoke(cli_app, ["models", sub, "--help"])
-        assert result.exit_code == 0, result.stdout
+        assert result.exit_code == 0, result.output
 
 
 class TestTrainSubgroup:
     @pytest.mark.parametrize("sub", ["finetune", "distill"])
     def test_train_subcommand_exists(self, runner, cli_app, sub):
         result = runner.invoke(cli_app, ["train", sub, "--help"])
-        assert result.exit_code == 0, result.stdout
+        assert result.exit_code == 0, result.output
 
 
 class TestValidateSubgroup:
     @pytest.mark.parametrize("sub", ["dataset", "export"])
     def test_validate_subcommand_exists(self, runner, cli_app, sub):
         result = runner.invoke(cli_app, ["validate", sub, "--help"])
-        assert result.exit_code == 0, result.stdout
+        assert result.exit_code == 0, result.output
 
 
 class TestInspectSubgroup:
     @pytest.mark.parametrize("sub", ["bench", "replay", "targets", "guard", "doctor"])
     def test_inspect_subcommand_exists(self, runner, cli_app, sub):
         result = runner.invoke(cli_app, ["inspect", sub, "--help"])
-        assert result.exit_code == 0, result.stdout
+        assert result.exit_code == 0, result.output
 
 
 class TestBackwardCompatAliases:
@@ -93,7 +93,7 @@ class TestBackwardCompatAliases:
     def test_old_validate_dataset_still_callable(self, runner, cli_app):
         # Just `--help` to confirm the alias still routes correctly
         result = runner.invoke(cli_app, ["validate-dataset", "--help"])
-        assert result.exit_code == 0, result.stdout
+        assert result.exit_code == 0, result.output
 
     def test_old_bench_still_callable(self, runner, cli_app):
         result = runner.invoke(cli_app, ["bench", "--help"])

--- a/tests/test_curate_opt_in_cli.py
+++ b/tests/test_curate_opt_in_cli.py
@@ -27,13 +27,13 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def test_status_when_not_opted_in(runner: CliRunner, home: Path) -> None:
     result = runner.invoke(contribute_app, ["--status"])
     assert result.exit_code == 0
-    assert "not opted in" in result.stdout
+    assert "not opted in" in result.output
 
 
 def test_opt_in_creates_receipt(runner: CliRunner, home: Path) -> None:
     result = runner.invoke(contribute_app, ["--opt-in"])
-    assert result.exit_code == 0, result.stdout
-    assert "Opted in" in result.stdout
+    assert result.exit_code == 0, result.output
+    assert "Opted in" in result.output
     receipt = home / ".reflex" / "consent.json"
     assert receipt.exists()
     data = json.loads(receipt.read_text())
@@ -45,15 +45,15 @@ def test_opt_in_idempotent(runner: CliRunner, home: Path) -> None:
     runner.invoke(contribute_app, ["--opt-in"])
     result = runner.invoke(contribute_app, ["--opt-in"])
     assert result.exit_code == 0
-    assert "Already opted in" in result.stdout
+    assert "Already opted in" in result.output
 
 
 def test_status_shows_after_opt_in(runner: CliRunner, home: Path) -> None:
     runner.invoke(contribute_app, ["--opt-in"])
     result = runner.invoke(contribute_app, ["--status"])
     assert result.exit_code == 0
-    assert "opted in" in result.stdout
-    assert "free" in result.stdout
+    assert "opted in" in result.output
+    assert "free" in result.output
 
 
 def test_opt_out_removes_receipt(runner: CliRunner, home: Path) -> None:
@@ -63,13 +63,13 @@ def test_opt_out_removes_receipt(runner: CliRunner, home: Path) -> None:
     result = runner.invoke(contribute_app, ["--opt-out"])
     assert result.exit_code == 0
     assert not receipt.exists()
-    assert "Opted out" in result.stdout
+    assert "Opted out" in result.output
 
 
 def test_opt_out_idempotent(runner: CliRunner, home: Path) -> None:
     result = runner.invoke(contribute_app, ["--opt-out"])
     assert result.exit_code == 0
-    assert "Already opted out" in result.stdout
+    assert "Already opted out" in result.output
 
 
 def test_revoke_with_yes_flag(runner: CliRunner, home: Path) -> None:
@@ -79,23 +79,23 @@ def test_revoke_with_yes_flag(runner: CliRunner, home: Path) -> None:
     result = runner.invoke(contribute_app, ["--revoke", "--yes"])
     assert result.exit_code == 0
     assert not receipt.exists()
-    assert "Revocation submitted" in result.stdout
+    assert "Revocation submitted" in result.output
 
 
 def test_revoke_when_not_opted_in(runner: CliRunner, home: Path) -> None:
     result = runner.invoke(contribute_app, ["--revoke", "--yes"])
     assert result.exit_code == 0
-    assert "nothing to revoke" in result.stdout
+    assert "nothing to revoke" in result.output
 
 
 def test_info_shows_privacy(runner: CliRunner, home: Path) -> None:
     result = runner.invoke(contribute_app, ["--info"])
     assert result.exit_code == 0
-    assert "privacy" in result.stdout.lower()
-    assert "GDPR" in result.stdout or "revoke" in result.stdout.lower()
+    assert "privacy" in result.output.lower()
+    assert "GDPR" in result.output or "revoke" in result.output.lower()
 
 
 def test_mutually_exclusive_flags_rejected(runner: CliRunner, home: Path) -> None:
     result = runner.invoke(contribute_app, ["--opt-in", "--opt-out"])
     assert result.exit_code != 0
-    assert "Pick one" in result.stdout
+    assert "Pick one" in result.output

--- a/tests/test_distill_cli_integration.py
+++ b/tests/test_distill_cli_integration.py
@@ -47,9 +47,9 @@ class TestDistillCLI:
         app = self._get_app()
         result = runner.invoke(app, ["distill", "--help"])
         assert result.exit_code == 0
-        assert "--teacher-export" in result.stdout
-        assert "--libero-gate-pp" in result.stdout
-        assert "SnapFlow" in result.stdout
+        assert "--teacher-export" in result.output
+        assert "--libero-gate-pp" in result.output
+        assert "SnapFlow" in result.output
 
     def test_dry_run_exits_without_training(self, tmp_path):
         """With --dry-run the CLI should reach preflight and bail before
@@ -77,7 +77,7 @@ class TestDistillCLI:
                 ],
             )
         # Exit 0 on successful dry run; non-zero if preflight mocking missed.
-        assert result.exit_code == 0, result.stdout
+        assert result.exit_code == 0, result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -92,7 +92,7 @@ def test_eval_rejects_missing_export_dir(tmp_path):
         app, ["eval", str(tmp_path / "does-not-exist")],
     )
     assert result.exit_code == 1
-    assert "not found" in result.stdout.lower()
+    assert "not found" in result.output.lower()
 
 
 def test_eval_rejects_unknown_suite(fake_export):
@@ -100,7 +100,7 @@ def test_eval_rejects_unknown_suite(fake_export):
         app, ["eval", str(fake_export), "--suite", "fictional"],
     )
     assert result.exit_code == 2
-    assert "Unknown suite" in result.stdout
+    assert "Unknown suite" in result.output
 
 
 def test_eval_rejects_unknown_runtime(fake_export):
@@ -108,7 +108,7 @@ def test_eval_rejects_unknown_runtime(fake_export):
         app, ["eval", str(fake_export), "--runtime", "kubernetes"],
     )
     assert result.exit_code == 2
-    assert "Unknown runtime" in result.stdout
+    assert "Unknown runtime" in result.output
 
 
 def test_eval_rejects_zero_episodes(fake_export):
@@ -116,7 +116,7 @@ def test_eval_rejects_zero_episodes(fake_export):
         app, ["eval", str(fake_export), "--num-episodes", "0"],
     )
     assert result.exit_code == 2
-    assert "Invalid configuration" in result.stdout
+    assert "Invalid configuration" in result.output
 
 
 def test_eval_rejects_zero_max_parallel(fake_export):
@@ -124,7 +124,7 @@ def test_eval_rejects_zero_max_parallel(fake_export):
         app, ["eval", str(fake_export), "--max-parallel", "0"],
     )
     assert result.exit_code == 2
-    assert "Invalid configuration" in result.stdout
+    assert "Invalid configuration" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -139,11 +139,11 @@ def test_eval_prints_banner_with_inputs(fake_export, stub_preflight_pass, stub_m
               "--seed", "42", "--tasks", "libero_spatial,libero_object"],
     )
     # Stub runners produce all-adapter-error → exit 5; that's expected Day 3
-    assert "Reflex Eval" in result.stdout
-    assert "libero_spatial" in result.stdout
-    assert "libero_object" in result.stdout
-    assert "Seed:" in result.stdout
-    assert "42" in result.stdout
+    assert "Reflex Eval" in result.output
+    assert "libero_spatial" in result.output
+    assert "libero_object" in result.output
+    assert "Seed:" in result.output
+    assert "42" in result.output
 
 
 def test_eval_banner_marks_video_when_set(fake_export, stub_preflight_pass, stub_modal_runner):
@@ -152,8 +152,8 @@ def test_eval_banner_marks_video_when_set(fake_export, stub_preflight_pass, stub
     result = runner.invoke(
         app, ["eval", str(fake_export), "--video"],
     )
-    assert "Video:" in result.stdout
-    assert "Phase 2" in result.stdout
+    assert "Video:" in result.output
+    assert "Phase 2" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -179,7 +179,7 @@ def test_cost_preview_exits_clean_without_running_preflight(fake_export, monkeyp
         app, ["eval", str(fake_export), "--cost-preview", "--num-episodes", "5"],
     )
     assert result.exit_code == 0
-    assert "Cost preview" in result.stdout
+    assert "Cost preview" in result.output
     assert called["n"] == 0  # preflight skipped
 
 
@@ -191,8 +191,8 @@ def test_cost_preview_shows_dollar_total(fake_export):
     )
     assert result.exit_code == 0
     # 3 tasks × (10 × $0.025 + $0.10) = $1.05; surfaces as "$1.05"
-    assert "$1.05" in result.stdout or "$1.0" in result.stdout
-    assert "Total estimate" in result.stdout
+    assert "$1.05" in result.output or "$1.0" in result.output
+    assert "Total estimate" in result.output
 
 
 def test_cost_preview_uses_default_tasks_when_unspecified(fake_export):
@@ -202,9 +202,9 @@ def test_cost_preview_uses_default_tasks_when_unspecified(fake_export):
     )
     assert result.exit_code == 0
     # 4 tasks × (5 × $0.025 + $0.10) = $0.90
-    assert "$0.90" in result.stdout or "$0.9" in result.stdout
+    assert "$0.90" in result.output or "$0.9" in result.output
     # Banner echoes 4 tasks
-    assert "4 tasks" in result.stdout
+    assert "4 tasks" in result.output
 
 
 def test_cost_preview_local_runtime_is_zero(fake_export):
@@ -213,8 +213,8 @@ def test_cost_preview_local_runtime_is_zero(fake_export):
               "--runtime", "local", "--num-episodes", "100"],
     )
     assert result.exit_code == 0
-    assert "$0.00" in result.stdout
-    assert "Local" in result.stdout
+    assert "$0.00" in result.output
+    assert "Local" in result.output
 
 
 def test_cost_preview_warns_above_guardrail(fake_export):
@@ -226,7 +226,7 @@ def test_cost_preview_warns_above_guardrail(fake_export):
     )
     assert result.exit_code == 0
     # 20 tasks × (1000 × $0.025 + $0.10) = 20 × $25.10 = $502.00
-    assert "guardrail" in result.stdout.lower() or "$50" in result.stdout
+    assert "guardrail" in result.output.lower() or "$50" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -237,15 +237,15 @@ def test_cost_preview_warns_above_guardrail(fake_export):
 def test_eval_aborts_on_preflight_failure(fake_export, stub_preflight_fail):
     result = runner.invoke(app, ["eval", str(fake_export)])
     assert result.exit_code == 4
-    assert "Pre-flight FAILED" in result.stdout
-    assert "dep-version-conflict" in result.stdout
-    assert "robosuite==1.4.1" in result.stdout  # remediation surfaced
+    assert "Pre-flight FAILED" in result.output
+    assert "dep-version-conflict" in result.output
+    assert "robosuite==1.4.1" in result.output  # remediation surfaced
 
 
 def test_eval_continues_on_preflight_pass(fake_export, stub_preflight_pass, stub_modal_runner):
     result = runner.invoke(app, ["eval", str(fake_export)])
     # Pre-flight OK + Day 3 stub runners → exit 5 (all adapter_error)
-    assert "Pre-flight OK" in result.stdout
+    assert "Pre-flight OK" in result.output
     assert result.exit_code == 5
 
 
@@ -281,8 +281,8 @@ def test_day3_stub_runner_exits_5_on_all_adapter_error(fake_export, stub_preflig
               "--tasks", "libero_spatial", "--num-episodes", "2"],
     )
     assert result.exit_code == 5
-    assert "adapter_error" in result.stdout.lower()
-    assert "Day" in result.stdout  # mentions deferral
+    assert "adapter_error" in result.output.lower()
+    assert "Day" in result.output  # mentions deferral
 
 
 def test_day3_emits_per_task_table(fake_export, stub_preflight_pass, stub_modal_runner):
@@ -291,9 +291,9 @@ def test_day3_emits_per_task_table(fake_export, stub_preflight_pass, stub_modal_
               "--tasks", "libero_spatial,libero_object", "--num-episodes", "1"],
     )
     # Per-task table should render even on all-adapter-error
-    assert "Per-task results" in result.stdout
-    assert "libero_spatial" in result.stdout
-    assert "libero_object" in result.stdout
+    assert "Per-task results" in result.output
+    assert "libero_spatial" in result.output
+    assert "libero_object" in result.output
 
 
 def test_day3_creates_output_directory(fake_export, stub_preflight_pass, stub_modal_runner, tmp_path):
@@ -339,8 +339,8 @@ def test_tasks_csv_strips_whitespace(fake_export, stub_preflight_pass, stub_moda
               "--tasks", " libero_spatial , libero_object ",
               "--num-episodes", "1"],
     )
-    assert "libero_spatial" in result.stdout
-    assert "libero_object" in result.stdout
+    assert "libero_spatial" in result.output
+    assert "libero_object" in result.output
 
 
 def test_tasks_csv_drops_empty_entries(fake_export, stub_preflight_pass, stub_modal_runner):
@@ -350,8 +350,8 @@ def test_tasks_csv_drops_empty_entries(fake_export, stub_preflight_pass, stub_mo
               "--num-episodes", "1"],
     )
     # Both real tasks present in per-task table; no empty rows
-    assert "libero_spatial" in result.stdout
-    assert "libero_object" in result.stdout
+    assert "libero_spatial" in result.output
+    assert "libero_object" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_eval_preflight.py
+++ b/tests/test_eval_preflight.py
@@ -262,7 +262,7 @@ def test_run_handles_timeout_with_bytes_stderr(monkeypatch):
     result = PreflightSmokeTest.run(timeout_s=10)
     assert not result.passed
     assert result.stderr == "binary err"
-    assert result.output == "binary output"
+    assert result.stdout == "binary output"
 
 
 def test_run_handles_timeout_with_none_outputs(monkeypatch):
@@ -274,7 +274,7 @@ def test_run_handles_timeout_with_none_outputs(monkeypatch):
     result = PreflightSmokeTest.run(timeout_s=10)
     assert not result.passed
     assert result.failure_mode == "osmesa-compile-hang"
-    assert result.output == ""
+    assert result.stdout == ""
     assert result.stderr == ""
 
 

--- a/tests/test_eval_preflight.py
+++ b/tests/test_eval_preflight.py
@@ -262,7 +262,7 @@ def test_run_handles_timeout_with_bytes_stderr(monkeypatch):
     result = PreflightSmokeTest.run(timeout_s=10)
     assert not result.passed
     assert result.stderr == "binary err"
-    assert result.stdout == "binary output"
+    assert result.output == "binary output"
 
 
 def test_run_handles_timeout_with_none_outputs(monkeypatch):
@@ -274,7 +274,7 @@ def test_run_handles_timeout_with_none_outputs(monkeypatch):
     result = PreflightSmokeTest.run(timeout_s=10)
     assert not result.passed
     assert result.failure_mode == "osmesa-compile-hang"
-    assert result.stdout == ""
+    assert result.output == ""
     assert result.stderr == ""
 
 

--- a/tests/test_export_errors_to_stderr.py
+++ b/tests/test_export_errors_to_stderr.py
@@ -56,3 +56,30 @@ def test_cli_export_routes_errors_to_stderr_via_err_console():
 
     # The "Missing monolithic dep" message specifically must go to stderr.
     assert "err_console.print(f\"Missing monolithic dep: {exc}\"" in src
+
+
+def test_no_stdout_error_paints_remain_in_cli():
+    """Post-2026-05-22 sweep: zero `console.print(...[red]...)` calls remain
+    in cli.py. All error/warning paints route through `err_console.print`
+    so subprocess wrappers see them in stderr.
+
+    Regression-pin: catches a contributor accidentally adding a new
+    error path via `console.print` instead of `err_console.print`. Same
+    class of bug as the Day 7 modal_test_gr00t empty-stderr issue.
+    """
+    import re
+    from pathlib import Path
+
+    cli_path = Path(__file__).parent.parent / "src" / "reflex" / "cli.py"
+    src = cli_path.read_text()
+
+    # Match `console.print(...)` (NOT `err_console.print(...)`) calls
+    # that contain `[red]` markup somewhere in the args. The word-boundary
+    # negative lookbehind ensures `err_console.print` is excluded.
+    pattern = re.compile(r"(?<![a-zA-Z_])console\.print\([^()]*\[red\]", re.DOTALL)
+    matches = pattern.findall(src)
+    assert len(matches) == 0, (
+        f"Found {len(matches)} stdout error path(s) in cli.py — these must "
+        "route through `err_console.print` so subprocess wrappers see them "
+        "in stderr.\nFirst few: " + "\n".join(m[:120] for m in matches[:3])
+    )

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -307,6 +307,6 @@ class TestCliWiring:
         runner = CliRunner()
         result = runner.invoke(cli_app, ["finetune", "--help"])
         assert result.exit_code == 0
-        assert "base" in result.stdout.lower()
-        assert "dataset" in result.stdout.lower()
-        assert "output" in result.stdout.lower()
+        assert "base" in result.output.lower()
+        assert "dataset" in result.output.lower()
+        assert "output" in result.output.lower()

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -170,22 +170,22 @@ class TestCliList:
         assert result.exit_code == 0
         # Table should mention each model_id from the registry
         for e in REGISTRY:
-            assert e.model_id in result.stdout
+            assert e.model_id in result.output
 
     def test_models_list_filter_by_family(self, runner, cli_app):
         result = runner.invoke(cli_app, ["models", "list", "--family", "smolvla"])
         assert result.exit_code == 0
         # smolvla entries should show, pi0/pi05 should not
-        assert "smolvla-base" in result.stdout
+        assert "smolvla-base" in result.output
         # pi05-base is in pi05 family, should be filtered out
-        assert "pi05-base" not in result.stdout or "smolvla" in result.stdout.split("pi05-base")[0]
+        assert "pi05-base" not in result.output or "smolvla" in result.output.split("pi05-base")[0]
 
     def test_models_list_json(self, runner, cli_app):
         result = runner.invoke(cli_app, ["models", "list", "--format", "json"])
         assert result.exit_code == 0
         # Parse the JSON portion (rich may add trailing newlines but shouldn't change JSON)
         # Find the JSON block
-        body = json.loads(result.stdout)
+        body = json.loads(result.output)
         assert body["n"] == len(REGISTRY)
         assert len(body["models"]) == len(REGISTRY)
         ids = {m["model_id"] for m in body["models"]}
@@ -197,7 +197,7 @@ class TestCliList:
         # won't accidentally match a future addition either.
         result = runner.invoke(cli_app, ["models", "list", "--family", "nonexistent_family_xyz"])
         assert result.exit_code == 0
-        assert "No models match" in result.stdout
+        assert "No models match" in result.output
 
     def test_models_list_invalid_format(self, runner, cli_app):
         result = runner.invoke(cli_app, ["models", "list", "--format", "xml"])
@@ -208,13 +208,13 @@ class TestCliInfo:
     def test_info_human(self, runner, cli_app):
         result = runner.invoke(cli_app, ["models", "info", "pi05-base"])
         assert result.exit_code == 0
-        assert "pi05-base" in result.stdout
-        assert "lerobot/pi05_base" in result.stdout
+        assert "pi05-base" in result.output
+        assert "lerobot/pi05_base" in result.output
 
     def test_info_json(self, runner, cli_app):
         result = runner.invoke(cli_app, ["models", "info", "smolvla-base", "--format", "json"])
         assert result.exit_code == 0
-        body = json.loads(result.stdout)
+        body = json.loads(result.output)
         assert body["model_id"] == "smolvla-base"
         assert body["family"] == "smolvla"
         assert body["action_dim"] == 7
@@ -222,18 +222,18 @@ class TestCliInfo:
     def test_info_unknown_id_exit_2(self, runner, cli_app):
         result = runner.invoke(cli_app, ["models", "info", "nope-xyz"])
         assert result.exit_code == 2
-        assert "Unknown model_id" in result.stdout
+        assert "Unknown model_id" in result.output
 
 
 class TestCliPull:
     def test_pull_unknown_id_lists_available(self, runner, cli_app):
         result = runner.invoke(cli_app, ["models", "pull", "nope-xyz"])
         assert result.exit_code == 2
-        assert "Unknown model_id" in result.stdout
-        assert "Available registry ids:" in result.stdout
+        assert "Unknown model_id" in result.output
+        assert "Available registry ids:" in result.output
         # Should list every registered model
         for e in REGISTRY:
-            assert e.model_id in result.stdout
+            assert e.model_id in result.output
 
     def test_pull_calls_snapshot_download_with_repo_id(self, runner, cli_app, tmp_path):
         with patch("huggingface_hub.snapshot_download") as mock_dl:
@@ -241,7 +241,7 @@ class TestCliPull:
             (tmp_path / "fake").mkdir()
             (tmp_path / "fake" / "config.json").write_text("{}")
             result = runner.invoke(cli_app, ["models", "pull", "smolvla-base", "--target-dir", str(tmp_path / "fake")])
-        assert result.exit_code == 0, result.stdout
+        assert result.exit_code == 0, result.output
         mock_dl.assert_called_once()
         kwargs = mock_dl.call_args.kwargs
         assert kwargs["repo_id"] == "lerobot/smolvla_base"
@@ -251,7 +251,7 @@ class TestCliPull:
         with patch("huggingface_hub.snapshot_download", side_effect=RuntimeError("403 forbidden")):
             result = runner.invoke(cli_app, ["models", "pull", "smolvla-base", "--target-dir", str(tmp_path / "out")])
         assert result.exit_code == 1
-        assert "Download failed" in result.stdout
+        assert "Download failed" in result.output
 
     def test_pull_passes_revision_override(self, runner, cli_app, tmp_path):
         with patch("huggingface_hub.snapshot_download") as mock_dl:
@@ -275,5 +275,5 @@ class TestCliPull:
                 cli_app,
                 ["models", "pull", "pi05-base", "--target-dir", str(tmp_path / "out")],
             )
-        assert result.exit_code == 0, result.stdout
-        assert "reflex export" in result.stdout
+        assert result.exit_code == 0, result.output
+        assert "reflex export" in result.output

--- a/tests/test_one_command_deploy.py
+++ b/tests/test_one_command_deploy.py
@@ -177,50 +177,50 @@ def cli_app():
 class TestReflexGoCli:
     def test_visible_in_top_level_help(self, runner, cli_app):
         result = runner.invoke(cli_app, ["--help"])
-        assert "go" in result.stdout
+        assert "go" in result.output
 
     def test_help_describes_pipeline(self, runner, cli_app):
         result = runner.invoke(cli_app, ["go", "--help"])
         assert result.exit_code == 0
-        assert "probe" in result.stdout.lower() or "Probe" in result.stdout
-        assert "--model" in result.stdout
-        assert "--embodiment" in result.stdout
-        assert "--device-class" in result.stdout
-        assert "--dry-run" in result.stdout
+        assert "probe" in result.output.lower() or "Probe" in result.output
+        assert "--model" in result.output
+        assert "--embodiment" in result.output
+        assert "--device-class" in result.output
+        assert "--dry-run" in result.output
 
     def test_missing_model_exits_2(self, runner, cli_app):
         result = runner.invoke(cli_app, ["go"])
         assert result.exit_code == 2
-        assert "--model is required" in result.stdout
+        assert "--model is required" in result.output
 
     def test_unknown_device_class_exits_2(self, runner, cli_app):
         result = runner.invoke(cli_app, ["go", "--model", "pi05-libero", "--device-class", "bogus"])
         assert result.exit_code == 2
-        assert "--device-class" in result.stdout
+        assert "--device-class" in result.output
 
     def test_dry_run_resolves_without_pulling(self, runner, cli_app):
         result = runner.invoke(cli_app, [
             "go", "--model", "pi05-libero", "--device-class", "a10g", "--dry-run",
         ])
-        assert result.exit_code == 0, result.stdout
-        assert "DRY RUN" in result.stdout
-        assert "pi05-libero" in result.stdout
-        assert "a10g" in result.stdout
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        assert "pi05-libero" in result.output
+        assert "a10g" in result.output
 
     def test_dry_run_with_family_resolves(self, runner, cli_app):
         result = runner.invoke(cli_app, [
             "go", "--model", "smolvla", "--device-class", "orin_nano", "--dry-run",
         ])
-        assert result.exit_code == 0, result.stdout
-        assert "smolvla" in result.stdout
-        assert "DRY RUN" in result.stdout
+        assert result.exit_code == 0, result.output
+        assert "smolvla" in result.output
+        assert "DRY RUN" in result.output
 
     def test_dry_run_unknown_model_exits_2(self, runner, cli_app):
         result = runner.invoke(cli_app, [
             "go", "--model", "totally-unknown-model", "--device-class", "a10g", "--dry-run",
         ])
         assert result.exit_code == 2
-        assert "No registry entry" in result.stdout or "Unknown" in result.stdout
+        assert "No registry entry" in result.output or "Unknown" in result.output
 
     def test_pull_then_export_then_serve_for_requires_export_model(self, runner, cli_app, tmp_path, monkeypatch):
         # Empty target dir → snapshot_download runs.
@@ -254,8 +254,8 @@ class TestReflexGoCli:
         mock_dl.assert_called_once()
         assert mock_dl.call_args.kwargs["repo_id"] == "lerobot/smolvla_base"
         mock_export.assert_called_once()
-        assert "exporting:" in result.stdout
-        assert "export complete" in result.stdout
+        assert "exporting:" in result.output
+        assert "export complete" in result.output
 
     def test_cache_hit_skips_pull(self, runner, cli_app, tmp_path, monkeypatch):
         target = tmp_path / "cached"
@@ -277,7 +277,7 @@ class TestReflexGoCli:
                 "--device-class", "a10g",
                 "--target-dir", str(target),
             ])
-        assert "cache hit" in result.stdout
+        assert "cache hit" in result.output
         mock_dl.assert_not_called()
 
     def test_export_dep_missing_errors_with_monolithic_install_hint(self, runner, cli_app, tmp_path, monkeypatch):
@@ -298,6 +298,6 @@ class TestReflexGoCli:
                 "--device-class", "a10g",
                 "--target-dir", str(target),
             ])
-        assert result.exit_code == 2, result.stdout
-        assert "monolithic" in result.stdout
-        assert "pip install" in result.stdout
+        assert result.exit_code == 2, result.output
+        assert "monolithic" in result.output
+        assert "pip install" in result.output

--- a/tests/test_policy_versioning_cli.py
+++ b/tests/test_policy_versioning_cli.py
@@ -47,7 +47,7 @@ def test_policy_a_alone_fails(fake_export, fake_export_b):
         app, ["serve", str(fake_export), "--policy-a", str(fake_export)],
     )
     assert result.exit_code == 1
-    assert "must be set together" in result.stdout
+    assert "must be set together" in result.output
 
 
 def test_policy_b_alone_fails(fake_export, fake_export_b):
@@ -56,7 +56,7 @@ def test_policy_b_alone_fails(fake_export, fake_export_b):
         app, ["serve", str(fake_export), "--policy-b", str(fake_export_b)],
     )
     assert result.exit_code == 1
-    assert "must be set together" in result.stdout
+    assert "must be set together" in result.output
 
 
 def test_2policy_mutually_exclusive_with_shadow(fake_export, fake_export_b, tmp_path):
@@ -72,7 +72,7 @@ def test_2policy_mutually_exclusive_with_shadow(fake_export, fake_export_b, tmp_
         ],
     )
     assert result.exit_code == 1
-    assert "mutually exclusive" in result.stdout
+    assert "mutually exclusive" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -90,7 +90,7 @@ def test_2policy_requires_no_rtc(fake_export, fake_export_b):
         ],
     )
     assert result.exit_code == 1
-    assert "--no-rtc" in result.stdout
+    assert "--no-rtc" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -109,7 +109,7 @@ def test_split_negative_rejected(fake_export, fake_export_b):
         ],
     )
     assert result.exit_code == 1
-    assert "split_a_percent" in result.stdout
+    assert "split_a_percent" in result.output
 
 
 def test_split_over_hundred_rejected(fake_export, fake_export_b):
@@ -123,7 +123,7 @@ def test_split_over_hundred_rejected(fake_export, fake_export_b):
         ],
     )
     assert result.exit_code == 1
-    assert "split_a_percent" in result.stdout
+    assert "split_a_percent" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -141,8 +141,8 @@ def test_missing_policy_a_path_rejected(fake_export, fake_export_b, tmp_path):
         ],
     )
     assert result.exit_code == 1
-    assert "--policy-a" in result.stdout
-    assert "not found" in result.stdout
+    assert "--policy-a" in result.output
+    assert "not found" in result.output
 
 
 def test_missing_policy_b_path_rejected(fake_export, fake_export_b, tmp_path):
@@ -155,8 +155,8 @@ def test_missing_policy_b_path_rejected(fake_export, fake_export_b, tmp_path):
         ],
     )
     assert result.exit_code == 1
-    assert "--policy-b" in result.stdout
-    assert "not found" in result.stdout
+    assert "--policy-b" in result.output
+    assert "not found" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -185,8 +185,8 @@ def test_shadow_policy_logs_phase15_warning(fake_export, tmp_path, monkeypatch):
         ],
     )
     # The warning text should appear before SystemExit takes us out
-    assert "shadow-policy" in result.stdout.lower()
-    assert "phase 1.5" in result.stdout.lower() or "inert" in result.stdout.lower()
+    assert "shadow-policy" in result.output.lower()
+    assert "phase 1.5" in result.output.lower() or "inert" in result.output.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -215,5 +215,5 @@ def test_2policy_valid_combo_surfaces_active_banner(fake_export, fake_export_b, 
             "--no-rtc",
         ],
     )
-    assert "2-policy mode active" in result.stdout
-    assert "--no-rtc enforced" in result.stdout
+    assert "2-policy mode active" in result.output
+    assert "--no-rtc enforced" in result.output


### PR DESCRIPTION
## Summary

Three small post-v0.10.0 polish items bundled per request.

### 1. Docstring fix in `src/reflex/models/vlas/pi0.py`

Both the file-level docstring (line 9) and the `from_pretrained` docstring (line 91) said `build_pi0_expert_stack` — but the code actually calls `build_pi0_expert_with_prefix` from `reflex.exporters.pi0_prefix`. The two are genuinely different expert variants:

- **Pi0VLA inference** (`predict_action`) uses the prefix-concat variant from `build_pi0_expert_with_prefix`
- **`export_pi0` ONNX serialization** uses the cross-attn variant from `build_pi0_expert_stack`

The docstring now reflects this. Pi05VLA's docstrings were already correct.

### 2. Sweep 51 stdout-error paths → stderr in `src/reflex/cli.py`

Same class of bug as the Day 7 `reflex export gr00t` empty-stderr issue. PR #164 fixed only the `export()` command's ~3 paths; this sweep covers the remaining 51 across `chat`, `doctor`, `eval`, `models pull`, `models list`, `bench`, `validate`, etc.

New regression-pin test: `test_no_stdout_error_paints_remain_in_cli` greps for any `console.print(...)` call containing `[red]` markup (not `err_console.print(...)`). Asserts zero matches. Catches future contributors adding new stdout-routed error paths.

### 3. Migration guide for v0.9 → v0.10

New `docs/migration_v0.9_to_v0.10.md` covers the 5 module renames library users hit on import:

| v0.9 path | v0.10 path | Day |
|---|---|---|
| `reflex.exporters.pi0_exporter` | `reflex.exporters.pi0` | 11 |
| `reflex.exporters.smolvla_exporter` | `reflex.exporters.smolvla` | 11 |
| `reflex.exporters.gr00t_exporter` | `reflex.exporters.gr00t` | 11 |
| `reflex.exporters.openvla_exporter` | `reflex.exporters.openvla` | 8 |
| `reflex.exporters.pi0_prefix_exporter` | `reflex.exporters.pi0_prefix` | 9 |

Plus a bulk-sed snippet + a pointer to `docs/adding_a_vla.md` for the new spine composition path. CHANGELOG entry updated to link the guide.

## Test plan

- [x] `tests/test_export_errors_to_stderr.py` — 3/3 (incl. new regression-pin)
- [x] Spine tests across Days 4-12 — 96 pass / 0 fail (no regression)
- [x] `cli.py` imports cleanly post-sweep
- [ ] CI full suite (in flight)

Generated with [Claude Code](https://claude.com/claude-code)
