### PR TITLE
lift #8: Aloha + UR3 ROS2 adapter starter kits (contrib/)

### DIFF
--- a/contrib/ros2/README.md
+++ b/contrib/ros2/README.md
@@ -1,0 +1,54 @@
+# ROS2 Robot Adapter Starter Kits
+
+**Fork-and-customize** adapters for running Reflex VLA on real robots via ROS2.
+These are NOT part of the core `pip install reflex-vla` — they live in `contrib/`
+and you're expected to adapt them to your specific robot setup.
+
+## Available Adapters
+
+| Robot | Directory | Cameras | Action Space |
+|---|---|---|---|
+| **Aloha** (Trossen/ALOHA 2) | `contrib/ros2/aloha/` | 3 cameras (cam_high, cam_left_wrist, cam_right_wrist) | Bimanual joint positions (14 DOF) |
+| **UR3/UR5** (Universal Robots) | `contrib/ros2/ur3/` | Configurable | 6 DOF joint + gripper |
+
+## Quick Start
+
+```bash
+# 1. Start reflex serve on a GPU machine
+reflex serve ./my_export/ --transport zmq --port 5555
+
+# 2. On the robot (ROS2 machine), run the adapter
+cd contrib/ros2/aloha/
+ros2 run reflex_aloha_adapter adapter_node \
+  --ros-args -p server_url:=tcp://gpu-server:5555 \
+  -p instruction:="pick up the red cup"
+```
+
+## Architecture
+
+```
+┌─────────────┐     HTTP/ZMQ      ┌──────────────┐
+│ Robot (ROS2) │ ────────────────> │ GPU Server   │
+│              │                   │ reflex serve │
+│ adapter_node │ <──────────────── │ --transport  │
+│ (this code)  │     actions       │   zmq/http   │
+└─────────────┘                   └──────────────┘
+```
+
+The adapter subscribes to ROS2 sensor topics, constructs the observation dict,
+calls `reflex serve`'s `/act` endpoint, and publishes actions to actuator topics.
+
+## Attribution
+
+Ported from FluxVLA Engine (LimX Dynamics, Apache-2.0):
+- `aloha_operator.py` → `contrib/ros2/aloha/`
+- `ur_operator.py` → `contrib/ros2/ur3/`
+
+Tron2 adapter KILLED per Lift #8 decision K2 (vendor-specific, LimX only).
+
+## Shared Utilities
+
+`contrib/ros2/_common/` contains shared code used by both adapters:
+- `observation_builder.py` — sensor sync + observation dict construction
+- `action_publisher.py` — action chunk → joint command publishing
+- `reflex_client.py` — HTTP/ZMQ client wrapper for calling reflex serve

--- a/contrib/ros2/_common/action_publisher.py
+++ b/contrib/ros2/_common/action_publisher.py
@@ -1,0 +1,94 @@
+"""Shared action publisher for ROS2 robot adapters.
+
+Converts reflex serve's action chunk [chunk_size, action_dim] into
+robot-specific joint commands, handling replan logic (action deque)
+and rate limiting.
+
+Ported from FluxVLA operator patterns (Apache-2.0, LimX Dynamics).
+"""
+from __future__ import annotations
+
+import collections
+import time
+from typing import Any
+
+import numpy as np
+
+
+class ActionPublisher:
+    """Manages action chunk → per-step joint command publishing.
+
+    Maintains a deque of pending actions from the last chunk. Each call
+    to ``next_action()`` pops one action; when the deque is empty,
+    ``needs_replan`` returns True.
+
+    Args:
+        action_dim: Robot action dimension (e.g. 7 for single-arm, 14 for bimanual).
+        replan_steps: How many actions to execute before replanning.
+            Typically 5-10 (shorter = more responsive, longer = smoother).
+        control_hz: Control loop frequency. Used for rate limiting.
+    """
+
+    def __init__(
+        self,
+        action_dim: int = 7,
+        replan_steps: int = 5,
+        control_hz: float = 50.0,
+    ) -> None:
+        self.action_dim = action_dim
+        self.replan_steps = replan_steps
+        self.control_hz = control_hz
+        self._action_deque: collections.deque = collections.deque()
+        self._last_action_time: float = 0.0
+        self._total_actions_published: int = 0
+
+    def set_chunk(self, actions: np.ndarray) -> None:
+        """Load a new action chunk from reflex serve.
+
+        Args:
+            actions: [chunk_size, action_dim] or [1, chunk_size, action_dim].
+                Only the first ``replan_steps`` actions are used.
+        """
+        if actions.ndim == 3:
+            actions = actions[0]  # drop batch dim
+        # Trim to action_dim (reflex may pad to max_action_dim=32)
+        actions = actions[:, :self.action_dim]
+        self._action_deque.clear()
+        for i in range(min(self.replan_steps, len(actions))):
+            self._action_deque.append(actions[i])
+
+    @property
+    def needs_replan(self) -> bool:
+        return len(self._action_deque) == 0
+
+    def next_action(self) -> np.ndarray | None:
+        """Pop the next action from the deque.
+
+        Returns None if the deque is empty (needs_replan is True).
+        Rate-limits to ``control_hz``.
+        """
+        if not self._action_deque:
+            return None
+
+        # Rate limit
+        now = time.time()
+        dt = now - self._last_action_time
+        min_dt = 1.0 / self.control_hz
+        if dt < min_dt:
+            time.sleep(min_dt - dt)
+
+        action = self._action_deque.popleft()
+        self._last_action_time = time.time()
+        self._total_actions_published += 1
+        return action
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._action_deque)
+
+    @property
+    def total_published(self) -> int:
+        return self._total_actions_published
+
+
+__all__ = ["ActionPublisher"]

