### PR TITLE
feat: MolmoAct2 — 7th VLA family on the spine

### DIFF
--- a/src/reflex/models/vlas/_molmoact2_safetensors_mapping.py
+++ b/src/reflex/models/vlas/_molmoact2_safetensors_mapping.py
@@ -1,0 +1,37 @@
+"""MolmoAct2 safetensors→flat-dict key transformation.
+
+Maps an ``allenai/MolmoAct2`` safetensors checkpoint (sharded, 5 files)
+into the flat-dict naming convention for the BaseVLA spine.
+
+Architecture: 3 components under ``model.*`` + ``lm_head``:
+- ``model.vision_backbone.*`` (414 keys) — SigLIP2 ViT
+- ``model.transformer.*`` (292 keys) — Molmo2-ER (Qwen3-based LLM)
+- ``model.action_expert.*`` (588 keys) — flow-matching action head
+- ``lm_head.weight`` (1 key) — language model head
+
+Source: huggingface.co/allenai/MolmoAct2 (Apache-2.0).
+"""
+from __future__ import annotations
+
+
+def molmoact2_safetensors_to_flat(key: str) -> str | None:
+    """Map a MolmoAct2 checkpoint key to its flat-dict equivalent.
+
+    Returns ``None`` for keys that should be skipped.
+    """
+    if key.startswith("model.vision_backbone."):
+        return "vision_backbone." + key[len("model.vision_backbone."):]
+
+    if key.startswith("model.transformer."):
+        return "vlm_backbone." + key[len("model.transformer."):]
+
+    if key.startswith("model.action_expert."):
+        return "vla_head." + key[len("model.action_expert."):]
+
+    if key == "lm_head.weight":
+        return "vlm_backbone.lm_head.weight"
+
+    return key
+
+
+__all__ = ["molmoact2_safetensors_to_flat"]

