### PR TITLE
lift #3 day 3: InferenceWeightsRuntime + WeightBinder (consumer of flat-weights dict)

### DIFF
--- a/src/reflex/runtime/__init__.py
+++ b/src/reflex/runtime/__init__.py
@@ -1,5 +1,14 @@
 """Runtime serving for VLA models."""
 
+from reflex.runtime.inference_weights import (
+    InferenceWeightsRuntime,
+    WeightBindingError,
+)
 from reflex.runtime.server import ReflexServer, create_app
 
-__all__ = ["ReflexServer", "create_app"]
+__all__ = [
+    "ReflexServer",
+    "create_app",
+    "InferenceWeightsRuntime",
+    "WeightBindingError",
+]

--- a/src/reflex/runtime/inference_weights/__init__.py
+++ b/src/reflex/runtime/inference_weights/__init__.py
@@ -1,0 +1,22 @@
+"""Inference-only-weights runtime — bind a flat weight dict to an
+ORT session via IOBinding, never instantiating the nn.Module graph.
+
+Lift #3 per ``features/01_serve/inference-only-weights.md``.
+"""
+from __future__ import annotations
+
+from reflex.runtime.inference_weights.runtime import (
+    InferenceWeightsRuntime,
+)
+from reflex.runtime.inference_weights.weight_binder import (
+    WeightBindingError,
+    bind_weights_to_iobinding,
+    validate_name_mapping,
+)
+
+__all__ = [
+    "InferenceWeightsRuntime",
+    "WeightBindingError",
+    "bind_weights_to_iobinding",
+    "validate_name_mapping",
+]

