### PR TITLE
lift #3 day 2: prepare_inference_weights() duplicate-key detection + disk cache

### DIFF
--- a/src/reflex/models/_inference_weights_cache.py
+++ b/src/reflex/models/_inference_weights_cache.py
@@ -1,0 +1,160 @@
+"""Disk cache for `prepare_inference_weights()` output.
+
+Per ``features/01_serve/inference-only-weights_plan.md`` Day 2.
+
+Cache key is a 5-tuple stable hash over ``(model_id, checkpoint_sha,
+vla_type, reflex_version, torch_version)`` — any of these changing
+invalidates the cache. The cache file lives at
+``~/.cache/reflex/inference_weights/<hash>.pt`` and stores the flat
+dict via ``torch.save``.
+
+Why a five-tuple key (defensively wide):
+
+- ``model_id``: distinct models (`lerobot/pi05_libero_finetuned_v044`
+  vs base) hash differently.
+- ``checkpoint_sha``: fine-tuning produces a new checkpoint with new
+  weights; cache must invalidate. Caller passes the HF commit hash or
+  a local fingerprint.
+- ``vla_type``: composition class name (``Pi05VLA`` / ``GR00TVLA``).
+  Different VLAs use different slot prefixes; the flat dict shape
+  differs.
+- ``reflex_version``: refactors to the spine slot layout (e.g. a
+  hypothetical "split the projector into two slots" change) would
+  silently shape-mismatch a cached dict. Invalidate on version bump.
+- ``torch_version``: torch's tensor pickle format / dtype defaults
+  change across major versions. Cheap insurance.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+import torch
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+def _cache_dir() -> Path:
+    """Returns the ~/.cache/reflex/inference_weights/ directory (created on demand)."""
+    base = Path.home() / ".cache" / "reflex" / "inference_weights"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _model_hash(
+    model_id: str,
+    checkpoint_sha: str,
+    vla_type: str,
+    reflex_version: str | None = None,
+    torch_version: str | None = None,
+) -> str:
+    """Stable 16-hex-char hash of the 5-tuple cache key.
+
+    `reflex_version` and `torch_version` default to the current process'
+    values when not supplied — callers can pin them for tests.
+    """
+    if reflex_version is None:
+        from reflex import __version__ as reflex_version  # noqa: F811
+    if torch_version is None:
+        torch_version = torch.__version__
+
+    tup = (
+        f"model_id={model_id}|"
+        f"checkpoint_sha={checkpoint_sha}|"
+        f"vla_type={vla_type}|"
+        f"reflex_version={reflex_version}|"
+        f"torch_version={torch_version}"
+    )
+    h = hashlib.sha256(tup.encode("utf-8")).hexdigest()
+    return h[:16]
+
+
+def cache_path(
+    model_id: str,
+    checkpoint_sha: str,
+    vla_type: str,
+    *,
+    reflex_version: str | None = None,
+    torch_version: str | None = None,
+) -> Path:
+    """Resolve the cache file path for the given 5-tuple key.
+
+    Does NOT check whether the file exists — callers should use
+    ``load_or_build`` for that.
+    """
+    h = _model_hash(
+        model_id=model_id,
+        checkpoint_sha=checkpoint_sha,
+        vla_type=vla_type,
+        reflex_version=reflex_version,
+        torch_version=torch_version,
+    )
+    return _cache_dir() / f"{h}.pt"
+
+
+def load_or_build(
+    model_id: str,
+    checkpoint_sha: str,
+    vla_type: str,
+    builder: Callable[[], dict[str, torch.Tensor]],
+    *,
+    reflex_version: str | None = None,
+    torch_version: str | None = None,
+) -> dict[str, torch.Tensor]:
+    """Returns the cached flat-dict if present, else builds + caches it.
+
+    Args:
+        model_id: HF model id (e.g. ``"lerobot/pi05_libero_finetuned_v044"``).
+        checkpoint_sha: Stable fingerprint of the underlying checkpoint
+            (HF commit hash or local content hash). Required because two
+            checkpoints with the same ``model_id`` (fine-tune vs base)
+            must hash to different cache files.
+        vla_type: Composition class name (e.g. ``"Pi05VLA"``).
+        builder: Zero-arg callable that returns the flat dict to cache.
+            Typically a bound ``vla.prepare_inference_weights`` call.
+        reflex_version: Override reflex version (for tests).
+        torch_version: Override torch version (for tests).
+
+    Returns:
+        The flat ``{key: tensor}`` dict, either freshly built or read
+        from disk.
+    """
+    path = cache_path(
+        model_id=model_id,
+        checkpoint_sha=checkpoint_sha,
+        vla_type=vla_type,
+        reflex_version=reflex_version,
+        torch_version=torch_version,
+    )
+
+    if path.exists():
+        logger.info("inference-weights cache HIT: %s", path)
+        loaded = torch.load(path, map_location="cpu", weights_only=True)
+        if not isinstance(loaded, dict):
+            raise RuntimeError(
+                f"inference-weights cache at {path} is corrupted "
+                "(expected dict, got "
+                f"{type(loaded).__name__}). Delete to force rebuild."
+            )
+        return loaded
+
+    logger.info("inference-weights cache MISS: %s — building", path)
+    weights = builder()
+    if not isinstance(weights, dict):
+        raise TypeError(
+            f"builder() returned {type(weights).__name__}, expected dict[str, Tensor]"
+        )
+    torch.save(weights, path)
+    logger.info(
+        "inference-weights cache WROTE: %s (%d keys, %.1f MB)",
+        path, len(weights), path.stat().st_size / 1e6,
+    )
+    return weights
+
+
+__all__ = ["load_or_build", "cache_path"]

--- a/src/reflex/models/base_vla.py
+++ b/src/reflex/models/base_vla.py
@@ -308,6 +308,19 @@ class BaseVLA(ABC):
                 continue
             slot_prefix = f"{prefix}{slot}."
             sub_weights = component.prepare_triton(prefix=slot_prefix)
+            # Defensive against accidental prefix collision (Lift #3 Day 2
+            # spec). Silently letting one slot's weights overwrite another's
+            # would corrupt inference. The slot_prefix design SHOULD prevent
+            # this, but check anyway in case a user-supplied component
+            # forgets to use the prefix.
+            duplicates = set(flat) & set(sub_weights)
+            if duplicates:
+                raise ValueError(
+                    f"prepare_inference_weights: duplicate key(s) when "
+                    f"merging slot {slot!r}: {sorted(duplicates)[:5]}"
+                    + (f" (and {len(duplicates) - 5} more)" if len(duplicates) > 5 else "")
+                    + ". A component is not honoring the prefix kwarg."
+                )
             flat.update(sub_weights)
         return flat
 

--- a/tests/test_inference_weights_cache.py
+++ b/tests/test_inference_weights_cache.py
@@ -1,0 +1,149 @@
+"""Lift #3 Day 2 — disk cache for `prepare_inference_weights()` output.
+
+Per ``features/01_serve/inference-only-weights_plan.md`` Day 2.
+
+4 test cases per the plan spec.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from reflex.models._inference_weights_cache import cache_path, load_or_build
+
+
+@pytest.fixture
+def tmp_cache_dir(tmp_path, monkeypatch):
+    """Point the cache root at a fresh tmp dir for each test."""
+    monkeypatch.setattr(
+        "reflex.models._inference_weights_cache.Path.home",
+        classmethod(lambda cls: tmp_path),  # type: ignore[arg-type]
+    )
+    return tmp_path / ".cache" / "reflex" / "inference_weights"
+
+
+def _builder() -> dict[str, torch.Tensor]:
+    return {"foo.weight": torch.randn(4, 4), "bar.bias": torch.randn(8)}
+
+
+# ─── Cold build → warm read produces byte-identical dict ─────────────
+
+
+def test_cold_build_then_warm_read_is_byte_identical(tmp_cache_dir):
+    """First call builds the dict + writes to cache. Second call reads
+    from cache and returns byte-identical tensors."""
+    torch.manual_seed(42)
+    cold = load_or_build(
+        model_id="test/model",
+        checkpoint_sha="abc123",
+        vla_type="TestVLA",
+        builder=_builder,
+        reflex_version="0.10.0",
+        torch_version="2.5.0",
+    )
+
+    # 2nd call: same key tuple → reads from disk
+    def _bad_builder():
+        raise AssertionError("builder should NOT be called on cache hit")
+
+    warm = load_or_build(
+        model_id="test/model",
+        checkpoint_sha="abc123",
+        vla_type="TestVLA",
+        builder=_bad_builder,
+        reflex_version="0.10.0",
+        torch_version="2.5.0",
+    )
+
+    assert set(cold.keys()) == set(warm.keys())
+    for k in cold:
+        assert torch.equal(cold[k], warm[k]), f"key {k!r} differs between cold + warm"
+
+
+# ─── Cache invalidates on checkpoint_sha change ──────────────────────
+
+
+def test_cache_invalidates_on_checkpoint_sha_change(tmp_cache_dir):
+    """Different `checkpoint_sha` → different cache file → builder
+    runs again."""
+    builder_calls = {"n": 0}
+
+    def _counting_builder():
+        builder_calls["n"] += 1
+        return {"key": torch.randn(4)}
+
+    load_or_build(
+        model_id="test/model",
+        checkpoint_sha="sha_v1",
+        vla_type="TestVLA",
+        builder=_counting_builder,
+        reflex_version="0.10.0",
+        torch_version="2.5.0",
+    )
+    load_or_build(
+        model_id="test/model",
+        checkpoint_sha="sha_v2",  # CHANGED
+        vla_type="TestVLA",
+        builder=_counting_builder,
+        reflex_version="0.10.0",
+        torch_version="2.5.0",
+    )
+
+    assert builder_calls["n"] == 2, "builder should have been called twice (cache miss on different sha)"
+
+
+# ─── Cache invalidates on reflex_version change ──────────────────────
+
+
+def test_cache_invalidates_on_reflex_version_change(tmp_cache_dir):
+    """Reflex refactor that changes spine slot layout would silently
+    shape-mismatch a cached dict. Version bump must invalidate."""
+    builder_calls = {"n": 0}
+
+    def _counting_builder():
+        builder_calls["n"] += 1
+        return {"key": torch.randn(4)}
+
+    load_or_build(
+        model_id="test/model",
+        checkpoint_sha="abc123",
+        vla_type="TestVLA",
+        builder=_counting_builder,
+        reflex_version="0.10.0",
+        torch_version="2.5.0",
+    )
+    load_or_build(
+        model_id="test/model",
+        checkpoint_sha="abc123",
+        vla_type="TestVLA",
+        builder=_counting_builder,
+        reflex_version="0.11.0",  # CHANGED
+        torch_version="2.5.0",
+    )
+
+    assert builder_calls["n"] == 2, "version bump should invalidate cache"
+
+
+# ─── Cache file path matches the hash convention ─────────────────────
+
+
+def test_cache_path_is_hash_pt_file_under_inference_weights_dir(tmp_cache_dir):
+    """`cache_path(...)` returns ``~/.cache/reflex/inference_weights/<hash>.pt``.
+    The directory is created on demand."""
+    p = cache_path(
+        model_id="test/model",
+        checkpoint_sha="abc123",
+        vla_type="TestVLA",
+        reflex_version="0.10.0",
+        torch_version="2.5.0",
+    )
+    assert p.suffix == ".pt"
+    assert p.parent.name == "inference_weights"
+    assert p.parent.parent.name == "reflex"
+    assert p.parent.parent.parent.name == ".cache"
+    # Hash should be a 16-hex-char filename (per the implementation).
+    stem = p.stem
+    assert len(stem) == 16, f"expected 16-char hex stem, got {stem!r}"
+    assert all(c in "0123456789abcdef" for c in stem), f"non-hex char in stem: {stem!r}"