--- a/contrib/ros2/_common/observation_builder.py
+++ b/contrib/ros2/_common/observation_builder.py
@@ -1,0 +1,108 @@
+"""Shared observation builder for ROS2 robot adapters.
+
+Handles sensor synchronization + observation dict construction
+for calling reflex serve's /act endpoint.
+
+Ported from FluxVLA aloha_operator.py + ur_operator.py common patterns
+(Apache-2.0, LimX Dynamics).
+"""
+from __future__ import annotations
+
+import collections
+import time
+from typing import Any
+
+import numpy as np
+
+
+class ObservationBuilder:
+    """Synchronizes multi-sensor data into a single observation dict.
+
+    Buffers incoming sensor readings (images, joint states, etc.) and
+    constructs the observation dict by matching timestamps within a
+    tolerance window.
+
+    Args:
+        image_keys: Names of camera topics to expect (e.g. ["cam_high", "cam_left_wrist"]).
+        state_dim: Expected state vector dimension.
+        buffer_size: Max readings to buffer per sensor before dropping old ones.
+        sync_tolerance_ms: Max timestamp difference (ms) for sensor synchronization.
+    """
+
+    def __init__(
+        self,
+        image_keys: list[str],
+        state_dim: int = 14,
+        buffer_size: int = 30,
+        sync_tolerance_ms: float = 50.0,
+    ) -> None:
+        self.image_keys = image_keys
+        self.state_dim = state_dim
+        self.sync_tolerance_ms = sync_tolerance_ms
+
+        # Per-sensor buffers: deque of (timestamp_sec, data)
+        self._image_buffers: dict[str, collections.deque] = {
+            k: collections.deque(maxlen=buffer_size) for k in image_keys
+        }
+        self._state_buffer: collections.deque = collections.deque(maxlen=buffer_size)
+        self._last_obs: dict[str, Any] | None = None
+
+    def push_image(self, key: str, image: np.ndarray, timestamp: float | None = None) -> None:
+        """Buffer a new camera frame."""
+        if key not in self._image_buffers:
+            self._image_buffers[key] = collections.deque(maxlen=30)
+        ts = timestamp if timestamp is not None else time.time()
+        self._image_buffers[key].append((ts, image))
+
+    def push_state(self, state: np.ndarray, timestamp: float | None = None) -> None:
+        """Buffer a new joint state reading."""
+        ts = timestamp if timestamp is not None else time.time()
+        self._state_buffer.append((ts, state))
+
+    def build(self, instruction: str = "") -> dict[str, Any] | None:
+        """Build a synchronized observation dict.
+
+        Returns None if any sensor is missing data. Otherwise returns a
+        dict matching reflex serve's /act request schema.
+        """
+        # Check all sensors have data
+        if not self._state_buffer:
+            return None
+        for key in self.image_keys:
+            if key not in self._image_buffers or not self._image_buffers[key]:
+                return None
+
+        # Use the latest state as anchor timestamp
+        anchor_ts, anchor_state = self._state_buffer[-1]
+
+        # Find closest image for each camera within tolerance
+        images = {}
+        for key in self.image_keys:
+            buf = self._image_buffers[key]
+            best_img = None
+            best_dt = float("inf")
+            for ts, img in buf:
+                dt = abs(ts - anchor_ts) * 1000  # ms
+                if dt < best_dt:
+                    best_dt = dt
+                    best_img = img
+            if best_img is None or best_dt > self.sync_tolerance_ms:
+                return None
+            images[key] = best_img
+
+        obs: dict[str, Any] = {}
+        for key, img in images.items():
+            obs[f"observation.images.{key}"] = img
+        obs["observation.state"] = anchor_state
+        if instruction:
+            obs["task"] = [instruction]
+
+        self._last_obs = obs
+        return obs
+
+    @property
+    def last_observation(self) -> dict[str, Any] | None:
+        return self._last_obs
+
+
+__all__ = ["ObservationBuilder"]