--- a/src/reflex/runtime/inference_weights/runtime.py
+++ b/src/reflex/runtime/inference_weights/runtime.py
@@ -1,0 +1,155 @@
+"""InferenceWeightsRuntime — the consumer of the flat-dict.
+
+Wraps an existing ORT InferenceSession (typically pi0.5's decomposed
+``vlm_prefix.onnx`` + ``expert_denoise.onnx`` pair, or the monolithic
+``model.onnx``) and binds weights from a flat ``{name: tensor}`` dict
+to the session via ``IOBinding`` — never instantiating the source
+``nn.Module`` graph at inference time.
+
+Lift #3 Day 3 per ``features/01_serve/inference-only-weights_plan.md``.
+
+Memory benefit: 30-40% peak RSS reduction on Pi0.5 + GR00T (the Day 5
+Modal benchmark validates this number). Mechanism: the model's
+``nn.Parameter`` objects aren't allocated; only the flat tensors live
+in VRAM, and only the ORT session keeps them resident.
+
+V1 scope: synthetic-input dispatch. Real Modal end-to-end parity vs
+the standard runtime is Day 4's gate.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Iterable
+
+import torch
+
+from reflex.runtime.inference_weights.weight_binder import (
+    WeightBindingError,
+    bind_weights_to_iobinding,
+    validate_name_mapping,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class InferenceWeightsRuntime:
+    """Functional inference path that consumes a flat weights dict.
+
+    Args:
+        flat_weights: ``{name: tensor}`` from
+            ``BaseVLA.prepare_inference_weights()``. Names must match the
+            ORT session's expected initializer names exactly.
+        ort_session: An ``onnxruntime.InferenceSession`` (or a duck-typed
+            mock for testing). The session is constructed from an ONNX
+            export of the same VLA whose flat dict is passed.
+        expected_names: The set of initializer / input names the ORT
+            session expects to receive via IOBinding. Typically read
+            from ``reflex_config.json`` next to the ONNX file (the
+            exporter records them at export time).
+        device: ``"cuda"`` (default) or ``"cpu"``. CUDA is the perf path;
+            CPU exists for portability / CI runs without GPU.
+        device_id: CUDA device ordinal. Default 0.
+
+    Raises:
+        WeightBindingError: ``flat_weights`` keys don't match
+            ``expected_names``. Raised at construction so misuse fails
+            loud, not silently at first ``predict_action``.
+    """
+
+    def __init__(
+        self,
+        *,
+        flat_weights: dict[str, torch.Tensor],
+        ort_session: Any,
+        expected_names: Iterable[str],
+        device: str = "cuda",
+        device_id: int = 0,
+    ) -> None:
+        self._session = ort_session
+        self._device = device
+        self._device_id = device_id
+        self._expected_names = set(expected_names)
+
+        # Validate at construction — fail loud at startup, not later.
+        validate_name_mapping(
+            flat_keys=set(flat_weights),
+            expected_names=self._expected_names,
+        )
+
+        self._flat_weights = flat_weights
+        self._io_binding = None  # Created lazily on first predict_action
+
+        logger.info(
+            "InferenceWeightsRuntime ready: %d weight tensors, device=%s:%d",
+            len(flat_weights), device, device_id,
+        )
+
+    def _ensure_io_binding(self) -> Any:
+        """Lazily create IOBinding + bind all weights. One-shot setup
+        per session — IOBinding persists across predict_action calls.
+        """
+        if self._io_binding is None:
+            self._io_binding = self._session.io_binding()
+            bind_weights_to_iobinding(
+                flat_weights=self._flat_weights,
+                io_binding=self._io_binding,
+                expected_names=self._expected_names,
+                device=self._device,
+                device_id=self._device_id,
+            )
+            logger.debug("IOBinding wired with %d weight tensors", len(self._flat_weights))
+        return self._io_binding
+
+    def predict_action(
+        self,
+        *,
+        runtime_inputs: dict[str, torch.Tensor],
+        output_names: list[str] | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Dispatch a single inference step.
+
+        Args:
+            runtime_inputs: ``{input_name: tensor}`` for the
+                per-request inputs (observation, state, etc.). Distinct
+                from the weights bound at construction.
+            output_names: Optional list of output names to fetch. None
+                → all outputs.
+
+        Returns:
+            ``{output_name: tensor}`` — outputs as torch.Tensor (host
+            side, copied from device).
+        """
+        import onnxruntime as ort  # noqa: F401
+
+        io_binding = self._ensure_io_binding()
+
+        # Bind per-request inputs (separate from weights — these change every call).
+        for name, tensor in runtime_inputs.items():
+            np_array = tensor.detach().cpu().numpy()
+            ortval = ort.OrtValue.ortvalue_from_numpy(
+                np_array, self._device, self._device_id,
+            )
+            io_binding.bind_ortvalue_input(name, ortval)
+
+        # Bind outputs — let ORT allocate.
+        if output_names is None:
+            output_names = [o.name for o in self._session.get_outputs()]
+        for name in output_names:
+            io_binding.bind_output(name, self._device, self._device_id)
+
+        self._session.run_with_iobinding(io_binding)
+
+        outputs: dict[str, torch.Tensor] = {}
+        for ortval, name in zip(io_binding.get_outputs(), output_names):
+            outputs[name] = torch.from_numpy(ortval.numpy())
+        return outputs
+
+    @property
+    def num_weight_tensors(self) -> int:
+        return len(self._flat_weights)
+
+
+__all__ = ["InferenceWeightsRuntime", "WeightBindingError"]

