### PR TITLE
feat: reflex connect — integration framework + RTSM

### DIFF
--- a/src/reflex/cli.py
+++ b/src/reflex/cli.py
@@ -4056,6 +4056,107 @@ app.add_typer(train_app, name="train")
 app.add_typer(validate_app, name="validate")
 app.add_typer(inspect_app, name="inspect")
 
+# ─── reflex connect {name} / disconnect / list ──────────────────────────────
+
+connect_app = typer.Typer(
+    help="Connect external tools (spatial memory, perception) to reflex.",
+)
+
+
+@connect_app.command("list")
+def connect_list():
+    """List available integrations."""
+    from rich.console import Console
+    from rich.table import Table
+    from reflex.integrations.registry import list_integrations
+
+    console = Console()
+    integrations = list_integrations()
+    table = Table(title="Available Integrations")
+    table.add_column("Name", style="cyan")
+    table.add_column("Status")
+    table.add_column("Description")
+    table.add_column("License")
+
+    for i in integrations:
+        if i.health_check():
+            status = "[green]running[/green]"
+        elif i.is_installed():
+            status = "[yellow]installed[/yellow]"
+        else:
+            status = "[dim]not installed[/dim]"
+        table.add_row(i.name, status, i.description, i.license)
+
+    console.print(table)
+
+
+@connect_app.command("up")
+def connect_up(
+    name: str = typer.Argument(help="Integration name (e.g. 'rtsm')"),
+    extra_args: list[str] = typer.Argument(default=None, help="Extra args passed to the integration"),
+):
+    """Install (if needed) and start an integration."""
+    from rich.console import Console
+    from reflex.integrations.connector import connect
+
+    console = Console()
+    try:
+        result = connect(name, extra_args=extra_args)
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(2)
+    except RuntimeError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)
+
+    if result["status"] == "already_running":
+        console.print(f"[green]{name}[/green] already running at {result['url']}")
+    else:
+        console.print(
+            f"[green]{name}[/green] started (pid {result['pid']}) at {result['url']}"
+        )
+    if result.get("mcp_tools"):
+        console.print(f"  MCP tools: {', '.join(result['mcp_tools'])}")
+
+
+@connect_app.command("down")
+def connect_down(
+    name: str = typer.Argument(help="Integration name to stop"),
+):
+    """Stop a running integration."""
+    from rich.console import Console
+    from reflex.integrations.connector import disconnect
+
+    console = Console()
+    result = disconnect(name)
+    console.print(f"[dim]{name}[/dim]: {result['status']}")
+
+
+@connect_app.command("status")
+def connect_status(
+    name: str = typer.Argument(help="Integration name to check"),
+):
+    """Check if an integration is running and healthy."""
+    from rich.console import Console
+    from reflex.integrations.registry import get_integration
+
+    console = Console()
+    integration = get_integration(name)
+    if integration is None:
+        console.print(f"[red]Unknown integration: {name}[/red]")
+        raise typer.Exit(2)
+
+    installed = integration.is_installed()
+    healthy = integration.health_check()
+    console.print(f"[cyan]{name}[/cyan]")
+    console.print(f"  Installed: {'yes' if installed else 'no'}")
+    console.print(f"  Running:   {'yes' if healthy else 'no'}")
+    console.print(f"  URL:       {integration.health_url}")
+    console.print(f"  MCP tools: {', '.join(integration.mcp_tools)}")
+
+
+app.add_typer(connect_app, name="connect")
+
 
 # ─── reflex traces {query, summary} ─────────────────────────────────────────
 # Customer trace archive (Phase 1.5 v1) per spec

--- a/src/reflex/integrations/__init__.py
+++ b/src/reflex/integrations/__init__.py
@@ -1,0 +1,8 @@
+"""Integration framework — connect external tools to reflex."""
+from reflex.integrations.registry import (
+    Integration,
+    get_integration,
+    list_integrations,
+)
+
+__all__ = ["Integration", "get_integration", "list_integrations"]

