### PR TITLE
fix: transformers 5.x DynamicCache 3-tuple iteration (Pi0/Pi05 predict_action)

### DIFF
--- a/src/reflex/models/vlas/pi0.py
+++ b/src/reflex/models/vlas/pi0.py
@@ -465,7 +465,14 @@ class Pi0VLA(BaseVLA):
 
         # Extract per-layer K and V. past_key_values may be DynamicCache
         # (`.layers[i].keys/.values`), older Cache (`.key_cache/.value_cache`),
-        # or legacy tuple-of-tuples. Both layouts arrive as [B, nkv, prefix_len, hd].
+        # or legacy tuple-of-tuples/3-tuples (transformers 5.x DynamicCache
+        # iteration yields 3-tuples).
+        if past_key_values is None:
+            raise RuntimeError(
+                "Pi0VLA.predict_action: language_model returned None for "
+                "past_key_values despite use_cache=True. Check transformers "
+                f"version ({__import__('transformers').__version__}) compatibility."
+            )
         prefix_k_list: list[torch.Tensor] = []
         prefix_v_list: list[torch.Tensor] = []
         if hasattr(past_key_values, "layers"):
@@ -477,9 +484,14 @@ class Pi0VLA(BaseVLA):
                 prefix_k_list.append(k)
                 prefix_v_list.append(v)
         else:
-            for (k, v) in past_key_values:
-                prefix_k_list.append(k)
-                prefix_v_list.append(v)
+            for layer_cache in past_key_values:
+                if isinstance(layer_cache, (tuple, list)):
+                    prefix_k_list.append(layer_cache[0])
+                    prefix_v_list.append(layer_cache[1])
+                else:
+                    raise TypeError(
+                        f"Unexpected past_key_values layer type: {type(layer_cache)}"
+                    )
         prefix_k = torch.stack(prefix_k_list, dim=0)  # [L, B, nkv, prefix_len, hd]
         prefix_v = torch.stack(prefix_v_list, dim=0)
 

--- a/src/reflex/models/vlas/pi05.py
+++ b/src/reflex/models/vlas/pi05.py
@@ -352,8 +352,18 @@ class Pi05VLA(BaseVLA):
         past_key_values = prefix_out.past_key_values
 
         # Extract per-layer K and V — same as Pi0VLA.
+        # Transformers 5.x DynamicCache changed its interface:
+        # - No .key_cache / .value_cache attributes
+        # - Iteration yields 3-tuples (key, value, extra) not 2-tuples
+        # Handle all three variants for forward/backward compat.
         prefix_k_list: list[torch.Tensor] = []
         prefix_v_list: list[torch.Tensor] = []
+        if past_key_values is None:
+            raise RuntimeError(
+                "Pi05VLA.predict_action: language_model returned None for "
+                "past_key_values despite use_cache=True. Check transformers "
+                f"version ({__import__('transformers').__version__}) compatibility."
+            )
         if hasattr(past_key_values, "layers"):
             for layer in past_key_values.layers:
                 prefix_k_list.append(layer.keys)
@@ -363,9 +373,14 @@ class Pi05VLA(BaseVLA):
                 prefix_k_list.append(k)
                 prefix_v_list.append(v)
         else:
-            for (k, v) in past_key_values:
-                prefix_k_list.append(k)
-                prefix_v_list.append(v)
+            for layer_cache in past_key_values:
+                if isinstance(layer_cache, (tuple, list)):
+                    prefix_k_list.append(layer_cache[0])
+                    prefix_v_list.append(layer_cache[1])
+                else:
+                    raise TypeError(
+                        f"Unexpected past_key_values layer type: {type(layer_cache)}"
+                    )
         prefix_k = torch.stack(prefix_k_list, dim=0)
         prefix_v = torch.stack(prefix_v_list, dim=0)
 


### PR DESCRIPTION
Fixes TypeError at Pi05VLA.predict_action line 366 (and Pi0VLA equivalent). Transformers 5.3.0 DynamicCache changed iteration from 2-tuples to 3-tuples. Uses index-based access instead of destructuring. Verified locally.