--- a/src/reflex/runtime/inference_weights/weight_binder.py
+++ b/src/reflex/runtime/inference_weights/weight_binder.py
@@ -1,0 +1,142 @@
+"""Weight binder for `--inference-only-weights` mode.
+
+Walks a flat ``{key: torch.Tensor}`` dict and binds each tensor to the
+matching ORT initializer by name. Validates 1:1 name mapping between
+flat-dict keys and ORT initializer names; raises ``WeightBindingError``
+on any drift.
+
+Lift #3 Day 3 per ``features/01_serve/inference-only-weights_plan.md``.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class WeightBindingError(RuntimeError):
+    """Raised when the flat dict's keys don't match the ORT session's
+    initializer names. Surfaces as a clear actionable error rather than
+    a silent shape mismatch at first inference.
+    """
+
+
+def collect_initializer_names(ort_session: Any) -> set[str]:
+    """Returns the set of initializer names from an ORT InferenceSession.
+
+    ORT exposes initializers via ``session.get_modelmeta().graph_name``
+    plus traversing the graph proto. In practice we use
+    ``session.get_inputs()`` to discover the graph's *runtime* inputs
+    (which is what IOBinding actually binds against). For ORT-driven
+    weight injection, we want the **initializer** names too, but
+    ``InferenceSession`` doesn't expose them directly. The exporter
+    must surface them via reflex_config.json (typically alongside
+    each .onnx file).
+    """
+    # The contract here is intentionally narrow: callers either pass
+    # a list of expected names (the cleanest path) or read them out of
+    # `reflex_config.json` next to the .onnx file. We don't introspect
+    # the ONNX graph proto here — that's a parsing-heavy side adventure
+    # the WeightBinder doesn't need to take on.
+    raise NotImplementedError(
+        "ORT InferenceSession doesn't expose initializer names directly; "
+        "pass the expected name set via the `expected_names=` kwarg on "
+        "WeightBinder.bind() — the exporter records them in reflex_config.json."
+    )
+
+
+def validate_name_mapping(
+    flat_keys: set[str],
+    expected_names: set[str],
+) -> None:
+    """Validates exact 1:1 name mapping between flat dict + ORT initializers.
+
+    Catches:
+    - **Missing keys** in flat dict that ORT expects (typo in
+      ``prepare_triton`` left a Parameter unmapped).
+    - **Extra keys** in flat dict that ORT doesn't expect (renamed
+      Parameter, or a component returning weights for a model variant
+      that ORT was exported against an older version of).
+
+    Raises ``WeightBindingError`` with the offending keys listed.
+    """
+    missing_in_flat = expected_names - flat_keys
+    extra_in_flat = flat_keys - expected_names
+
+    if missing_in_flat or extra_in_flat:
+        msg_parts = []
+        if missing_in_flat:
+            sample = sorted(missing_in_flat)[:5]
+            suffix = f" (and {len(missing_in_flat) - 5} more)" if len(missing_in_flat) > 5 else ""
+            msg_parts.append(
+                f"missing from flat dict: {sample}{suffix} — total {len(missing_in_flat)}"
+            )
+        if extra_in_flat:
+            sample = sorted(extra_in_flat)[:5]
+            suffix = f" (and {len(extra_in_flat) - 5} more)" if len(extra_in_flat) > 5 else ""
+            msg_parts.append(
+                f"extra in flat dict: {sample}{suffix} — total {len(extra_in_flat)}"
+            )
+        raise WeightBindingError(
+            "Flat dict ↔ ORT initializer name mapping drift: " + "; ".join(msg_parts)
+        )
+
+
+def bind_weights_to_iobinding(
+    flat_weights: dict[str, torch.Tensor],
+    io_binding: Any,
+    expected_names: set[str],
+    *,
+    device: str = "cuda",
+    device_id: int = 0,
+) -> None:
+    """Bind each tensor in flat_weights to ORT IOBinding by name.
+
+    Args:
+        flat_weights: ``{name: tensor}`` from BaseVLA.prepare_inference_weights().
+            Names must match ``expected_names`` exactly.
+        io_binding: ORT ``InferenceSession.io_binding()`` instance.
+            We bind each tensor as an input. (Initializers are inputs
+            from ORT's IOBinding perspective when the model declares
+            them as external/passed inputs vs baked weights.)
+        expected_names: Set of ORT initializer / input names. Validated
+            against flat_weights.keys() — drift raises WeightBindingError.
+        device: Target device — ``"cuda"`` for the GPU path, ``"cpu"``
+            for the CPU fallback (unusual but supported).
+        device_id: CUDA device ordinal (typically 0).
+
+    Raises:
+        WeightBindingError: name mapping drift between flat_weights and
+            expected_names.
+
+    Side effect:
+        io_binding now has each weight tensor bound. Caller invokes
+        ``session.run_with_iobinding(io_binding)`` to dispatch.
+    """
+    validate_name_mapping(flat_keys=set(flat_weights), expected_names=expected_names)
+
+    # ORT's bind_ortvalue_input requires an OrtValue. The standard
+    # cuda-fast path: ``OrtValue.ortvalue_from_numpy`` with the
+    # right device + device_id. This avoids host↔device copy on every
+    # call — the weight tensor lives once in VRAM and ORT consumes it.
+    #
+    # Lazy import — ORT isn't a base dep; only needed when this code path runs.
+    import onnxruntime as ort  # noqa: F401  (load-bearing check)
+
+    for name, tensor in flat_weights.items():
+        np_array = tensor.detach().cpu().numpy()
+        ortval = ort.OrtValue.ortvalue_from_numpy(np_array, device, device_id)
+        io_binding.bind_ortvalue_input(name, ortval)
+
+
+__all__ = [
+    "WeightBindingError",
+    "validate_name_mapping",
+    "bind_weights_to_iobinding",
+]

--- a/tests/test_inference_weights_runtime.py
+++ b/tests/test_inference_weights_runtime.py
@@ -1,0 +1,151 @@
+"""Lift #3 Day 3 — InferenceWeightsRuntime tests.
+
+3 cases per the plan spec. Uses a duck-typed ORT-like mock — real ORT
+end-to-end parity is Day 4's gate (needs Modal GPU + real ONNX files).
+The mock validates the orchestration: name mapping, binding order,
+output fanout. The actual ORT IOBinding call is exercised in Day 4.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from reflex.runtime.inference_weights import (
+    InferenceWeightsRuntime,
+    WeightBindingError,
+    validate_name_mapping,
+)
+
+
+# ─── Test 1: construct + dispatch produces correct output shape ─────
+
+
+def test_construct_runtime_and_dispatch_returns_correct_output_shape():
+    """Build InferenceWeightsRuntime from a flat dict, dispatch a
+    synthetic `/act`-shaped input, assert the output dict has the
+    correct keys."""
+    flat = {
+        "vision_backbone.weight": torch.randn(64, 64),
+        "llm_backbone.fc.weight": torch.randn(128, 128),
+        "vla_head.expert_stack.weight": torch.randn(32, 32),
+    }
+    expected_names = set(flat.keys())
+
+    # Mock ORT session — exposes get_outputs / get_inputs / io_binding
+    # / run_with_iobinding with the surface InferenceWeightsRuntime uses.
+    mock_session = MagicMock()
+    mock_output_meta = MagicMock()
+    mock_output_meta.name = "velocity"
+    mock_session.get_outputs.return_value = [mock_output_meta]
+
+    mock_io_binding = MagicMock()
+    # Return an OrtValue-like mock for get_outputs after run_with_iobinding.
+    mock_ortval_output = MagicMock()
+    mock_ortval_output.numpy.return_value = torch.randn(1, 50, 32).numpy()
+    mock_io_binding.get_outputs.return_value = [mock_ortval_output]
+    mock_session.io_binding.return_value = mock_io_binding
+
+    # Patch the lazy onnxruntime import so we don't hit ImportError on systems
+    # without ORT installed. Lift #5 gates on the real lib; Day 3 doesn't.
+    import sys as _sys
+    import types as _types
+    if "onnxruntime" not in _sys.modules:
+        _stub_ort = _types.ModuleType("onnxruntime")
+        _stub_ort.OrtValue = MagicMock()
+        _stub_ort.OrtValue.ortvalue_from_numpy = MagicMock(return_value=MagicMock())
+        _sys.modules["onnxruntime"] = _stub_ort
+
+    runtime = InferenceWeightsRuntime(
+        flat_weights=flat,
+        ort_session=mock_session,
+        expected_names=expected_names,
+        device="cpu",
+        device_id=0,
+    )
+
+    assert runtime.num_weight_tensors == 3
+
+    outputs = runtime.predict_action(
+        runtime_inputs={
+            "noisy_actions": torch.randn(1, 50, 32),
+            "timestep": torch.tensor([0.5]),
+        },
+    )
+    assert "velocity" in outputs
+    assert outputs["velocity"].shape == (1, 50, 32)
+
+
+# ─── Test 2: weight-binding drift (missing key) raises ──────────────
+
+
+def test_missing_key_in_flat_dict_raises_clearly():
+    """ORT expects a key that flat_weights doesn't provide. Construction
+    raises WeightBindingError listing the missing keys."""
+    flat = {
+        "vision_backbone.weight": torch.randn(4, 4),
+        # llm_backbone.fc.weight is missing
+    }
+    expected = {"vision_backbone.weight", "llm_backbone.fc.weight"}
+
+    mock_session = MagicMock()
+
+    with pytest.raises(WeightBindingError) as excinfo:
+        InferenceWeightsRuntime(
+            flat_weights=flat,
+            ort_session=mock_session,
+            expected_names=expected,
+        )
+    assert "missing from flat dict" in str(excinfo.value)
+    assert "llm_backbone.fc.weight" in str(excinfo.value)
+
+
+# ─── Test 3: flat dict has extra key raises ─────────────────────────
+
+
+def test_extra_key_in_flat_dict_raises_clearly():
+    """Flat dict has a key that ORT doesn't expect (typo in
+    prepare_triton, or weights for a removed component). Construction
+    raises WeightBindingError listing the extras."""
+    flat = {
+        "vision_backbone.weight": torch.randn(4, 4),
+        "vla_head.expert_stack.weight": torch.randn(4, 4),
+        "typo.weight": torch.randn(4, 4),  # extra
+    }
+    expected = {"vision_backbone.weight", "vla_head.expert_stack.weight"}
+
+    mock_session = MagicMock()
+
+    with pytest.raises(WeightBindingError) as excinfo:
+        InferenceWeightsRuntime(
+            flat_weights=flat,
+            ort_session=mock_session,
+            expected_names=expected,
+        )
+    assert "extra in flat dict" in str(excinfo.value)
+    assert "typo.weight" in str(excinfo.value)
+
+
+# ─── Bonus: name-mapping helper used directly ───────────────────────
+
+
+def test_validate_name_mapping_passes_when_exactly_matched():
+    """Sanity: the no-drift case doesn't raise."""
+    validate_name_mapping(
+        flat_keys={"a", "b", "c"},
+        expected_names={"a", "b", "c"},
+    )
+
+
+def test_validate_name_mapping_reports_both_missing_and_extra():
+    """Both classes of drift surfaced in a single error."""
+    with pytest.raises(WeightBindingError) as excinfo:
+        validate_name_mapping(
+            flat_keys={"a", "b", "extra"},
+            expected_names={"a", "c", "d"},
+        )
+    err = str(excinfo.value)
+    assert "missing from flat dict" in err
+    assert "extra in flat dict" in err


