### PR TITLE
fix: add dreamzero to canonical family set

### DIFF
--- a/src/reflex/registry/models.py
+++ b/src/reflex/registry/models.py
@@ -66,7 +66,7 @@ class ModelEntry:
         if "/" not in self.hf_repo:
             raise ValueError(f"hf_repo must be 'org/name' format: {self.hf_repo!r}")
         if self.family not in ("pi0", "pi05", "smolvla", "openvla", "groot", "dreamzero"):
-            raise ValueError(f"family must be one of pi0/pi05/smolvla/openvla/groot, got {self.family!r}")
+            raise ValueError(f"family must be one of pi0/pi05/smolvla/openvla/groot/dreamzero, got {self.family!r}")
         if self.action_dim <= 0:
             raise ValueError(f"action_dim must be positive, got {self.action_dim}")
         if self.vla_type is not None and not self.vla_type.startswith("_"):

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -43,7 +43,7 @@ class TestRegistryInvariants:
             assert "/" in e.hf_repo, f"{e.model_id}: hf_repo missing org/: {e.hf_repo!r}"
 
     def test_every_family_is_canonical(self):
-        canonical = {"pi0", "pi05", "smolvla", "openvla", "groot"}
+        canonical = {"pi0", "pi05", "smolvla", "openvla", "groot", "dreamzero"}
         for e in REGISTRY:
             assert e.family in canonical, f"{e.model_id}: bad family {e.family!r}"
 


### PR DESCRIPTION
## Summary
- Adds `dreamzero` to the test's hardcoded canonical families set in `test_model_registry.py`
- Updates the validator error message in `models.py` to include `dreamzero`
- Lift #7 (DreamZero WAM) registered the family correctly in the allowlist but these two strings were missed

## Test plan
- [x] `pytest tests/test_model_registry.py` — 36/36 passed (was 35 pass + 1 fail)

Generated with [Claude Code](https://claude.com/claude-code)