--- a/src/reflex/integrations/connector.py
+++ b/src/reflex/integrations/connector.py
@@ -1,0 +1,91 @@
+"""Connector — install, start, query, and stop integrations."""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from typing import Any
+
+import requests
+
+from reflex.integrations.registry import Integration, get_integration
+
+logger = logging.getLogger(__name__)
+
+_RUNNING: dict[str, subprocess.Popen] = {}
+
+
+def connect(name: str, extra_args: list[str] | None = None) -> dict[str, Any]:
+    integration = get_integration(name)
+    if integration is None:
+        from reflex.integrations.registry import list_integrations
+        available = [i.name for i in list_integrations()]
+        raise ValueError(f"Unknown integration {name!r}. Available: {available}")
+
+    if integration.health_check():
+        return {
+            "status": "already_running",
+            "name": name,
+            "url": integration.health_url,
+            "mcp_tools": integration.mcp_tools,
+        }
+
+    if not integration.is_installed():
+        integration.install()
+
+    proc = integration.start(extra_args=extra_args)
+    _RUNNING[name] = proc
+
+    return {
+        "status": "started",
+        "name": name,
+        "pid": proc.pid,
+        "url": integration.health_url,
+        "mcp_tools": integration.mcp_tools,
+    }
+
+
+def disconnect(name: str) -> dict[str, Any]:
+    proc = _RUNNING.pop(name, None)
+    if proc is not None and proc.poll() is None:
+        proc.terminate()
+        proc.wait(timeout=10)
+        return {"status": "stopped", "name": name, "pid": proc.pid}
+
+    integration = get_integration(name)
+    if integration and integration.health_check():
+        return {"status": "external_still_running", "name": name}
+
+    return {"status": "not_running", "name": name}
+
+
+def query_objects(
+    integration_url: str, endpoint: str = "/objects", **params: Any,
+) -> list[dict]:
+    resp = requests.get(f"{integration_url.rstrip('/')}{endpoint}", params=params, timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def semantic_search(
+    integration_url: str, query: str, top_k: int = 5,
+) -> list[dict]:
+    resp = requests.get(
+        f"{integration_url.rstrip('/')}/search/semantic",
+        params={"query": query, "top_k": top_k},
+        timeout=5,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def spatial_search(
+    integration_url: str, x: float, y: float, z: float, radius: float = 1.5,
+) -> list[dict]:
+    resp = requests.get(
+        f"{integration_url.rstrip('/')}/search/spatial",
+        params={"x": x, "y": y, "z": z, "radius": radius},
+        timeout=5,
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/src/reflex/integrations/registry.py
+++ b/src/reflex/integrations/registry.py
@@ -1,0 +1,115 @@
+"""Integration registry — known external tools reflex can connect to."""
+from __future__ import annotations
+
+import importlib
+import logging
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Integration:
+    name: str
+    description: str
+    pip_package: str
+    pip_extras: str = ""
+    health_url: str = "http://localhost:8000/healthz"
+    start_command: list[str] = field(default_factory=list)
+    stop_signal: str = "SIGTERM"
+    default_port: int = 8000
+    mcp_tools: tuple[str, ...] = ()
+    homepage: str = ""
+    license: str = ""
+
+    @property
+    def pip_spec(self) -> str:
+        if self.pip_extras:
+            return f"{self.pip_package}[{self.pip_extras}]"
+        return self.pip_package
+
+    def is_installed(self) -> bool:
+        try:
+            importlib.import_module(self.pip_package.replace("-", "_").split("[")[0])
+            return True
+        except ImportError:
+            return False
+
+    def install(self) -> None:
+        logger.info("Installing %s...", self.pip_spec)
+        cmd = [
+            sys.executable, "-m", "pip", "install", self.pip_spec,
+            "--extra-index-url", "https://download.pytorch.org/whl/cu128",
+            "-q",
+        ]
+        subprocess.check_call(cmd)
+        logger.info("Installed %s", self.pip_spec)
+
+    def health_check(self, timeout: float = 2.0) -> bool:
+        try:
+            resp = requests.get(self.health_url, timeout=timeout)
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    def start(self, extra_args: list[str] | None = None) -> subprocess.Popen:
+        cmd = list(self.start_command)
+        if extra_args:
+            cmd.extend(extra_args)
+        logger.info("Starting %s: %s", self.name, " ".join(cmd))
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        for _ in range(30):
+            if self.health_check(timeout=1.0):
+                logger.info("%s is healthy at %s", self.name, self.health_url)
+                return proc
+            time.sleep(1)
+        proc.terminate()
+        raise RuntimeError(
+            f"{self.name} failed to become healthy at {self.health_url} "
+            f"within 30s. Check logs with: {' '.join(cmd)}"
+        )
+
+
+RTSM = Integration(
+    name="rtsm",
+    description="Real-Time Spatial Memory — persistent 3D object map from RGB-D streams",
+    pip_package="rtsm",
+    pip_extras="gpu",
+    health_url="http://localhost:8002/healthz",
+    start_command=[sys.executable, "-m", "rtsm", "demo", "--no-viz"],
+    default_port=8002,
+    mcp_tools=(
+        "rtsm.semantic_query",
+        "rtsm.spatial_query",
+        "rtsm.relational_query",
+        "rtsm.list_objects",
+        "rtsm.get_object",
+        "rtsm.status",
+    ),
+    homepage="https://github.com/calabi-inc/rtsm",
+    license="Apache-2.0",
+)
+
+
+_REGISTRY: dict[str, Integration] = {
+    "rtsm": RTSM,
+}
+
+
+def get_integration(name: str) -> Integration | None:
+    return _REGISTRY.get(name)
+
+
+def list_integrations() -> list[Integration]:
+    return list(_REGISTRY.values())

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,84 @@
+"""Tests for the integration framework (reflex connect)."""
+from __future__ import annotations
+
+import pytest
+
+from reflex.integrations.registry import (
+    Integration,
+    get_integration,
+    list_integrations,
+)
+
+
+class TestRegistry:
+    def test_list_non_empty(self):
+        assert len(list_integrations()) >= 1
+
+    def test_rtsm_exists(self):
+        rtsm = get_integration("rtsm")
+        assert rtsm is not None
+        assert rtsm.name == "rtsm"
+
+    def test_unknown_returns_none(self):
+        assert get_integration("nonexistent_xyz") is None
+
+    def test_rtsm_pip_spec(self):
+        rtsm = get_integration("rtsm")
+        assert rtsm.pip_spec == "rtsm[gpu]"
+
+    def test_rtsm_mcp_tools(self):
+        rtsm = get_integration("rtsm")
+        assert len(rtsm.mcp_tools) == 6
+        assert "rtsm.semantic_query" in rtsm.mcp_tools
+        assert "rtsm.spatial_query" in rtsm.mcp_tools
+
+    def test_rtsm_health_fails_when_not_running(self):
+        rtsm = get_integration("rtsm")
+        assert rtsm.health_check(timeout=0.5) is False
+
+    def test_integration_frozen(self):
+        rtsm = get_integration("rtsm")
+        with pytest.raises(AttributeError):
+            rtsm.name = "something_else"
+
+
+class TestConnector:
+    def test_connect_unknown_raises(self):
+        from reflex.integrations.connector import connect
+        with pytest.raises(ValueError, match="Unknown integration"):
+            connect("nonexistent_xyz")
+
+    def test_disconnect_not_running(self):
+        from reflex.integrations.connector import disconnect
+        result = disconnect("rtsm")
+        assert result["status"] == "not_running"
+
+
+class TestCli:
+    @pytest.fixture
+    def runner(self):
+        typer_testing = pytest.importorskip("typer.testing")
+        return typer_testing.CliRunner()
+
+    @pytest.fixture
+    def cli_app(self):
+        from reflex.cli import app
+        return app
+
+    def test_connect_list(self, runner, cli_app):
+        result = runner.invoke(cli_app, ["connect", "list"])
+        assert result.exit_code == 0
+        assert "rtsm" in result.output
+
+    def test_connect_status_rtsm(self, runner, cli_app):
+        result = runner.invoke(cli_app, ["connect", "status", "rtsm"])
+        assert result.exit_code == 0
+        assert "Installed" in result.output
+
+    def test_connect_status_unknown(self, runner, cli_app):
+        result = runner.invoke(cli_app, ["connect", "status", "nonexistent_xyz"])
+        assert result.exit_code == 2
+
+    def test_connect_up_unknown(self, runner, cli_app):
+        result = runner.invoke(cli_app, ["connect", "up", "nonexistent_xyz"])
+        assert result.exit_code == 2


### PR DESCRIPTION
## Summary
- New `reflex connect` CLI: `list`, `up`, `down`, `status` subcommands
- Integration registry pattern — known external tools with pip spec, health check, start command, MCP tool manifest
- RTSM as first integration: persistent 3D spatial memory from RGB-D streams (6 MCP tools)
- reflex handles install + lifecycle; external tool owns its own perception code

## Usage
```bash
reflex connect list              # show available integrations
reflex connect up rtsm           # pip install + start + health check
reflex connect down rtsm         # stop sidecar
reflex connect status rtsm       # check if running
```

## Test plan
- [x] 13 tests — registry, connector, CLI (all pass)
- [x] `reflex connect list` shows RTSM with status/description/license
- [x] `reflex connect status rtsm` shows install + health status

Generated with [Claude Code](https://claude.com/claude-code)