--- a/tests/test_prepare_inference_weights.py
+++ b/tests/test_prepare_inference_weights.py
@@ -1,0 +1,220 @@
+"""Lift #3 Day 2 — `BaseVLA.prepare_inference_weights()` composition tests.
+
+Per ``features/01_serve/inference-only-weights_plan.md`` Day 2. The
+method aggregates each bound slot's ``prepare_triton`` output into a
+single flat ``{key: tensor}`` dict, validating that no two slots'
+prefixes collide.
+
+5 test cases per the plan spec.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import torch
+import torch.nn as nn
+
+from reflex.models.base_vla import BaseVLA
+from reflex.models.heads import VLAHead
+from reflex.models.heads.flow_matching_head import FlowMatchingHead
+from reflex.models.llm import LLMBackbone
+from reflex.models.projectors.linear_projector import LinearProjector
+from reflex.models.vision import VisionBackbone
+from reflex.models.vlm import VLMBackbone
+
+
+# ─── Stubs for the spine slot classes ─────────────────────────────────
+# Each stub overrides `prepare_triton` with the canonical real-component
+# pattern (named_parameters() under prefix, detached + cloned).
+
+
+def _named_params_with_prefix(self, prefix: str = ""):
+    return {f"{prefix}{n}": p.detach().clone() for n, p in self.named_parameters()}
+
+
+class _StubVision(VisionBackbone, nn.Module):
+    def __init__(self) -> None:
+        nn.Module.__init__(self)
+        self.weight = nn.Parameter(torch.randn(4, 4))
+
+    def forward(self, images, *a, **kw):
+        return images
+
+    prepare_triton = _named_params_with_prefix
+
+
+class _StubLLM(LLMBackbone, nn.Module):
+    def __init__(self) -> None:
+        nn.Module.__init__(self)
+        self.fc = nn.Linear(4, 4)
+
+    def forward(self, *a, **kw):
+        return None
+
+    prepare_triton = _named_params_with_prefix
+
+
+class _StubVLM(VLMBackbone, nn.Module):
+    def __init__(self) -> None:
+        nn.Module.__init__(self)
+        self.fc = nn.Linear(8, 8)
+
+    def forward(self, *a, **kw):
+        return None
+
+    prepare_triton = _named_params_with_prefix
+
+
+class _StubHead(VLAHead, nn.Module):
+    def __init__(self) -> None:
+        nn.Module.__init__(self)
+        self.fc = nn.Linear(4, 4)
+
+    def forward(self, *a, **kw):
+        return None
+
+    prepare_triton = _named_params_with_prefix
+
+
+# ─── Tiny concrete BaseVLA for the test ──────────────────────────────
+
+
+class _TestPi0VLA(BaseVLA):
+    REQUIRED_SLOTS = ("vision_backbone", "llm_backbone", "projector", "vla_head")
+    OPTIONAL_SLOTS = ()
+
+    def forward(self, batch): ...
+    def predict_action(self, *args, **kwargs): ...
+
+
+class _TestGR00TVLA(BaseVLA):
+    """GR00T-style: vlm_backbone + vla_head only."""
+    REQUIRED_SLOTS = ("vlm_backbone", "vla_head")
+    OPTIONAL_SLOTS = ()
+
+    def forward(self, batch): ...
+    def predict_action(self, *args, **kwargs): ...
+
+
+# ─── Pi0-style composition: vision + llm + projector + head ──────────
+
+
+def test_pi0_style_composition_builds_flat_dict():
+    """4-slot VLA: each component's keys get nested under `{slot}.{...}`."""
+    head = FlowMatchingHead(expert_stack=nn.Linear(4, 4))
+    vla = _TestPi0VLA(
+        vision_backbone=_StubVision(),
+        llm_backbone=_StubLLM(),
+        projector=LinearProjector(in_dim=4, out_dim=4),
+        vla_head=head,
+    )
+    flat = vla.prepare_inference_weights()
+
+    # The 4 slot prefixes each appear in at least one key.
+    prefixes_seen = {k.split(".", 1)[0] for k in flat.keys()}
+    assert "vision_backbone" in prefixes_seen
+    assert "llm_backbone" in prefixes_seen
+    assert "projector" in prefixes_seen
+    assert "vla_head" in prefixes_seen
+
+
+def test_pi0_style_total_param_count_matches():
+    """Key count of the flat dict equals the sum of nn.Module
+    parameter counts across the 4 bound slots (modulo ABC base-class
+    no-ops which return {}).
+
+    For these stubs:
+      vision: 1 param (Parameter(4, 4))
+      llm: 2 params (fc.weight, fc.bias)
+      projector: 2 (linear.weight, linear.bias)
+      flow_matching_head wraps nn.Linear: 2 (expert_stack.weight, expert_stack.bias)
+    Total = 7.
+    """
+    head = FlowMatchingHead(expert_stack=nn.Linear(4, 4))
+    vla = _TestPi0VLA(
+        vision_backbone=_StubVision(),
+        llm_backbone=_StubLLM(),
+        projector=LinearProjector(in_dim=4, out_dim=4),
+        vla_head=head,
+    )
+    flat = vla.prepare_inference_weights()
+    assert len(flat) == 7, f"got {len(flat)} keys; full: {sorted(flat.keys())}"
+
+
+# ─── GR00T-style: vlm_backbone + vla_head only ───────────────────────
+
+
+def test_gr00t_style_only_2_slots():
+    """REQUIRED_SLOTS=(vlm_backbone, vla_head). All other slots None →
+    no entries for them in the flat dict."""
+    head = FlowMatchingHead(expert_stack=nn.Linear(4, 4))
+    vla = _TestGR00TVLA(
+        vlm_backbone=_StubVLM(),
+        vla_head=head,
+    )
+    flat = vla.prepare_inference_weights()
+
+    prefixes_seen = {k.split(".", 1)[0] for k in flat.keys()}
+    assert prefixes_seen == {"vlm_backbone", "vla_head"}, (
+        f"unexpected prefixes: {prefixes_seen}"
+    )
+    # No vision_backbone / llm_backbone / projector / text_encoder keys
+    forbidden = {"vision_backbone", "llm_backbone", "projector", "text_encoder"}
+    leaked = {k for k in flat.keys() if any(k.startswith(f + ".") for f in forbidden)}
+    assert not leaked, f"leaked unused-slot keys: {leaked}"
+
+
+# ─── Prefix collision: defensive raise on duplicate keys ─────────────
+
+
+def test_duplicate_key_detection_raises():
+    """A component that ignores the prefix kwarg would collide with
+    another slot. The merge step must raise — silent overwrite would
+    corrupt inference."""
+
+    class _BrokenVision(VisionBackbone, nn.Module):
+        """Ignores prefix, always returns same keys — collides at merge."""
+
+        def __init__(self) -> None:
+            nn.Module.__init__(self)
+            self.weight = nn.Parameter(torch.randn(4, 4))
+
+        def forward(self, images, *a, **kw):
+            return images
+
+        def prepare_triton(self, prefix: str = "") -> dict[str, torch.Tensor]:
+            # BUG: ignores prefix kwarg + returns exactly the key that
+            # FlowMatchingHead.prepare_triton would produce on a
+            # nn.Linear-wrapped expert_stack. When vla_head iterates,
+            # the merge step will find the collision.
+            return {"vla_head.expert_stack.weight": self.weight.detach().clone()}
+
+    head = FlowMatchingHead(expert_stack=nn.Linear(4, 4))
+    vla = _TestPi0VLA(
+        vision_backbone=_BrokenVision(),
+        llm_backbone=_StubLLM(),
+        projector=LinearProjector(in_dim=4, out_dim=4),
+        vla_head=head,
+    )
+    with pytest.raises(ValueError, match="duplicate key"):
+        vla.prepare_inference_weights()
+
+
+# ─── Empty composition: no slots → empty dict ────────────────────────
+
+
+def test_empty_composition_returns_empty_dict():
+    """A VLA with no slots bound (other than required-only) should
+    return an empty flat dict — used by VLAs where every slot is
+    populated with the base ABC no-op class."""
+
+    class _MinimalVLA(BaseVLA):
+        REQUIRED_SLOTS = ()
+        OPTIONAL_SLOTS = ()
+
+        def forward(self, batch): ...
+        def predict_action(self, *args, **kwargs): ...
+
+    flat = _MinimalVLA().prepare_inference_weights()
+    assert flat == {}


### PR DESCRIPTION
Per features/01_serve/inference-only-weights_plan.md Day 2.

- BaseVLA.prepare_inference_weights gains duplicate-key detection (defensive against components that ignore the prefix kwarg)
- New src/reflex/models/_inference_weights_cache.py — 5-tuple stable hash cache at ~/.cache/reflex/inference_weights/<hash>.pt
- 9 tests: 5 for composition + 4 for cache behavior (cold→warm bit-identical, invalidation on checkpoint_sha / reflex_version change, hash convention)

Local: 113 pass / 0 fail across Lift #3 Day 1-2 tests + spine regression.

Day 3 next: InferenceWeightsRuntime (the consumer that binds the flat dict to ORT IOBinding).

Generated with [Claude Code](https://claude.com/claude-code)