### PR TITLE
lift #3 day 5: pivot RSS bench to from_lerobot_policy

### DIFF
--- a/scripts/modal_inference_weights_rss.py
+++ b/scripts/modal_inference_weights_rss.py
@@ -103,7 +103,8 @@ def run_rss_benchmark(model_id: str = "lerobot/pi05_libero_finetuned_v044"):
     # prereq #1 PR #173). Both PATH A and PATH B reload from this baseline.
     def _load_pi05_policy():
         # Lazy import — lerobot is an [rtc] extra, not a base dep.
-        from lerobot.common.policies.pi05.modeling_pi05 import PI05Policy
+        # Modern lerobot uses lerobot.policies.* (no .common.* in the path).
+        from lerobot.policies.pi05.modeling_pi05 import PI05Policy
         policy = PI05Policy.from_pretrained(model_id)
         policy.to(dtype=torch.float32).to("cpu")
         return policy

--- a/scripts/modal_inference_weights_rss.py
+++ b/scripts/modal_inference_weights_rss.py
@@ -57,8 +57,9 @@ image = (
         "torch", "safetensors>=0.4.0", "huggingface_hub",
         "transformers<5.4,>=4.40",
         "numpy", "Pillow", "pydantic>=2.0", "pyyaml",
-        "onnx>=1.16", "onnxruntime-gpu>=1.20", "onnxscript>=0.1",
+        "onnx>=1.16", "onnxscript>=0.1",
         "psutil", "typer", "rich",
+        "lerobot==0.5.1",  # for PI05Policy in from_lerobot_policy
     )
     .run_commands(
         f'pip install "reflex-vla @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/reflex-vla@{_HEAD}"',
@@ -97,42 +98,45 @@ def run_rss_benchmark(model_id: str = "lerobot/pi05_libero_finetuned_v044"):
     rss_initial = _rss_mb()
     print(f"[rss] Initial RSS: {rss_initial:.1f} MB")
 
-    # ─── PATH A: standard nn.Module instantiation ───────────────
-    print("\n[rss] PATH A: standard nn.Module residency")
+    # Load the lerobot policy ONCE — this is the working loader path for
+    # real lerobot/pi05_* checkpoints (per the from_lerobot_policy fix in
+    # prereq #1 PR #173). Both PATH A and PATH B reload from this baseline.
+    def _load_pi05_policy():
+        # Lazy import — lerobot is an [rtc] extra, not a base dep.
+        from lerobot.common.policies.pi05.modeling_pi05 import PI05Policy
+        policy = PI05Policy.from_pretrained(model_id)
+        policy.to(dtype=torch.float32).to("cpu")
+        return policy
+
+    # ─── PATH A: standard nn.Module residency ────────────────────
+    print("\n[rss] PATH A: standard nn.Module residency (Pi05VLA via from_lerobot_policy)")
     t0 = time.time()
-    from reflex.checkpoint import load_checkpoint
-    state_dict, _ = load_checkpoint(model_id)
-    print(f"[rss]   state_dict loaded ({len(state_dict)} tensors) in {time.time()-t0:.1f}s, RSS={_rss_mb():.1f} MB")
+    policy = _load_pi05_policy()
+    rss_after_policy = _rss_mb()
+    print(f"[rss]   policy loaded in {time.time()-t0:.1f}s, RSS={rss_after_policy:.1f} MB")
 
     from reflex.models.vlas.pi05 import Pi05VLA
     t0 = time.time()
-    vla = Pi05VLA.from_pretrained(state_dict=state_dict)
+    vla = Pi05VLA.from_lerobot_policy(policy)
     rss_after_module = _rss_mb()
     print(f"[rss]   Pi05VLA instantiated in {time.time()-t0:.1f}s, RSS={rss_after_module:.1f} MB")
 
-    # Drop the state_dict to isolate the cost of the nn.Module graph.
-    del state_dict
-    gc.collect()
-    rss_after_drop = _rss_mb()
-    print(f"[rss]   after dropping state_dict, RSS={rss_after_drop:.1f} MB")
-
-    # PATH A peak: nn.Module + (transient) state_dict at load time.
-    peak_a = max(rss_after_module, rss_after_drop)
+    # PATH A peak: nn.Module + the source lerobot policy (both resident).
+    peak_a = max(rss_after_policy, rss_after_module)
     print(f"[rss] PATH A peak RSS: {peak_a:.1f} MB")
 
     # Free PATH A before measuring PATH B.
     del vla
+    del policy
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
     rss_after_a_free = _rss_mb()
     print(f"[rss]   after freeing PATH A, RSS={rss_after_a_free:.1f} MB")
 
-    # ─── PATH B: inference-only-weights ─────────────────────────
+    # ─── PATH B: inference-only-weights (flat dict + drop module) ─
     print("\n[rss] PATH B: inference-only-weights (flat dict, no nn.Module residence)")
-    t0 = time.time()
-    state_dict, _ = load_checkpoint(model_id)
-    vla_b = Pi05VLA.from_pretrained(state_dict=state_dict)
+    vla_b = Pi05VLA.from_lerobot_policy(policy)
     rss_after_b_module = _rss_mb()
     print(f"[rss]   built nn.Module (transient) in {time.time()-t0:.1f}s, RSS={rss_after_b_module:.1f} MB")
 
@@ -141,14 +145,14 @@ def run_rss_benchmark(model_id: str = "lerobot/pi05_libero_finetuned_v044"):
     rss_after_flat = _rss_mb()
     print(f"[rss]   flat-dict ({len(flat)} tensors) built in {time.time()-t0:.1f}s, RSS={rss_after_flat:.1f} MB")
 
-    # The win comes from dropping the nn.Module after extracting the flat dict.
+    # The win comes from dropping the nn.Module + source policy after extracting the flat dict.
     del vla_b
-    del state_dict
+    del policy
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
     rss_after_drop_b = _rss_mb()
-    print(f"[rss]   after dropping nn.Module + state_dict, RSS={rss_after_drop_b:.1f} MB")
+    print(f"[rss]   after dropping nn.Module + policy, RSS={rss_after_drop_b:.1f} MB")
 
     peak_b = rss_after_drop_b
     print(f"[rss] PATH B steady RSS (flat dict only): {peak_b:.1f} MB")

--- a/scripts/modal_inference_weights_rss.py
+++ b/scripts/modal_inference_weights_rss.py
@@ -137,6 +137,8 @@ def run_rss_benchmark(model_id: str = "lerobot/pi05_libero_finetuned_v044"):
 
     # ─── PATH B: inference-only-weights (flat dict + drop module) ─
     print("\n[rss] PATH B: inference-only-weights (flat dict, no nn.Module residence)")
+    t0 = time.time()
+    policy = _load_pi05_policy()  # PATH A's policy was freed; reload for B
     vla_b = Pi05VLA.from_lerobot_policy(policy)
     rss_after_b_module = _rss_mb()
     print(f"[rss]   built nn.Module (transient) in {time.time()-t0:.1f}s, RSS={rss_after_b_module:.1f} MB")

--- a/src/reflex/models/vlas/pi0.py
+++ b/src/reflex/models/vlas/pi0.py
@@ -192,7 +192,7 @@ class Pi0VLA(BaseVLA):
         pattern to a first-class spine API.
 
         Args:
-            policy: A constructed ``lerobot.common.policies.pi0.modeling_pi0.PI0Policy``
+            policy: A constructed ``lerobot.policies.pi0.modeling_pi0.PI0Policy``
                 instance. Typically loaded via
                 ``PI0Policy.from_pretrained("lerobot/pi0_base")`` + cast
                 to fp32 + cpu before passing in.

--- a/src/reflex/models/vlas/pi05.py
+++ b/src/reflex/models/vlas/pi05.py
@@ -142,7 +142,7 @@ class Pi05VLA(BaseVLA):
         prereq #1 promotes it to a first-class spine API.
 
         Args:
-            policy: A constructed ``lerobot.common.policies.pi05.modeling_pi05.PI05Policy``
+            policy: A constructed ``lerobot.policies.pi05.modeling_pi05.PI05Policy``
                 instance. Typically loaded via
                 ``PI05Policy.from_pretrained("lerobot/pi05_libero_finetuned_v044")``
                 + cast to fp32 + cpu before passing in.


### PR DESCRIPTION
Day 5 RSS benchmark blocked on a known-broken `Pi05VLA.from_pretrained` path. Prereq #1 (PR #173 merged) added `from_lerobot_policy` which is the working loader for real lerobot/pi05_* checkpoints.

This PR pivots the RSS bench to use the new loader and **fires it** — the result is honest data, not a happy verdict:

## Result (Modal A100-40GB, run `ap-hTvbVc4PkemE8oMpIx4qyK`)

```
PATH A peak: 26,603 MB  (standard, nn.Module + source policy resident)
PATH B peak: 30,771 MB  (flat dict from prepare_inference_weights, source dropped)
Delta:       -4,168 MB (-15.7%)  ← FAIL — gate is +30%
```

## Why it failed (architectural finding, not bench bug)

The Lift #3 plan claims 30-40% RSS reduction with mechanism "the model's nn.Parameter objects aren't allocated; only the flat tensors live in VRAM." That requires a **safetensors → flat-dict direct loader** that bypasses `nn.Module` entirely.

What Days 1-3 actually shipped: extract a flat dict from a loaded `nn.Module` via `.detach().clone()` (the clone protects against silent-corruption per Day 1's aliasing-safety contract). This pipeline:
1. Loads nn.Module (~26 GB)
2. Clones weights into flat dict (+4 GB)
3. Drops nn.Module (-12 GB but clone stays)

Net: PATH B is WORSE than PATH A. Reverting to `.detach()` (alias storage) would shave a few GB but breaks the Lift #5 IOBinding contract.

## What this PR still contributes

- Modal harness for future RSS measurements (when the safetensors-direct loader lands as Lift #5 prereq)
- `lerobot.policies.*` import path fix (was `lerobot.common.policies.*`)
- 3 incremental fixes (CUDA EP missing → import path → UnboundLocalError → result)

## Honest next steps

Per the experiment note at `reflex_context/03_experiments/2026-05-22-lift3-rss-bench-FAIL-architectural-finding.md`:

- **Lift #3 substrate** (Days 1-3: prepare_triton + cache + InferenceWeightsRuntime + WeightBinder) IS valuable for Lift #5 Triton kernel binding. The IOBinding consumer side is built.
- **Lift #3's 30% RSS claim** needs a direct-loader implementation (Lift #5 prereq, multi-day) OR claim revision down.
- **Day 4 bit-exact parity gate** as specified needs external-weights ONNX export — also Lift #5 prereq, also re-scoped.

Recommend: leave this PR open for visibility on the architectural finding; merge if the bench harness is worth keeping in main; close if not. The substrate work in #168-173 stands regardless.