--- a/contrib/ros2/_common/reflex_client.py
+++ b/contrib/ros2/_common/reflex_client.py
@@ -1,0 +1,114 @@
+"""Shared reflex serve client for ROS2 robot adapters.
+
+Wraps either the ZMQ client (preferred for production) or HTTP client
+(fallback) with a unified interface. Robot adapters call
+``predict_action(obs)`` without caring about the transport.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class ReflexClient:
+    """Unified client for calling reflex serve from ROS2 adapters.
+
+    Args:
+        server_url: Server URL. Format determines transport:
+            - ``tcp://host:port`` → ZMQ (preferred)
+            - ``http://host:port`` → HTTP fallback
+        timeout_ms: Request timeout in milliseconds.
+    """
+
+    def __init__(
+        self,
+        server_url: str = "tcp://localhost:5555",
+        timeout_ms: int = 5000,
+    ) -> None:
+        self._server_url = server_url
+        self._timeout_ms = timeout_ms
+        self._client: Any = None
+        self._transport: str = ""
+        self._connect()
+
+    def _connect(self) -> None:
+        if self._server_url.startswith("tcp://"):
+            try:
+                from reflex.runtime.transports.zmq.client import ZmqRuntimeClient
+                self._client = ZmqRuntimeClient(
+                    self._server_url, timeout_ms=self._timeout_ms,
+                )
+                self._transport = "zmq"
+                logger.info("Connected via ZMQ: %s", self._server_url)
+            except ImportError:
+                raise ImportError(
+                    "ZMQ transport requires: pip install pyzmq msgpack opencv-python-headless"
+                )
+        elif self._server_url.startswith("http"):
+            try:
+                import httpx
+                self._client = httpx.Client(
+                    base_url=self._server_url,
+                    timeout=self._timeout_ms / 1000,
+                )
+                self._transport = "http"
+                logger.info("Connected via HTTP: %s", self._server_url)
+            except ImportError:
+                raise ImportError("HTTP transport requires: pip install httpx")
+        else:
+            raise ValueError(
+                f"Unknown URL scheme: {self._server_url!r}. "
+                "Use tcp:// for ZMQ or http:// for HTTP."
+            )
+
+    def predict_action(self, obs: dict[str, Any]) -> np.ndarray:
+        """Send observation, receive action chunk.
+
+        Args:
+            obs: Observation dict with images + state + task.
+
+        Returns:
+            np.ndarray of shape [chunk_size, action_dim].
+        """
+        if self._transport == "zmq":
+            return self._client.predict_action(obs)
+        elif self._transport == "http":
+            import io
+            import json
+            import base64
+
+            payload: dict = {}
+            for k, v in obs.items():
+                if isinstance(v, np.ndarray):
+                    buf = io.BytesIO()
+                    np.save(buf, v, allow_pickle=False)
+                    payload[k] = {"__numpy_b64__": base64.b64encode(buf.getvalue()).decode()}
+                else:
+                    payload[k] = v
+
+            resp = self._client.post("/act", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            action_b64 = data.get("actions_b64", data.get("actions"))
+            if isinstance(action_b64, str):
+                return np.load(io.BytesIO(base64.b64decode(action_b64)))
+            return np.array(action_b64)
+        else:
+            raise RuntimeError(f"Unknown transport: {self._transport}")
+
+    def close(self) -> None:
+        if hasattr(self._client, "close"):
+            self._client.close()
+
+    def __enter__(self) -> "ReflexClient":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+__all__ = ["ReflexClient"]

--- a/contrib/ros2/aloha/adapter.py
+++ b/contrib/ros2/aloha/adapter.py
@@ -1,0 +1,234 @@
+"""Aloha ROS2 adapter — dual-arm bimanual robot control via Reflex VLA.
+
+Ported from FluxVLA ``aloha_operator.py`` (682 LOC, Apache-2.0, LimX Dynamics).
+ROS1 (``rospy``) → ROS2 (``rclpy``) port with these changes per R-1..R-4:
+
+- Uses HTTP or ZMQ to call ``reflex serve`` (R-1: no ROS2 transport dependency)
+- 3-camera setup: ``cam_high``, ``cam_left_wrist``, ``cam_right_wrist`` (R-3)
+- Bimanual joint state: 14 DOF (7 left + 7 right including grippers)
+- Replan every 5 steps by default
+
+Usage::
+
+    # Terminal 1: GPU machine
+    reflex serve ./my_export/ --transport zmq --port 5555
+
+    # Terminal 2: Robot (ROS2)
+    python3 contrib/ros2/aloha/adapter.py \
+        --server tcp://gpu-server:5555 \
+        --instruction "pick up the red cup"
+
+Requires: rclpy, sensor_msgs, std_msgs, cv_bridge, numpy, pyzmq/httpx
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Any
+
+import numpy as np
+
+# ROS2 imports — these fail gracefully if not in a ROS2 environment
+try:
+    import rclpy
+    from rclpy.node import Node
+    from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+    from sensor_msgs.msg import Image, JointState
+    from std_msgs.msg import Float64MultiArray
+    from cv_bridge import CvBridge
+    HAS_ROS2 = True
+except ImportError:
+    HAS_ROS2 = False
+
+# Add contrib parent to path for shared utilities
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+from _common.observation_builder import ObservationBuilder
+from _common.action_publisher import ActionPublisher
+from _common.reflex_client import ReflexClient
+
+
+# Default Aloha topic names (Trossen ALOHA 2 convention)
+DEFAULT_TOPICS = {
+    "cam_high": "/cam_high/image_raw",
+    "cam_left_wrist": "/cam_left_wrist/image_raw",
+    "cam_right_wrist": "/cam_right_wrist/image_raw",
+    "joint_states_left": "/puppet_left/joint_states",
+    "joint_states_right": "/puppet_right/joint_states",
+    "cmd_left": "/puppet_left/joint_group_position_controller/commands",
+    "cmd_right": "/puppet_right/joint_group_position_controller/commands",
+}
+
+ALOHA_ACTION_DIM = 14  # 7 joints per arm × 2 arms
+ALOHA_STATE_DIM = 14
+ALOHA_IMAGE_SIZE = 224
+ALOHA_CAMERA_KEYS = ["cam_high", "cam_left_wrist", "cam_right_wrist"]
+
+
+class AlohaAdapterNode(Node if HAS_ROS2 else object):
+    """ROS2 node that bridges Aloha sensors → Reflex VLA → Aloha actuators.
+
+    Subscribes to 3 cameras + 2 joint state topics, constructs observation,
+    calls reflex serve, publishes joint commands.
+    """
+
+    def __init__(
+        self,
+        server_url: str = "tcp://localhost:5555",
+        instruction: str = "",
+        control_hz: float = 30.0,
+        replan_steps: int = 5,
+        image_size: int = ALOHA_IMAGE_SIZE,
+    ) -> None:
+        if HAS_ROS2:
+            super().__init__("reflex_aloha_adapter")
+        self.instruction = instruction
+        self.image_size = image_size
+
+        # Reflex client
+        self.client = ReflexClient(server_url)
+
+        # Observation builder (3 cameras)
+        self.obs_builder = ObservationBuilder(
+            image_keys=ALOHA_CAMERA_KEYS,
+            state_dim=ALOHA_STATE_DIM,
+        )
+
+        # Action publisher
+        self.action_pub = ActionPublisher(
+            action_dim=ALOHA_ACTION_DIM,
+            replan_steps=replan_steps,
+            control_hz=control_hz,
+        )
+
+        # CV bridge for ROS Image → numpy
+        if HAS_ROS2:
+            self.bridge = CvBridge()
+            self._setup_subscribers()
+            self._setup_publishers()
+
+        # Joint state buffers
+        self._left_joints: np.ndarray | None = None
+        self._right_joints: np.ndarray | None = None
+
+        self.get_logger().info(
+            f"Aloha adapter ready: server={server_url}, "
+            f"instruction={instruction!r}, hz={control_hz}"
+        ) if HAS_ROS2 else None
+
+    def _setup_subscribers(self) -> None:
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+        )
+
+        # Camera subscribers
+        for cam_key, topic in [
+            ("cam_high", DEFAULT_TOPICS["cam_high"]),
+            ("cam_left_wrist", DEFAULT_TOPICS["cam_left_wrist"]),
+            ("cam_right_wrist", DEFAULT_TOPICS["cam_right_wrist"]),
+        ]:
+            self.create_subscription(
+                Image, topic,
+                lambda msg, k=cam_key: self._on_image(k, msg),
+                qos,
+            )
+
+        # Joint state subscribers
+        self.create_subscription(
+            JointState, DEFAULT_TOPICS["joint_states_left"],
+            self._on_left_joints, qos,
+        )
+        self.create_subscription(
+            JointState, DEFAULT_TOPICS["joint_states_right"],
+            self._on_right_joints, qos,
+        )
+
+    def _setup_publishers(self) -> None:
+        self.cmd_left_pub = self.create_publisher(
+            Float64MultiArray, DEFAULT_TOPICS["cmd_left"], 10,
+        )
+        self.cmd_right_pub = self.create_publisher(
+            Float64MultiArray, DEFAULT_TOPICS["cmd_right"], 10,
+        )
+
+    def _on_image(self, key: str, msg: Any) -> None:
+        img = self.bridge.imgmsg_to_cv2(msg, desired_encoding="rgb8")
+        # Resize to model input size
+        from PIL import Image as PILImage
+        pil = PILImage.fromarray(img).resize((self.image_size, self.image_size))
+        self.obs_builder.push_image(key, np.asarray(pil))
+
+    def _on_left_joints(self, msg: Any) -> None:
+        self._left_joints = np.array(msg.position, dtype=np.float32)
+
+    def _on_right_joints(self, msg: Any) -> None:
+        self._right_joints = np.array(msg.position, dtype=np.float32)
+        # When we have both arms, push combined state
+        if self._left_joints is not None:
+            combined = np.concatenate([self._left_joints, self._right_joints])
+            self.obs_builder.push_state(combined)
+
+    def step(self) -> bool:
+        """One control loop iteration. Returns True if action was published."""
+        if self.action_pub.needs_replan:
+            obs = self.obs_builder.build(instruction=self.instruction)
+            if obs is None:
+                return False
+
+            actions = self.client.predict_action(obs)
+            self.action_pub.set_chunk(actions)
+
+        action = self.action_pub.next_action()
+        if action is None:
+            return False
+
+        # Split into left (0:7) and right (7:14) arm commands
+        left_cmd = Float64MultiArray(data=action[:7].tolist())
+        right_cmd = Float64MultiArray(data=action[7:14].tolist())
+
+        if HAS_ROS2:
+            self.cmd_left_pub.publish(left_cmd)
+            self.cmd_right_pub.publish(right_cmd)
+
+        return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Aloha ROS2 adapter for Reflex VLA")
+    parser.add_argument("--server", default="tcp://localhost:5555", help="Reflex serve URL")
+    parser.add_argument("--instruction", default="", help="Task instruction")
+    parser.add_argument("--hz", type=float, default=30.0, help="Control loop Hz")
+    parser.add_argument("--replan-steps", type=int, default=5, help="Steps between replans")
+    args = parser.parse_args()
+
+    if not HAS_ROS2:
+        print("ERROR: rclpy not found. Install ROS2 first.")
+        print("This adapter requires a ROS2 environment (e.g. ros2 humble/iron).")
+        sys.exit(1)
+
+    rclpy.init()
+    node = AlohaAdapterNode(
+        server_url=args.server,
+        instruction=args.instruction,
+        control_hz=args.hz,
+        replan_steps=args.replan_steps,
+    )
+
+    try:
+        rate = node.create_rate(args.hz)
+        while rclpy.ok():
+            rclpy.spin_once(node, timeout_sec=0.01)
+            node.step()
+            rate.sleep()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.client.close()
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/ros2/ur3/adapter.py
+++ b/contrib/ros2/ur3/adapter.py
@@ -1,0 +1,216 @@
+"""UR3/UR5 ROS2 adapter — single-arm robot control via Reflex VLA.
+
+Ported from FluxVLA ``ur_operator.py`` (623 LOC, Apache-2.0, LimX Dynamics).
+Per R-2: modernized to use ``ur_robot_driver``'s canonical
+``FollowJointTrajectory`` ActionClient (NOT FluxVLA's custom ``/cmd/movel``
+topics which are UR-internal and deprecated).
+
+Usage::
+
+    # Terminal 1: GPU machine
+    reflex serve ./my_export/ --transport zmq --port 5555
+
+    # Terminal 2: Robot (ROS2 + ur_robot_driver)
+    python3 contrib/ros2/ur3/adapter.py \
+        --server tcp://gpu-server:5555 \
+        --instruction "pick up the red cup"
+
+Requires: rclpy, sensor_msgs, control_msgs, trajectory_msgs, cv_bridge, numpy
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Any
+
+import numpy as np
+
+try:
+    import rclpy
+    from rclpy.node import Node
+    from rclpy.action import ActionClient
+    from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+    from sensor_msgs.msg import Image, JointState
+    from control_msgs.action import FollowJointTrajectory
+    from trajectory_msgs.msg import JointTrajectoryPoint
+    from cv_bridge import CvBridge
+    from builtin_interfaces.msg import Duration
+    HAS_ROS2 = True
+except ImportError:
+    HAS_ROS2 = False
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+from _common.observation_builder import ObservationBuilder
+from _common.action_publisher import ActionPublisher
+from _common.reflex_client import ReflexClient
+
+
+# Default UR topic names (ur_robot_driver convention)
+DEFAULT_TOPICS = {
+    "camera": "/camera/image_raw",
+    "joint_states": "/joint_states",
+    "follow_joint_trajectory": "/scaled_joint_trajectory_controller/follow_joint_trajectory",
+}
+
+UR_JOINT_NAMES = [
+    "shoulder_pan_joint",
+    "shoulder_lift_joint",
+    "elbow_joint",
+    "wrist_1_joint",
+    "wrist_2_joint",
+    "wrist_3_joint",
+]
+
+UR_ACTION_DIM = 7  # 6 joints + 1 gripper
+UR_STATE_DIM = 7
+UR_IMAGE_SIZE = 224
+
+
+class URAdapterNode(Node if HAS_ROS2 else object):
+    """ROS2 node that bridges UR sensors → Reflex VLA → UR actuators.
+
+    Subscribes to camera + joint states, constructs observation,
+    calls reflex serve, sends FollowJointTrajectory goals.
+    """
+
+    def __init__(
+        self,
+        server_url: str = "tcp://localhost:5555",
+        instruction: str = "",
+        control_hz: float = 10.0,
+        replan_steps: int = 5,
+        image_size: int = UR_IMAGE_SIZE,
+        camera_topic: str = DEFAULT_TOPICS["camera"],
+    ) -> None:
+        if HAS_ROS2:
+            super().__init__("reflex_ur_adapter")
+        self.instruction = instruction
+        self.image_size = image_size
+
+        self.client = ReflexClient(server_url)
+        self.obs_builder = ObservationBuilder(
+            image_keys=["camera"],
+            state_dim=UR_STATE_DIM,
+        )
+        self.action_pub = ActionPublisher(
+            action_dim=UR_ACTION_DIM,
+            replan_steps=replan_steps,
+            control_hz=control_hz,
+        )
+
+        if HAS_ROS2:
+            self.bridge = CvBridge()
+            qos = QoSProfile(
+                reliability=ReliabilityPolicy.BEST_EFFORT,
+                history=HistoryPolicy.KEEP_LAST,
+                depth=1,
+            )
+
+            self.create_subscription(
+                Image, camera_topic, self._on_image, qos,
+            )
+            self.create_subscription(
+                JointState, DEFAULT_TOPICS["joint_states"],
+                self._on_joint_state, qos,
+            )
+
+            self._trajectory_client = ActionClient(
+                self, FollowJointTrajectory,
+                DEFAULT_TOPICS["follow_joint_trajectory"],
+            )
+
+        self._current_joints: np.ndarray | None = None
+        self._gripper_state: float = 0.0
+
+        self.get_logger().info(
+            f"UR adapter ready: server={server_url}, instruction={instruction!r}"
+        ) if HAS_ROS2 else None
+
+    def _on_image(self, msg: Any) -> None:
+        img = self.bridge.imgmsg_to_cv2(msg, desired_encoding="rgb8")
+        from PIL import Image as PILImage
+        pil = PILImage.fromarray(img).resize((self.image_size, self.image_size))
+        self.obs_builder.push_image("camera", np.asarray(pil))
+
+    def _on_joint_state(self, msg: Any) -> None:
+        positions = np.array(msg.position[:6], dtype=np.float32)
+        self._current_joints = positions
+        state = np.concatenate([positions, [self._gripper_state]])
+        self.obs_builder.push_state(state)
+
+    def _send_joint_trajectory(self, target_joints: np.ndarray) -> None:
+        """Send a FollowJointTrajectory goal to the UR driver."""
+        if not HAS_ROS2:
+            return
+
+        goal = FollowJointTrajectory.Goal()
+        point = JointTrajectoryPoint()
+        point.positions = target_joints[:6].tolist()
+        point.time_from_start = Duration(sec=0, nanosec=int(0.1 * 1e9))
+        goal.trajectory.joint_names = UR_JOINT_NAMES
+        goal.trajectory.points = [point]
+
+        if self._trajectory_client.wait_for_server(timeout_sec=1.0):
+            self._trajectory_client.send_goal_async(goal)
+
+        # Handle gripper separately if action_dim includes it
+        if len(target_joints) > 6:
+            self._gripper_state = float(target_joints[6])
+
+    def step(self) -> bool:
+        """One control loop iteration."""
+        if self.action_pub.needs_replan:
+            obs = self.obs_builder.build(instruction=self.instruction)
+            if obs is None:
+                return False
+
+            actions = self.client.predict_action(obs)
+            self.action_pub.set_chunk(actions)
+
+        action = self.action_pub.next_action()
+        if action is None:
+            return False
+
+        self._send_joint_trajectory(action)
+        return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="UR3/UR5 ROS2 adapter for Reflex VLA")
+    parser.add_argument("--server", default="tcp://localhost:5555", help="Reflex serve URL")
+    parser.add_argument("--instruction", default="", help="Task instruction")
+    parser.add_argument("--hz", type=float, default=10.0, help="Control loop Hz")
+    parser.add_argument("--replan-steps", type=int, default=5)
+    parser.add_argument("--camera-topic", default=DEFAULT_TOPICS["camera"])
+    args = parser.parse_args()
+
+    if not HAS_ROS2:
+        print("ERROR: rclpy not found. Install ROS2 first.")
+        sys.exit(1)
+
+    rclpy.init()
+    node = URAdapterNode(
+        server_url=args.server,
+        instruction=args.instruction,
+        control_hz=args.hz,
+        replan_steps=args.replan_steps,
+        camera_topic=args.camera_topic,
+    )
+
+    try:
+        rate = node.create_rate(args.hz)
+        while rclpy.ok():
+            rclpy.spin_once(node, timeout_sec=0.01)
+            node.step()
+            rate.sleep()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.client.close()
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Phase 2 Lift #8. Two ROS2 robot adapters in contrib/ (fork-and-customize, NOT core pip install). Aloha bimanual (3 cameras, 14 DOF) + UR3/UR5 (FollowJointTrajectory ActionClient, modernized from FluxVLA's deprecated custom topics). Shared utilities: ObservationBuilder, ActionPublisher, ReflexClient. ~820 LOC total.