--- a/src/reflex/models/vlas/molmoact2.py
+++ b/src/reflex/models/vlas/molmoact2.py
@@ -1,0 +1,134 @@
+"""MolmoAct2VLA — Allen AI's MolmoAct2 on the BaseVLA spine.
+
+Architecture: SigLIP2 ViT (vision) + Qwen3-based Molmo2-ER (LLM) +
+flow-matching continuous action expert. Uses per-layer KV-cache
+conditioning from VLM to action expert.
+
+Spine mapping:
+    MolmoAct2VLA = BaseVLA(
+        vision_backbone = SigLIP2 ViT (model.vision_backbone.*),
+        vlm_backbone    = Molmo2-ER transformer (model.transformer.*),
+        vla_head        = Flow-matching action expert (model.action_expert.*),
+        # Unused slots:
+        llm_backbone = None,
+        projector    = None,
+        text_encoder = None,
+    )
+
+Source: huggingface.co/allenai/MolmoAct2 (Apache-2.0).
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import torch
+
+from reflex.models.base_vla import BaseVLA
+from reflex.registry.components import VLAS
+
+
+@VLAS.register
+class MolmoAct2VLA(BaseVLA):
+    """MolmoAct2 spine composition — SigLIP2 vision + Molmo2-ER VLM + flow-matching action expert."""
+
+    REQUIRED_SLOTS: ClassVar[tuple[str, ...]] = (
+        "vision_backbone",
+        "vlm_backbone",
+        "vla_head",
+    )
+    OPTIONAL_SLOTS: ClassVar[tuple[str, ...]] = ()
+    NAME_MAPPING: ClassVar[dict[str, str]] = {}
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        hf_id: str = "allenai/MolmoAct2",
+        *,
+        state_dict: dict[str, torch.Tensor] | None = None,
+    ) -> "MolmoAct2VLA":
+        """Build MolmoAct2VLA from a HuggingFace checkpoint.
+
+        MolmoAct2 uses custom model code (auto_map in config.json), so we
+        load via transformers' trust_remote_code path and wrap the components.
+        """
+        if state_dict is None:
+            from transformers import AutoModelForImageTextToText
+            model = AutoModelForImageTextToText.from_pretrained(
+                hf_id, trust_remote_code=True,
+            )
+            return cls(
+                vision_backbone=model.model.vision_backbone,
+                vlm_backbone=model.model.transformer,
+                vla_head=model.model.action_expert if hasattr(model.model, "action_expert") else None,
+            )
+
+        raise NotImplementedError(
+            "MolmoAct2VLA.from_pretrained with raw state_dict not yet supported. "
+            "Use hf_id= to load via transformers."
+        )
+
+    # ── Phase B safetensors-direct loader ─────────────────────────────
+
+    @classmethod
+    def flat_dict_from_safetensors(
+        cls,
+        safetensors_path: str,
+        *,
+        dtype: torch.dtype | None = torch.bfloat16,
+        device: str = "cuda",
+        device_id: int = 0,
+    ) -> dict[str, torch.Tensor]:
+        """Load MolmoAct2 safetensors checkpoint into a flat dict.
+
+        Supports sharded checkpoints (directory with index.json).
+        """
+        from pathlib import Path
+
+        from reflex.models.vlas._molmoact2_safetensors_mapping import (
+            molmoact2_safetensors_to_flat,
+        )
+
+        path = Path(safetensors_path)
+        if path.is_dir():
+            from reflex.runtime.inference_weights.safetensors_direct import (
+                load_flat_dict_from_safetensors_dir,
+            )
+            raw = load_flat_dict_from_safetensors_dir(
+                path, dtype=dtype, device=device, device_id=device_id,
+            )
+        else:
+            from safetensors import safe_open
+            device_str = f"{device}:{device_id}" if device == "cuda" else device
+            raw = {}
+            with safe_open(str(path), framework="pt", device=device_str) as f:
+                for k in f.keys():
+                    tensor = f.get_tensor(k)
+                    if dtype is not None and tensor.dtype != dtype:
+                        tensor = tensor.to(dtype=dtype)
+                    raw[k] = tensor
+
+        flat: dict[str, torch.Tensor] = {}
+        for src_key, tensor in raw.items():
+            target_key = molmoact2_safetensors_to_flat(src_key)
+            if target_key is None:
+                continue
+            flat[target_key] = tensor
+
+        return flat
+
+    # ── ABC contract ────────────────────────────────────────────────────
+
+    def forward(self, batch: dict[str, Any]) -> Any:
+        raise NotImplementedError(
+            "MolmoAct2VLA.forward() requires the full MolmoAct2 inference pipeline. "
+            "Use from_pretrained() + the model's generate/act methods instead."
+        )
+
+    def predict_action(self, **kwargs: Any) -> torch.Tensor:
+        raise NotImplementedError(
+            "MolmoAct2VLA.predict_action() requires the full MolmoAct2 inference pipeline. "
+            "Use from_pretrained() + the model's generate/act methods instead."
+        )
+
+
+__all__ = ["MolmoAct2VLA"]

--- a/src/reflex/registry/data.py
+++ b/src/reflex/registry/data.py
@@ -198,4 +198,52 @@ REGISTRY: tuple[ModelEntry, ...] = (
         license="apache-2.0",
         hf_revision=None,
     ),
+    # ──────────────────────────────────────────────────────────────────────
+    # MolmoAct2 — Allen AI's VLA. SigLIP2 + Qwen3 Molmo2-ER + flow-matching
+    # action expert. 7th model family on the spine.
+    # ──────────────────────────────────────────────────────────────────────
+    ModelEntry(
+        model_id="molmoact2-base",
+        hf_repo="allenai/MolmoAct2",
+        family="molmoact2",
+        action_dim=7,
+        size_mb=21800,
+        supported_embodiments=("franka", "so100", "yam"),
+        supported_devices=("a10g", "a100", "h100", "h200"),
+        benchmarks=(),
+        requires_export=False,
+        description="MolmoAct2 base — Allen AI's VLA. SigLIP2 + Molmo2-ER (Qwen3) "
+                    "+ flow-matching action expert. 5B params. Apache-2.0.",
+        license="apache-2.0",
+        hf_revision=None,
+    ),
+    ModelEntry(
+        model_id="molmoact2-libero",
+        hf_repo="allenai/MolmoAct2-LIBERO",
+        family="molmoact2",
+        action_dim=7,
+        size_mb=21800,
+        supported_embodiments=("franka",),
+        supported_devices=("a10g", "a100", "h100", "h200"),
+        benchmarks=(),
+        requires_export=False,
+        description="MolmoAct2 LIBERO fine-tune — Allen AI's VLA on LIBERO benchmark. "
+                    "Franka 7-DoF. Apache-2.0.",
+        license="apache-2.0",
+        hf_revision=None,
+    ),
+    ModelEntry(
+        model_id="molmoact2-droid",
+        hf_repo="allenai/MolmoAct2-DROID",
+        family="molmoact2",
+        action_dim=7,
+        size_mb=21800,
+        supported_embodiments=("franka",),
+        supported_devices=("a10g", "a100", "h100", "h200"),
+        benchmarks=(),
+        requires_export=False,
+        description="MolmoAct2 DROID fine-tune — Franka DROID embodiment. Apache-2.0.",
+        license="apache-2.0",
+        hf_revision=None,
+    ),
 )

--- a/src/reflex/registry/models.py
+++ b/src/reflex/registry/models.py
@@ -65,8 +65,8 @@ class ModelEntry:
             raise ValueError(f"model_id must be kebab-case (no slashes): {self.model_id!r}")
         if "/" not in self.hf_repo:
             raise ValueError(f"hf_repo must be 'org/name' format: {self.hf_repo!r}")
-        if self.family not in ("pi0", "pi05", "smolvla", "openvla", "groot", "dreamzero"):
-            raise ValueError(f"family must be one of pi0/pi05/smolvla/openvla/groot/dreamzero, got {self.family!r}")
+        if self.family not in ("pi0", "pi05", "smolvla", "openvla", "groot", "dreamzero", "molmoact2"):
+            raise ValueError(f"family must be one of pi0/pi05/smolvla/openvla/groot/dreamzero/molmoact2, got {self.family!r}")
         if self.action_dim <= 0:
             raise ValueError(f"action_dim must be positive, got {self.action_dim}")
         if self.vla_type is not None and not self.vla_type.startswith("_"):

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -43,7 +43,7 @@ class TestRegistryInvariants:
             assert "/" in e.hf_repo, f"{e.model_id}: hf_repo missing org/: {e.hf_repo!r}"
 
     def test_every_family_is_canonical(self):
-        canonical = {"pi0", "pi05", "smolvla", "openvla", "groot", "dreamzero"}
+        canonical = {"pi0", "pi05", "smolvla", "openvla", "groot", "dreamzero", "molmoact2"}
         for e in REGISTRY:
             assert e.family in canonical, f"{e.model_id}: bad family {e.family!r}"
 

--- a/tests/test_molmoact2_safetensors_mapping_unit.py
+++ b/tests/test_molmoact2_safetensors_mapping_unit.py
@@ -1,0 +1,34 @@
+"""Unit tests for MolmoAct2 safetensors→flat-dict mapping."""
+from __future__ import annotations
+
+from reflex.models.vlas._molmoact2_safetensors_mapping import (
+    molmoact2_safetensors_to_flat,
+)
+
+
+def test_vision_backbone():
+    src = "model.vision_backbone.image_pooling_2d.wk.weight"
+    assert molmoact2_safetensors_to_flat(src) == "vision_backbone.image_pooling_2d.wk.weight"
+
+
+def test_transformer_to_vlm():
+    src = "model.transformer.blocks.0.attn_norm.weight"
+    assert molmoact2_safetensors_to_flat(src) == "vlm_backbone.blocks.0.attn_norm.weight"
+
+
+def test_action_expert_to_vla_head():
+    src = "model.action_expert.blocks.0.cross_attn.out_proj.weight"
+    assert molmoact2_safetensors_to_flat(src) == "vla_head.blocks.0.cross_attn.out_proj.weight"
+
+
+def test_action_embed():
+    src = "model.action_expert.action_embed.weight"
+    assert molmoact2_safetensors_to_flat(src) == "vla_head.action_embed.weight"
+
+
+def test_lm_head():
+    assert molmoact2_safetensors_to_flat("lm_head.weight") == "vlm_backbone.lm_head.weight"
+
+
+def test_passthrough():
+    assert molmoact2_safetensors_to_flat("some.unknown.key") == "some.unknown.key"


### PR DESCRIPTION
## Summary
- MolmoAct2VLA spine composition: SigLIP2 ViT + Qwen3 Molmo2-ER + flow-matching action expert
- Safetensors mapping: 1295 keys, 3 components (vision, transformer, expert)
- Registry entries: molmoact2-base, molmoact2-libero, molmoact2-droid (all Apache-2.0)
- 7th model family (after pi0, pi0.5, SmolVLA, GR00T, OpenVLA, DreamZero)

## Test plan
- [x] 42/42 tests pass (registry + mapping)
- [x] MolmoAct2VLA imports cleanly
- [x] `reflex models list` shows 3 MolmoAct2 entries

Generated with [Claude Code](https://claude.com/claude-code)