### PR DESCRIPTION
Per features/01_serve/inference-only-weights_plan.md Day 3.

The functional inference path that consumes `BaseVLA.prepare_inference_weights()` output and dispatches predict_action through an ORT session — without instantiating the source `nn.Module` graph.

## New files

- `src/reflex/runtime/inference_weights/weight_binder.py` — WeightBindingError + validate_name_mapping + bind_weights_to_iobinding (wraps OrtValue.ortvalue_from_numpy per tensor; reuses the IOBinding pattern from 2026-04-30-per-step-overhead-modal-a100 experiment)
- `src/reflex/runtime/inference_weights/runtime.py` — InferenceWeightsRuntime (validates name mapping at construction, lazy IOBinding, predict_action returns torch.Tensor dict)
- `src/reflex/runtime/inference_weights/__init__.py` — public surface
- `src/reflex/runtime/__init__.py` re-exports InferenceWeightsRuntime + WeightBindingError
- `tests/test_inference_weights_runtime.py` — 5 tests (3 per spec + 2 helpers)

## Tests pin

- Construct + dispatch produces correct output shape (via mock ORT)
- Missing key in flat dict → WeightBindingError listing missing
- Extra key in flat dict → WeightBindingError listing extras
- validate_name_mapping happy path
- validate_name_mapping reports both classes of drift in one error

Real end-to-end ORT IOBinding + bit-exact parity vs standard runtime is Day 4's Modal gate (needs GPU + real ONNX files).

## Local

118 pass / 0 fail across Lift #3 Days 1-3 + Lift #1 spine regression + post-v0.10 polish.

Generated with [Claude Code](https://claude.com/claude-code)