### PR TITLE
fix(modal): force onnxruntime-gpu install for inference_weights_parity (CUDA EP fix)

### DIFF
--- a/scripts/modal_inference_weights_parity.py
+++ b/scripts/modal_inference_weights_parity.py
@@ -51,11 +51,16 @@ image = (
         "torch", "safetensors>=0.4.0", "huggingface_hub",
         "transformers<5.4,>=4.40",
         "numpy", "Pillow", "pydantic>=2.0", "pyyaml",
-        "onnx>=1.16", "onnxruntime-gpu>=1.20", "onnxscript>=0.1",
+        "onnx>=1.16", "onnxscript>=0.1",
         "typer", "rich",
     )
     .run_commands(
+        # reflex-vla first (may pull plain onnxruntime as transitive)
         f'pip install "reflex-vla @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/reflex-vla@{_HEAD}"',
+        # Force GPU build (uninstall plain ORT first to avoid the silent
+        # CUDAExecutionProvider-unavailable failure we hit on first fire).
+        "pip uninstall -y onnxruntime || true",
+        "pip install --force-reinstall 'onnxruntime-gpu>=1.20'",
         secrets=[modal.Secret.from_name("github-token")],
     )
 )


### PR DESCRIPTION
First fire of `scripts/modal_inference_weights_parity.py` hit `CUDA Provider not available` at `OrtValue.ortvalue_from_numpy(..., 'cuda', 0)`. Cause: `pip install reflex-vla` pulled plain `onnxruntime` as a transitive override of the `onnxruntime-gpu>=1.20` requested in the image's pip_install.

Fix: uninstall plain ORT after reflex-vla, force-reinstall `onnxruntime-gpu`. Same pattern as prior Modal scripts in the repo that hit this collision.

Re-fire in flight (bg job `by3tqxgqa`).

Generated with [Claude Code](https://claude.com/claude-code)