### PR TITLE
serve+bench: harden monolithic serve/bench path + external-data ONNX (v0.11.1)

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -33,17 +33,16 @@ If `--device cuda` errors with "CUDAExecutionProvider not available," see [Troub
 Reflex auto-detects model type from the HuggingFace repo. Pick one based on what you have:
 
 ```bash
-# Smallest, fastest to download — good for first try
+# Orin Nano-safe first try. Export on a dev/cloud box, then copy to Jetson.
 reflex export lerobot/smolvla_base --target orin-nano --output ./smolvla
 
-# pi0 — Physical Intelligence's flagship 3.5B model
-reflex export lerobot/pi0_base --target orin-nano --output ./pi0
+# pi0 / pi0.5 are datacenter targets in Reflex's registry today.
+reflex export lerobot/pi0_base --target desktop --output ./pi0
 
-# pi0.5 — newer pi0 variant with AdaRMSNorm time conditioning
-reflex export lerobot/pi05_base --target orin-nano --output ./pi05
+reflex export lerobot/pi05_base --target desktop --output ./pi05
 
-# GR00T N1.6 — NVIDIA's humanoid model (3.29B)
-reflex export nvidia/GR00T-N1.6-3B --target orin-nano --output ./gr00t
+# GR00T N1.6 needs AGX Orin/Thor/datacenter-class memory, not Orin Nano.
+reflex export nvidia/GR00T-N1.6-3B --target orin --output ./gr00t
 ```
 
 Each command:
@@ -53,7 +52,7 @@ Each command:
 4. Validates the ONNX numerically against the PyTorch reference (max_diff < 1e-5)
 5. If trtexec is available, builds a TensorRT engine
 
-The `--target` flag picks per-hardware tuning (FP16 on Orin, FP8 on Thor, etc.). See `reflex targets` for the full list.
+The `--target` flag picks per-hardware tuning (FP16 on Orin, FP8 on Thor, etc.). It does not make an oversized model fit a small device. Use `reflex models list --device orin_nano` before targeting Jetson Orin Nano.
 
 After export your output directory looks like:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,13 @@ dependencies = [
     # transitively pulled by huggingface_hub on most installs. Required at
     # base level so `reflex pro` commands work on bare `pip install reflex-vla`.
     "cryptography>=42.0",
+    # HTTP client for the `reflex connect` integration framework (#188):
+    # integrations/registry.py + integrations/connector.py call requests.get()
+    # at module import, and the `reflex connect` / `reflex integrations`
+    # commands are core (not behind an extra). Undeclared since #188 — CI clean
+    # installs hit ModuleNotFoundError on tests/test_integrations.py collection
+    # (masked locally where requests is a transitive dep).
+    "requests>=2.28.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/modal_flashrt_bench.py
+++ b/scripts/modal_flashrt_bench.py
@@ -1,41 +1,35 @@
 """Modal: build + bench FlashRT public Python version on L40S.
 
-Validates LiangSu8899/FlashRT's 18× JAX baseline claim on Modal-available
-Ada-class hardware (L40S = SM89, same arch as RTX 4090). Initial attempt
-on A100 (SM80) failed: FlashRT's Pi0.5 RTX frontend uses
-torch.float8_e4m3fn which requires SM89+ tensor cores. L40S is the
-closest Modal-available match to FlashRT's published 4090 numbers.
+Rewritten 2026-05-27 for FlashRT's current HEAD — major changes since
+the 2026-04-30 v3 attempt (all v1-v3 failed on FA2 build issues):
 
-Establishes reflex-vla's reference before Liang's pure-C++ pi05 binary
-arrives ~2026-05-06 for the `--runtime flashrt` integration spike.
+  - Package renamed from ``flash_vla`` → ``flash_rt``
+  - CMake overhaul: GPU_ARCH auto-detection, FA2 slimming flags, SM89
+    build tested by community + documented in docs/deployment_rtx4090.md
+  - Pi0.5 SM89 path confirmed working with FP8 via cuBLASLt
+  - Python API unchanged: ``flash_rt.load_model()`` + ``model.predict()``
 
-Per 2026-04-29 Discord exchange + competitor profile
-`reflex_context/02_research/competitors/flashrt.md`.
+Uses CUDA 12.5 devel image + torch 2.5.1 (matches our prior Modal stack
+for FlashRT; their docs reference CUDA 13 / torch 2.9 in NGC containers
+but the cmake build supports CUDA 12.x fine).
+
+Hardware: L40S (SM89, same compute capability as RTX 4090).
+Cost: ~$5-10 (image build ~$3-5 first time, GPU run ~$2-3).
 
 Usage:
-    modal profile activate suranjana-jain
-    HF_TOKEN=<token> modal run scripts/modal_flashrt_bench.py
-
-Cost: ~$5-8 ($3 image build first time / cached afterward, $2-3 GPU run).
-Wall: ~25-40 min first run (cmake + make on CUTLASS + checkpoint download
-+ FP8 calibration + benchmark), ~5-10 min subsequent runs (cached).
+    modal profile activate novarepmarketing
+    modal run scripts/modal_flashrt_bench.py
 """
 from __future__ import annotations
 
 import os
 import modal
 
-app = modal.App("flashrt-bench")
+app = modal.App("flashrt-bench-v4")
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-
-# Bumped 2026-04-30 to pull Liang's latest HEAD with two fixes:
-# 1) HF pi model loader (norm_stats.json from lerobot/pi05_libero_finetuned_v044
-#    no longer raises FileNotFoundError)
-# 2) install.md compilation notes for FA2_ARCH_NATIVE_ONLY=ON
-# Plus Thor→N1.7 model update.
-# Bump again only when you need a fresh FlashRT git clone.
-_BUILD_BUST = "20260430-ninja-install"
+# Bump this string to force a fresh git clone + rebuild of FlashRT HEAD.
+_BUILD_BUST = "20260527-v3-paligemma-tokenizer"
 
 
 def _hf_secret():
@@ -48,132 +42,88 @@ def _hf_secret():
         return modal.Secret.from_dict({})
 
 
-# Persistent volume to cache the cloned FlashRT + built kernels + HF cache
-# across runs. First run takes the build hit; subsequent runs reuse.
 hf_cache = modal.Volume.from_name("pi0-hf-cache", create_if_missing=True)
-flashrt_cache = modal.Volume.from_name("flashrt-cache", create_if_missing=True)
 HF_CACHE = "/root/.cache/huggingface"
 FLASHRT_DIR = "/opt/flashrt"
 
-
-# Per FlashRT INSTALL.md prerequisites:
-# - CUDA 12.4+ devel image (cmake needs nvcc, not just CUDA runtime)
-# - GCC 11+ (C++17), CMake 3.24+
-# - SM80+ GPU (A100 = SM80, fits)
-# - Python 3.10/3.11/3.12 with the SAME interpreter for cmake AND import
 image = (
     modal.Image.from_registry(
         "nvidia/cuda:12.5.1-cudnn-devel-ubuntu22.04",
         add_python="3.12",
     )
-    .apt_install(
-        "git",
-        "build-essential",
-        "wget",
-        "ninja-build",
-        # NOTE: cmake from apt is 3.22.1 on Ubuntu 22.04 jammy, but FlashRT's
-        # CMakeLists.txt requires 3.24+. We install cmake via pip below so
-        # /usr/local/bin/cmake (3.x latest) wins on PATH.
-    )
+    .apt_install("git", "build-essential", "wget", "ninja-build")
     .pip_install(
-        # cmake>=3.24 required by FlashRT's CMakeLists.txt.
-        # The pip-installed cmake binary lives in /usr/local/bin, which is
-        # before /usr/bin in our PATH env, so it shadows the apt cmake (if any).
         "cmake>=3.24,<4",
-        # FlashRT's torch frontend requires torch + safetensors + numpy.
-        # Pinning torch to match CUDA 12 + SM80.
         "torch==2.5.1",
         "safetensors>=0.4.0",
         "numpy<2.0",
         "pybind11>=2.12",
         "huggingface_hub>=0.20",
         "transformers>=4.40,<5.4",
+        "sentencepiece",
         "Pillow",
+        "ml_dtypes",
     )
-    .run_commands(
-        # Verify versions: cmake (need 3.24+ from pip), gcc (need 11+ from apt).
-        "which cmake && cmake --version && gcc --version",
-    )
+    .run_commands("which cmake && cmake --version && gcc --version")
     .env({
         "HF_HOME": HF_CACHE,
         "TRANSFORMERS_CACHE": f"{HF_CACHE}/transformers",
-        # CMake needs to find the right CUDA + compiler.
         "CUDACXX": "/usr/local/cuda/bin/nvcc",
         "PATH": "/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     })
     .run_commands(
-        # Bust cache for the actual build step so we re-pull FlashRT HEAD
-        # if needed but keep the image base layers cached.
         f'echo "build_bust={_BUILD_BUST}"',
-        # Clone FlashRT + CUTLASS 4.4.2 (pinned per their INSTALL.md §4),
-        # then cmake + make + editable pip install. This is the one-time
-        # ~10-15 min compile step.
+        # Clone latest FlashRT HEAD + CUTLASS 4.4.2 (pinned per their docs).
         f"mkdir -p {FLASHRT_DIR} && cd {FLASHRT_DIR} && "
         "git clone --depth 1 https://github.com/LiangSu8899/FlashRT.git . && "
         "git clone --depth 1 --branch v4.4.2 "
         "  https://github.com/NVIDIA/cutlass.git third_party/cutlass && "
         "mkdir -p build && cd build && "
-        # SM80 = A100 (no FP8), SM86 = A10/A10G (no FP8), SM89 = 4090/L40S (FP8 native),
-        # SM110 = Thor, SM120 = 5090. FlashRT's pi0.5 frontend requires SM89+
-        # for FP8 tensor cores (torch.float8_e4m3fn). Building only SM89 to
-        # match L40S target.
+        # SM89 = L40S/4090 (Ada Lovelace). FA2 vendored in-SO, built for
+        # sm_80 which runs natively on SM89. FA2_ARCH_NATIVE_ONLY skips
+        # sm_120 PTX (requires CUDA 12.8+, we have 12.5).
         "cmake .. -GNinja "
         "  -DCMAKE_BUILD_TYPE=Release "
         "  -DCMAKE_CUDA_ARCHITECTURES=89 "
+        "  -DGPU_ARCH=89 "
         "  -DENABLE_FA2=ON "
-        # FA2_ARCH_NATIVE_ONLY=ON skips sm_80 + compute_120 PTX AOT path.
-        # Required because our CUDA 12.5 image's nvcc doesn't support
-        # compute_120 (Blackwell needs CUDA 12.8+). Documented at
-        # FlashRT/CMakeLists.txt:93.
-        "  -DFA2_ARCH_NATIVE_ONLY=ON && "
+        "  -DFA2_ARCH_NATIVE_ONLY=ON "
+        "  -DFA2_HDIMS='128;256' "
+        "  -DFA2_DTYPES='bf16' && "
         "ninja -j$(nproc) && "
-        # CRITICAL: ninja install copies the built .so files
-        # (flash_vla_kernels.so, flash_vla_fa2.so) FROM build/ INTO
-        # flash_vla/ where pyproject.toml's package_data scoops them up.
-        # Without this, Python imports of flash_vla.flash_vla_fa2 fail
-        # at runtime even though the build linked successfully. Documented
-        # in upstream setup.py.
-        "ninja install && "
-        f"cd {FLASHRT_DIR} && pip install -e '.[torch]'",
-        gpu="L40S",  # cmake reads $CUDA_ARCH_LIST + needs nvcc; build on GPU
+        # Skip `ninja install` — it has a path bug where it can't find
+        # the .so that ninja already linked into flash_rt/. Instead,
+        # manually copy from build/ per docs/deployment_rtx4090.md §4.
+        f"cd {FLASHRT_DIR} && "
+        "cp build/flash_rt_kernels.cpython-312-x86_64-linux-gnu.so "
+        "   flash_rt/flash_rt_kernels.cpython-312-x86_64-linux-gnu.so 2>/dev/null || true && "
+        "cp build/flash_rt_fa2.cpython-312-x86_64-linux-gnu.so "
+        "   flash_rt/flash_rt_fa2.cpython-312-x86_64-linux-gnu.so 2>/dev/null || true && "
+        "pip install -e '.[torch]' && "
+        # FlashRT's Pi0.5 frontend needs the PaliGemma tokenizer .model
+        # file which isn't bundled with HF checkpoints.
+        "mkdir -p /root/.cache/flash_rt && "
+        "curl -L https://storage.googleapis.com/big_vision/paligemma_tokenizer.model "
+        "  -o /root/.cache/flash_rt/paligemma_tokenizer.model",
+        gpu="L40S",
     )
-    # Late-stage deps that aren't in FlashRT's pyproject extras.
-    # Kept in a separate pip_install AFTER the run_commands so adding
-    # them doesn't invalidate the expensive FA2 build cache.
-    #
-    # ml_dtypes — required by flash_vla.models.pi05.pipeline_rtx (line 45);
-    #             surfaced via v5's GPU_FAIL.
-    # flash-attn — required by flash_vla.hardware.rtx.attn_backend (line 354);
-    #             surfaced via v8's GPU_FAIL. Comment in upstream:
-    #             "Always import flash_attn: used either as the full legacy
-    #             backend (when _use_fvk_fa2 is False) or as per-site fallback
-    #             when FVK_RTX_FA2_SITES excludes some sites during bisection."
-    #             Despite us building flash_vla_fa2 successfully (v8 cleared
-    #             the previous blocker), the SM89 codepath still needs
-    #             pip flash-attn for non-vendored attention sites.
-    .pip_install("ml_dtypes", "flash-attn", extra_options="--no-build-isolation")
 )
 
 
 @app.function(
     image=image,
-    gpu="L40S",  # SM89 — closest Modal-available match to FlashRT's published 4090 numbers
-    volumes={HF_CACHE: hf_cache, FLASHRT_DIR + "_cache": flashrt_cache},
+    gpu="L40S",
+    volumes={HF_CACHE: hf_cache},
     secrets=[_hf_secret()],
-    timeout=2400,  # 40 min hard cap
+    timeout=2400,
 )
 def bench(
     checkpoint_id: str = "lerobot/pi05_libero_finetuned_v044",
-    benchmark_iters: int = 20,
-    warmup_iters: int = 50,
+    benchmark_iters: int = 50,
+    warmup_iters: int = 100,
     num_views: int = 2,
     prompt: str = "pick up the red block and place it in the tray",
 ):
-    """Run FlashRT's bundled quickstart benchmark + compare to reflex-vla
-    cuda-graphs A/B numbers.
-
-    Returns dict with measured latency stats + verification info.
-    """
     import json
     import os
     import subprocess
@@ -188,37 +138,27 @@ def bench(
     print(f"num_views: {num_views}")
     print("=" * 60)
 
-    # ---- 1. Verify FlashRT is built + importable ----
-    # Public surface = flash_vla.load_model + flash_vla.VLAModel only;
-    # compiled .so kernels are loaded internally by frontends.
-    print("\n[1/4] verifying flash_vla import...", flush=True)
+    # 1. Verify flash_rt is importable
+    print("\n[1/4] verifying flash_rt import...", flush=True)
     try:
-        import flash_vla
-        print(f"  flash_vla.__version__ = {getattr(flash_vla, '__version__', '(no __version__)')}")
-        assert hasattr(flash_vla, "load_model"), "flash_vla.load_model missing"
-        assert hasattr(flash_vla, "VLAModel"), "flash_vla.VLAModel missing"
-        print(f"  flash_vla.load_model + VLAModel exposed OK")
+        import flash_rt
+        print(f"  flash_rt version: {getattr(flash_rt, '__version__', '(none)')}")
+        assert hasattr(flash_rt, "load_model"), "flash_rt.load_model missing"
+        print("  flash_rt.load_model OK")
     except Exception as exc:
         return {"status": "fail", "stage": "import", "error": repr(exc)}
 
-    # ---- 2. Download checkpoint via HF cache ----
+    # 2. Download checkpoint
     print(f"\n[2/4] downloading {checkpoint_id}...", flush=True)
     from huggingface_hub import snapshot_download
     try:
-        ckpt_path = snapshot_download(
-            repo_id=checkpoint_id,
-            cache_dir=HF_CACHE,
-        )
+        ckpt_path = snapshot_download(repo_id=checkpoint_id, cache_dir=HF_CACHE)
         print(f"  checkpoint at: {ckpt_path}")
-        # FlashRT expects a directory containing the safetensors weights;
-        # explore the structure to find the right subdirectory.
-        for entry in Path(ckpt_path).iterdir():
-            print(f"  - {entry.name}")
     except Exception as exc:
         return {"status": "fail", "stage": "checkpoint_download", "error": repr(exc)}
 
-    # ---- 3. Run quickstart benchmark ----
-    print(f"\n[3/4] running examples/quickstart.py --benchmark {benchmark_iters}...", flush=True)
+    # 3. Run quickstart benchmark
+    print(f"\n[3/4] running quickstart.py --benchmark {benchmark_iters}...", flush=True)
     cmd = [
         sys.executable,
         f"{FLASHRT_DIR}/examples/quickstart.py",
@@ -229,61 +169,54 @@ def bench(
         "--benchmark", str(benchmark_iters),
         "--warmup", str(warmup_iters),
         "--autotune", "3",
+        "--config", "pi05",
+        "--hardware", "rtx_sm89",
     ]
     print(f"  cmd: {' '.join(cmd)}")
     t0 = time.perf_counter()
     proc = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        env={**os.environ},
-        timeout=1800,
+        cmd, capture_output=True, text=True, env={**os.environ}, timeout=1800,
     )
     wall_s = time.perf_counter() - t0
-    print(f"\n--- quickstart stdout ---")
-    print(proc.stdout[-4000:] if len(proc.stdout) > 4000 else proc.stdout)
+    print(f"\n--- stdout ---")
+    print(proc.stdout[-6000:] if len(proc.stdout) > 6000 else proc.stdout)
     if proc.returncode != 0:
-        print(f"\n--- quickstart stderr ---")
-        print(proc.stderr[-2000:])
+        print(f"\n--- stderr ---")
+        print(proc.stderr[-4000:])
         return {
             "status": "fail",
             "stage": "benchmark",
             "exit_code": proc.returncode,
-            "stderr_tail": proc.stderr[-2000:],
+            "stderr_tail": proc.stderr[-4000:],
+            "stdout_tail": proc.stdout[-4000:],
             "wall_s": wall_s,
         }
     print(f"\n  wall: {wall_s:.1f}s, exit 0")
 
-    # ---- 4. Summarize ----
-    print(f"\n[4/4] summary")
-    print(f"  reflex-vla cuda-graphs A/B (A100, pi0.5 num_steps=10):")
-    print(f"    OFF: 270.85 ms / chunk")
-    print(f"    ON:  207.74 ms / chunk (1.30x speedup)")
-    print(f"  See reflex_context/03_experiments/2026-04-29-cuda-graphs-ab-modal-a100.md")
-    print(f"  (note: A100 ≠ this L40S run — separate L40S A/B needed for true apples-to-apples)")
-    print(f"")
-    print(f"  FlashRT published numbers (Ada-class):")
-    print(f"    Pi0.5 RTX 4090: published reference (Liang's repo)")
-    print(f"    Pi0.5 RTX 5090: 17.58 ms (57 Hz)")
-    print(f"    Pi0.5 Thor:     44 ms / 39.78 ms NVFP4")
-    print(f"    L40S: not published, this run is the first reference")
+    # 4. Summary + comparison context
+    print(f"\n[4/4] context")
+    print(f"  Reflex Triton+Graph (A100, pi0.5): 51.0 ms (2.5x over PyTorch)")
+    print(f"  Reflex cuda-graphs A/B (A100):     207.74 ms / chunk (1.30x)")
+    print(f"  FlashRT published (4090):           community-tested SM89")
+    print(f"  FlashRT published (5090):           17.58 ms Pi0.5 2-view")
+    print(f"  FlashRT published (Thor):           44 ms / 39.78 ms NVFP4")
+    print(f"  This run: L40S (SM89, datacenter Ada)")
 
     return {
         "status": "ok",
         "checkpoint": checkpoint_id,
         "wall_s": wall_s,
-        "stdout_tail": proc.stdout[-4000:] if len(proc.stdout) > 4000 else proc.stdout,
+        "stdout_tail": proc.stdout[-6000:] if len(proc.stdout) > 6000 else proc.stdout,
     }
 
 
 @app.local_entrypoint()
 def main(
     checkpoint_id: str = "lerobot/pi05_libero_finetuned_v044",
-    benchmark_iters: int = 20,
-    warmup_iters: int = 50,
+    benchmark_iters: int = 50,
+    warmup_iters: int = 100,
 ):
-    """Local entrypoint."""
-    print("FlashRT bench → A100-80GB → quickstart --benchmark")
+    print("FlashRT bench → L40S (SM89) → quickstart --benchmark")
     print(f"  checkpoint: {checkpoint_id}")
     print(f"  iters: {benchmark_iters} (warmup: {warmup_iters})")
     print()
@@ -300,7 +233,7 @@ def main(
     if result.get("status") == "ok":
         print(f"  wall:   {result.get('wall_s', '?'):.1f}s")
         print()
-        print("Stdout tail (last ~4000 chars):")
+        print("Stdout tail:")
         print(result.get("stdout_tail", "(none)"))
     else:
         print(f"  stage:  {result.get('stage')}")

--- a/scripts/modal_verify_bench_all.py
+++ b/scripts/modal_verify_bench_all.py
@@ -11,9 +11,12 @@ Capture inference_mode and per-chunk latency from the bench output.
 
 Usage:
     modal run scripts/modal_verify_bench_all.py
+    modal run scripts/modal_verify_bench_all.py --gpu L40S --models smolvla,pi0
+    modal run scripts/modal_verify_bench_all.py --gpu L40S --source local --spawn-only
 """
 
 import modal
+from pathlib import Path
 
 app = modal.App("reflex-bench-all-verify")
 
@@ -22,34 +25,165 @@ image = (
         "nvcr.io/nvidia/tensorrt:24.10-py3",
         add_python="3.12",
     )
-    .apt_install("git")
+    .apt_install("git", "clang", "build-essential")
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+local_image = image.add_local_dir(
+    _REPO_ROOT,
+    "/workspace/reflex-vla",
+    copy=True,
+    ignore=[
+        ".git",
+        ".venv",
+        ".mypy_cache",
+        "dist",
+        "build",
+        "build_binary",
+        "reference",
+        ".pytest_cache",
+        ".ruff_cache",
+        "**/__pycache__",
+        "*.pyc",
+    ],
 )
 
 
-@app.function(image=image, gpu="A10G", timeout=3600)
-def run_all():
+def _run_streamed(cmd, *, timeout: int):
     import os
-    import re
+    import selectors
     import subprocess
     import time
 
-    # Install reflex from git (clean install path — same as users get)
-    print("=== Installing reflex-vla[serve,gpu] from git ===", flush=True)
-    r = subprocess.run(
-        ["pip", "install",
-         "reflex-vla[serve,gpu] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/reflex-vla"],
-        capture_output=True, text=True, timeout=600,
+    started = time.time()
+    heartbeat_s = 60.0
+    last_heartbeat = started
+    env = os.environ.copy()
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=0,
+        env=env,
     )
-    if r.returncode != 0:
-        return {"error": "pip install failed", "stderr": r.stderr[-1000:]}
-    print("  install ok", flush=True)
+    lines: list[str] = []
+    timed_out = False
+    assert proc.stdout is not None
+    fd = proc.stdout.fileno()
+    os.set_blocking(fd, False)
+    selector = selectors.DefaultSelector()
+    selector.register(fd, selectors.EVENT_READ)
+    try:
+        while True:
+            now = time.time()
+            elapsed = now - started
+            if elapsed > timeout:
+                timed_out = True
+                proc.kill()
+                returncode = proc.wait()
+                break
 
-    models = [
+            if proc.poll() is not None:
+                while True:
+                    try:
+                        chunk = os.read(fd, 65536)
+                    except BlockingIOError:
+                        break
+                    if not chunk:
+                        break
+                    text = chunk.decode("utf-8", errors="replace")
+                    print(text, end="", flush=True)
+                    lines.append(text)
+                returncode = proc.returncode
+                break
+
+            events = selector.select(timeout=1.0)
+            if events:
+                try:
+                    chunk = os.read(fd, 65536)
+                except BlockingIOError:
+                    chunk = b""
+                if chunk:
+                    text = chunk.decode("utf-8", errors="replace")
+                    print(text, end="", flush=True)
+                    lines.append(text)
+                continue
+
+            now = time.time()
+            if now - last_heartbeat >= heartbeat_s:
+                print(
+                    f"[modal-verify] still running ({now - started:.0f}s/{timeout}s): "
+                    + " ".join(str(part) for part in cmd[:4]),
+                    flush=True,
+                )
+                last_heartbeat = now
+    finally:
+        selector.close()
+
+    return {
+        "returncode": returncode,
+        "timed_out": timed_out,
+        "stdout": "".join(lines),
+        "elapsed_s": time.time() - started,
+    }
+
+
+def _run_all_impl(
+    gpu_label: str = "A10G",
+    models_csv: str = "",
+    export_timeout: int = 1800,
+    artifact_dir: str = "/tmp/reflex_bench_artifacts",
+    source: str = "git",
+):
+    import os
+    import json
+    import re
+    import time
+    from pathlib import Path
+
+    # Install reflex. "git" validates the public install path; "local" validates
+    # the exact dirty worktree mounted into the Modal image.
+    source_norm = source.lower()
+    # This script runs on NVIDIA's TensorRT NGC image, so libnvinfer is already
+    # present. Use gpu-min to avoid rebuilding/downloading PyPI's multi-GB
+    # TensorRT wheel while still installing ORT-GPU and CUDA libs.
+    extras = "serve,gpu-min,monolithic"
+    install_cmd = [
+        "pip", "install",
+        f"reflex-vla[{extras}] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/reflex-vla",
+    ]
+    if source_norm == "local":
+        install_cmd = ["pip", "install", "-e", f"/workspace/reflex-vla[{extras}]"]
+    print(
+        f"=== Installing reflex-vla[{extras}] from {source_norm} ===",
+        flush=True,
+    )
+    r = _run_streamed(
+        install_cmd,
+        timeout=900,
+    )
+    if r["returncode"] != 0:
+        return {
+            "error": "pip install failed",
+            "timed_out": r["timed_out"],
+            "stdout_tail": r["stdout"][-4000:],
+        }
+    print("  install ok", flush=True)
+    Path(artifact_dir).mkdir(parents=True, exist_ok=True)
+
+    all_models = [
         ("smolvla", "lerobot/smolvla_base"),
         ("pi0", "lerobot/pi0_base"),
         ("pi05", "lerobot/pi05_base"),
         ("gr00t", "nvidia/GR00T-N1.6-3B"),
     ]
+    if models_csv:
+        wanted = {m.strip() for m in models_csv.split(",") if m.strip()}
+        models = [m for m in all_models if m[0] in wanted]
+    else:
+        models = all_models
 
     results = {}
     for tag, hf_id in models:
@@ -58,32 +192,41 @@ def run_all():
 
         # Export
         t0 = time.time()
-        r = subprocess.run(
+        r = _run_streamed(
             ["reflex", "export", hf_id, "--target", "desktop", "--output", export_dir],
-            capture_output=True, text=True, timeout=900,
+            timeout=export_timeout,
         )
         export_s = time.time() - t0
-        if r.returncode != 0:
-            results[tag] = {"export_error": r.stderr[-500:]}
-            print(f"  EXPORT FAIL ({export_s:.1f}s): {r.stderr[-300:]}", flush=True)
+        if r["returncode"] != 0:
+            results[tag] = {
+                "export_s": round(export_s, 1),
+                "export_error": r["stdout"][-4000:],
+                "export_timed_out": r["timed_out"],
+            }
+            reason = "TIMEOUT" if r["timed_out"] else "FAIL"
+            print(f"  EXPORT {reason} ({export_s:.1f}s)", flush=True)
             continue
         files = os.listdir(export_dir)
         print(f"  export ok ({export_s:.1f}s, files={files})", flush=True)
 
         # Bench
         t0 = time.time()
-        r = subprocess.run(
+        report_json = str(Path(artifact_dir) / f"{tag}_{gpu_label.lower()}_bench.json")
+        report_md = str(Path(artifact_dir) / f"{tag}_{gpu_label.lower()}_bench.md")
+        r = _run_streamed(
             ["reflex", "bench", export_dir, "--iterations", "50", "--warmup", "10",
-             "--device", "cuda"],
-            capture_output=True, text=True, timeout=600,
+             "--device", "cuda", "--report-json", report_json, "--report", report_md],
+            timeout=900,
         )
         bench_s = time.time() - t0
-        if r.returncode != 0:
+        if r["returncode"] != 0:
             results[tag] = {
                 "export_s": round(export_s, 1),
-                "bench_error": r.stderr[-500:] or r.stdout[-500:],
+                "bench_error": r["stdout"][-4000:],
+                "bench_timed_out": r["timed_out"],
             }
-            print(f"  BENCH FAIL ({bench_s:.1f}s): {r.stdout[-400:]}", flush=True)
+            reason = "TIMEOUT" if r["timed_out"] else "FAIL"
+            print(f"  BENCH {reason} ({bench_s:.1f}s)", flush=True)
             continue
 
         # Parse the bench output. The CLI prints lines like:
@@ -93,34 +236,62 @@ def run_all():
         #   p99     12.01 ms
         #   hz       86.8
         #   Inference mode: onnx_trt_fp16
-        out = r.stdout
+        out = r["stdout"]
         def _parse(label):
             m = re.search(rf"^\s*{re.escape(label)}\s+([\d.]+)\s*ms?", out, re.MULTILINE)
             return float(m.group(1)) if m else None
 
         mode_match = re.search(r"Inference mode:\s*(\S+)", out)
         mode = mode_match.group(1) if mode_match else "?"
+        provider_match = re.search(r"Provider:\s*(\S+)", out)
+        provider_mode = provider_match.group(1) if provider_match else "?"
+        active_match = re.search(r"Active EP:\s*(.+)", out)
+        active_providers = (
+            [p.strip() for p in active_match.group(1).split(",")]
+            if active_match else []
+        )
+
+        report_payload = None
+        if Path(report_json).exists():
+            try:
+                report_payload = json.loads(Path(report_json).read_text())
+                stats = report_payload.get("stats", {})
+                env = report_payload.get("environment", {})
+                provider_mode = env.get("provider_mode") or provider_mode
+                active_providers = env.get("active_providers") or active_providers
+            except Exception as exc:
+                print(f"  report parse skipped: {exc}", flush=True)
+                stats = {}
+        else:
+            stats = {}
 
         results[tag] = {
             "export_s": round(export_s, 1),
             "bench_s": round(bench_s, 1),
-            "mean_ms": _parse("mean"),
-            "p50_ms": _parse("p50"),
-            "p95_ms": _parse("p95"),
-            "p99_ms": _parse("p99"),
-            "min_ms": _parse("min"),
+            "mean_ms": stats.get("mean_ms") or _parse("mean"),
+            "p50_ms": stats.get("p50_ms") or _parse("p50"),
+            "p95_ms": stats.get("p95_ms") or _parse("p95"),
+            "p99_ms": stats.get("p99_ms") or _parse("p99"),
+            "p99_9_ms": stats.get("p99_9_ms"),
+            "min_ms": stats.get("min_ms") or _parse("min"),
             "inference_mode": mode,
+            "provider_mode": provider_mode,
+            "active_providers": active_providers,
+            "report_json": report_json if Path(report_json).exists() else None,
+            "report_md": report_md if Path(report_md).exists() else None,
+            "report": report_payload,
         }
         print(f"  bench ok ({bench_s:.1f}s): mean={results[tag]['mean_ms']}ms "
-              f"p95={results[tag]['p95_ms']}ms mode={mode}", flush=True)
+              f"p95={results[tag]['p95_ms']}ms mode={mode} provider={provider_mode}",
+              flush=True)
 
         # Free disk between models — checkpoints are huge
-        subprocess.run(["rm", "-rf", export_dir], check=False)
+        _run_streamed(["rm", "-rf", export_dir], timeout=60)
 
     print(f"\n{'='*80}", flush=True)
-    print("VERDICT — `reflex bench` works for all 4 VLAs", flush=True)
+    print(f"VERDICT — `reflex bench` on {gpu_label}", flush=True)
     print(f"{'='*80}", flush=True)
-    print(f"{'Model':<10} {'mean_ms':>10} {'p95_ms':>10} {'mode':>20} {'export_s':>10}", flush=True)
+    print(f"{'Model':<10} {'mean_ms':>10} {'p95_ms':>10} {'provider':>16} {'mode':>20} {'export_s':>10}", flush=True)
     for tag, r in results.items():
         if "export_error" in r:
             print(f"{tag:<10} EXPORT FAILED", flush=True)
@@ -130,15 +301,107 @@ def run_all():
             mean = r.get("mean_ms", "—")
             p95 = r.get("p95_ms", "—")
             mode = r.get("inference_mode", "?")
+            provider = r.get("provider_mode", "?")
             exp = f"{r.get('export_s', 0)}s"
-            print(f"{tag:<10} {str(mean):>10} {str(p95):>10} {mode:>20} {exp:>10}", flush=True)
+            print(f"{tag:<10} {str(mean):>10} {str(p95):>10} {provider:>16} {mode:>20} {exp:>10}", flush=True)
+    print("\n=== JSON ===", flush=True)
+    print(json.dumps(results, indent=2, default=str), flush=True)
     return results
 
 
+@app.function(image=image, gpu="A10G", timeout=7200)
+def run_all_a10g(models_csv: str = "", export_timeout: int = 1800, artifact_dir: str = "/tmp/reflex_bench_artifacts"):
+    return _run_all_impl(
+        gpu_label="A10G",
+        models_csv=models_csv,
+        export_timeout=export_timeout,
+        artifact_dir=artifact_dir,
+        source="git",
+    )
+
+
+@app.function(image=image, gpu="L40S", timeout=7200)
+def run_all_l40s(models_csv: str = "", export_timeout: int = 1800, artifact_dir: str = "/tmp/reflex_bench_artifacts"):
+    return _run_all_impl(
+        gpu_label="L40S",
+        models_csv=models_csv,
+        export_timeout=export_timeout,
+        artifact_dir=artifact_dir,
+        source="git",
+    )
+
+
+@app.function(image=local_image, gpu="A10G", timeout=7200)
+def run_all_a10g_local(models_csv: str = "", export_timeout: int = 1800, artifact_dir: str = "/tmp/reflex_bench_artifacts"):
+    return _run_all_impl(
+        gpu_label="A10G",
+        models_csv=models_csv,
+        export_timeout=export_timeout,
+        artifact_dir=artifact_dir,
+        source="local",
+    )
+
+
+@app.function(image=local_image, gpu="L40S", timeout=7200)
+def run_all_l40s_local(models_csv: str = "", export_timeout: int = 1800, artifact_dir: str = "/tmp/reflex_bench_artifacts"):
+    return _run_all_impl(
+        gpu_label="L40S",
+        models_csv=models_csv,
+        export_timeout=export_timeout,
+        artifact_dir=artifact_dir,
+        source="local",
+    )
+
+
 @app.local_entrypoint()
-def main():
-    print("Verifying `reflex bench` works for all 4 VLAs (auto-TRT)\n")
-    r = run_all.remote()
+def main(
+    gpu: str = "A10G",
+    models: str = "",
+    export_timeout: int = 1800,
+    artifact_dir: str = "/tmp/reflex_bench_artifacts",
+    source: str = "git",
+    spawn_only: bool = False,
+):
     import json
+
+    gpu_norm = gpu.upper()
+    source_norm = source.lower()
+    print(f"Verifying `reflex bench` works on {gpu_norm} (auto-TRT, source={source_norm})\n")
+    if gpu_norm == "A10G" and source_norm == "git":
+        fn = run_all_a10g
+    elif gpu_norm == "L40S" and source_norm == "git":
+        fn = run_all_l40s
+    elif gpu_norm == "A10G" and source_norm == "local":
+        fn = run_all_a10g_local
+    elif gpu_norm == "L40S" and source_norm == "local":
+        fn = run_all_l40s_local
+    else:
+        raise ValueError(
+            f"Unsupported --gpu/source {gpu!r}/{source!r}; expected gpu A10G|L40S "
+            f"and source git|local"
+        )
+
+    kwargs = {
+        "models_csv": models,
+        "export_timeout": export_timeout,
+        "artifact_dir": artifact_dir,
+    }
+    if spawn_only:
+        call = fn.spawn(**kwargs)
+        call.hydrate()
+        payload = {
+            "function_call_id": call.object_id,
+            "gpu": gpu_norm,
+            "source": source_norm,
+            "models": models,
+            "artifact_dir": artifact_dir,
+        }
+        print("\n=== SPAWNED ===")
+        print(json.dumps(payload, indent=2, default=str))
+        print("\nUse `modal app logs reflex-bench-all-verify -f` to stream remote logs.")
+        print("Use `modal.FunctionCall.from_id(<id>).get()` to fetch the result later.")
+        return
+
+    r = fn.remote(**kwargs)
     print("\n=== JSON ===")
     print(json.dumps(r, indent=2, default=str))

--- a/src/reflex/__init__.py
+++ b/src/reflex/__init__.py
@@ -1,6 +1,6 @@
 """Reflex — Deploy any VLA model to any edge hardware. One command."""
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 # Heavy submodules (validate_roundtrip pulls in torch) are lazy-loaded so that
 # `reflex --version`, `reflex --help`, `reflex chat`, etc. don't pay the

--- a/src/reflex/bench/report.py
+++ b/src/reflex/bench/report.py
@@ -52,6 +52,8 @@ class BenchEnvironment:
     export_dir: str
     inference_mode: str  # e.g. "onnx_trt_fp16", "onnx_cpu"
     device: str  # "cuda" / "cpu"
+    provider_mode: str = ""  # e.g. "onnx_trt_fp16", "onnx_gpu", "onnx_cpu"
+    active_providers: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -114,14 +116,30 @@ def _reflex_version() -> str:
         return "0.1.0+dev"
 
 
+def _sha256_prefix(path: Path, prefix_len: int = 16) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(16 * 1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()[:prefix_len]
+
+
 def _onnx_file_summary(export_dir: Path) -> list[dict]:
-    """Hash + size of each *.onnx file under the export dir."""
+    """Hash + size ONNX model files, including external-data weight files."""
     out: list[dict] = []
-    for p in sorted(export_dir.glob("*.onnx")):
+    patterns = ("*.onnx", "*.onnx.data", "*.data")
+    files: list[Path] = []
+    for pattern in patterns:
+        files.extend(export_dir.glob(pattern))
+    for p in sorted(set(files)):
         try:
-            data = p.read_bytes()
-            h = hashlib.sha256(data).hexdigest()[:16]
-            out.append({"name": p.name, "sha256_prefix": h, "bytes": len(data)})
+            out.append(
+                {
+                    "name": p.name,
+                    "sha256_prefix": _sha256_prefix(p),
+                    "bytes": p.stat().st_size,
+                }
+            )
         except Exception:
             out.append({"name": p.name, "sha256_prefix": "", "bytes": -1})
     return out
@@ -131,6 +149,8 @@ def capture_environment(
     export_dir: str | Path,
     device: str = "cuda",
     inference_mode: str = "",
+    provider_mode: str = "",
+    active_providers: list[str] | None = None,
     seed: int = 0,
     repo_dir: str | Path | None = None,
 ) -> BenchEnvironment:
@@ -153,6 +173,8 @@ def capture_environment(
         export_dir=str(export_path),
         inference_mode=inference_mode,
         device=device,
+        provider_mode=provider_mode,
+        active_providers=list(active_providers or []),
     )
 
 
@@ -225,6 +247,8 @@ class BenchReport:
             f"- **onnxruntime**: `{e.ort_version or 'n/a'}`",
             f"- **device**: `{e.device}`",
             f"- **inference_mode**: `{e.inference_mode or 'n/a'}`",
+            f"- **provider_mode**: `{e.provider_mode or 'n/a'}`",
+            f"- **active_providers**: `{', '.join(e.active_providers) or 'n/a'}`",
             f"- **seed**: `{e.seed}`",
             f"- **export_dir**: `{e.export_dir}`",
             "",

--- a/src/reflex/cli.py
+++ b/src/reflex/cli.py
@@ -62,6 +62,17 @@ def _looks_like_pi05_model_ref(model: str) -> bool:
     return "pi05" in normalized or "pi0.5" in model.lower()
 
 
+def _is_jetson_linux_aarch64() -> bool:
+    """Return True when running on a Jetson-class Linux/aarch64 host."""
+    import platform
+
+    return (
+        platform.system().lower() == "linux"
+        and platform.machine().lower() in {"aarch64", "arm64"}
+        and Path("/etc/nv_tegra_release").exists()
+    )
+
+
 def _version_callback(value: bool) -> None:
     if value:
         typer.echo(
@@ -814,8 +825,51 @@ def benchmark_cmd(
     if benchmark:
         console.print(f"  Benchmark: [cyan]{benchmark}[/cyan] ({episodes_per_task} eps/task)")
 
-    from reflex.runtime.server import ReflexServer
-    server = ReflexServer(export_dir, device=device, strict_providers=False)
+    config_path = export_path / "reflex_config.json"
+    export_config = {}
+    if config_path.exists():
+        try:
+            export_config = json.loads(config_path.read_text())
+        except Exception:
+            export_config = {}
+
+    if export_config.get("export_kind") == "monolithic":
+        model_type = export_config.get("model_type", "smolvla")
+        if model_type == "pi0":
+            from reflex.runtime.pi0_onnx_server import Pi0OnnxServer
+            server = Pi0OnnxServer(
+                export_dir,
+                device=device,
+                max_batch=1,
+                strict_providers=False,
+            )
+        elif model_type == "pi05":
+            from reflex.runtime.pi05_onnx_server import Pi05OnnxServer
+            server = Pi05OnnxServer(
+                export_dir,
+                device=device,
+                max_batch=1,
+                strict_providers=False,
+            )
+        elif model_type == "smolvla":
+            from reflex.runtime.smolvla_onnx_server import SmolVLAOnnxServer
+            server = SmolVLAOnnxServer(
+                export_dir,
+                device=device,
+                max_batch=1,
+                strict_providers=False,
+            )
+        elif model_type == "gr00t":
+            from reflex.runtime.server import ReflexServer
+            server = ReflexServer(export_dir, device=device, strict_providers=False)
+        else:
+            err_console.print(
+                f"[red]Benchmark does not support monolithic model_type={model_type!r} yet.[/red]"
+            )
+            raise typer.Exit(2)
+    else:
+        from reflex.runtime.server import ReflexServer
+        server = ReflexServer(export_dir, device=device, strict_providers=False)
     console.print("[dim]Loading model...[/dim]")
     t0 = _t.perf_counter()
     server.load()
@@ -823,9 +877,19 @@ def benchmark_cmd(
     if not server.ready:
         err_console.print("[red]Model failed to load.[/red]")
         raise typer.Exit(1)
+    provider_mode = getattr(server, "_provider_mode", getattr(server, "_inference_mode", ""))
+    active_providers = list(getattr(server, "_active_providers", []) or [])
+    if not active_providers and getattr(server, "_ort_session", None) is not None:
+        try:
+            active_providers = list(server._ort_session.get_providers())
+        except Exception:
+            active_providers = []
     console.print(
         f"  Loaded:    {load_s:.1f}s  (mode={server._inference_mode})"
     )
+    console.print(f"  Provider:  {provider_mode or 'unknown'}")
+    if active_providers:
+        console.print(f"  Active EP: {', '.join(active_providers)}")
 
     # Warmup
     console.print(f"[dim]Warming up ({warmup} iterations)...[/dim]")
@@ -864,7 +928,7 @@ def benchmark_cmd(
     console.print(
         f"\n  [dim]Inference mode:[/dim] [bold]{server._inference_mode}[/bold]"
     )
-    if server._inference_mode == "onnx_cpu" and device == "cuda":
+    if provider_mode == "onnx_cpu" and device == "cuda":
         console.print(
             "  [yellow]Note: requested device=cuda but ended up on CPU. "
             "Install onnxruntime-gpu and CUDA 12 + cuDNN 9 for GPU performance.[/yellow]"
@@ -887,6 +951,8 @@ def benchmark_cmd(
             export_dir=export_dir,
             device=device,
             inference_mode=server._inference_mode,
+            provider_mode=provider_mode,
+            active_providers=active_providers,
             seed=seed,
         )
         bench_report = BenchReport(
@@ -3729,6 +3795,20 @@ def go(
     console.print(f"  strategy: {resolution.matched_strategy}")
     for note in resolution.notes:
         console.print(f"  [yellow]note:[/yellow] {note}")
+
+    if entry.requires_export and _is_jetson_linux_aarch64():
+        err_console.print(
+            "[red]This registry entry ships raw PyTorch/LeRobot weights, and "
+            "`reflex go` cannot export those inline on Jetson.[/red]"
+        )
+        console.print(
+            "\nExport on a Python 3.12+ dev/cloud box, then copy the ONNX export "
+            "to the Jetson and serve it there:\n"
+            f"  [cyan]reflex export {entry.hf_repo} --target orin-nano --output ./export[/cyan]\n"
+            "  [cyan]scp -r ./export jetson:~/export[/cyan]\n"
+            "  [cyan]reflex serve ~/export --device cuda --port 8000[/cyan]"
+        )
+        raise typer.Exit(2)
 
     # Step 3: target dir
     target = Path(target_dir) if target_dir else (Path.home() / ".cache" / "reflex" / "models" / entry.model_id)

--- a/src/reflex/cli.py
+++ b/src/reflex/cli.py
@@ -4103,10 +4103,10 @@ def connect_up(
     try:
         result = connect(name, extra_args=extra_args)
     except ValueError as e:
-        console.print(f"[red]{e}[/red]")
+        err_console.print(f"[red]{e}[/red]")
         raise typer.Exit(2)
     except RuntimeError as e:
-        console.print(f"[red]{e}[/red]")
+        err_console.print(f"[red]{e}[/red]")
         raise typer.Exit(1)
 
     if result["status"] == "already_running":
@@ -4143,7 +4143,7 @@ def connect_status(
     console = Console()
     integration = get_integration(name)
     if integration is None:
-        console.print(f"[red]Unknown integration: {name}[/red]")
+        err_console.print(f"[red]Unknown integration: {name}[/red]")
         raise typer.Exit(2)
 
     installed = integration.is_installed()

--- a/src/reflex/exporters/monolithic.py
+++ b/src/reflex/exporters/monolithic.py
@@ -58,6 +58,59 @@ _CCM_NONE_RATIONALE = (
     "num_steps=10. See 01_architecture/pi0_monolithic_wrap_pattern.md."
 )
 
+_TOKENIZER_REFS = {
+    "pi0": "google/paligemma-3b-pt-224",
+    "pi05": "google/paligemma-3b-pt-224",
+    "smolvla": "HuggingFaceTB/SmolLM2-135M",
+}
+
+
+def _quiet_noisy_export_loggers() -> None:
+    """Keep streamed export logs readable while preserving warnings/errors."""
+    for name in ("onnx_ir", "onnxscript"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
+def _bundle_tokenizer(output_dir: Path, model_type: str) -> dict[str, Any]:
+    """Best-effort tokenizer bundle for offline serve/bench.
+
+    Tokenizer failure should not fail ONNX export: pi0's canonical PaliGemma
+    tokenizer may be gated on HF, while the model graph itself can still export
+    and serve pre-tokenized requests. When bundling succeeds, runtimes load from
+    ``export_dir/tokenizer`` with ``local_files_only=True``.
+    """
+    tokenizer_ref = _TOKENIZER_REFS.get(model_type)
+    meta: dict[str, Any] = {
+        "tokenizer_ref": tokenizer_ref,
+        "tokenizer_path": None,
+        "tokenizer_bundled": False,
+        "tokenizer_error": None,
+    }
+    if not tokenizer_ref:
+        return meta
+    try:
+        from transformers import AutoTokenizer
+        tok = AutoTokenizer.from_pretrained(tokenizer_ref)
+        if getattr(tok, "pad_token", None) is None and getattr(tok, "eos_token", None) is not None:
+            tok.pad_token = tok.eos_token
+        tok_dir = output_dir / "tokenizer"
+        tok.save_pretrained(tok_dir)
+        meta.update(
+            {
+                "tokenizer_path": "tokenizer",
+                "tokenizer_bundled": True,
+            }
+        )
+    except Exception as exc:
+        meta["tokenizer_error"] = f"{type(exc).__name__}: {exc}"
+        logger.warning(
+            "[export] tokenizer bundle skipped for %s (%s): %s",
+            model_type,
+            tokenizer_ref,
+            exc,
+        )
+    return meta
+
 
 def _require_monolithic_deps() -> None:
     """Check that the ``[monolithic]`` optional dep group is installed.
@@ -65,6 +118,7 @@ def _require_monolithic_deps() -> None:
     Raises ImportError with a clean message if anything's missing or a
     transformers version mismatch is detected (5.4+ has the q_length bug).
     """
+    _quiet_noisy_export_loggers()
     missing = []
     try:
         import transformers
@@ -161,6 +215,82 @@ def apply_export_patches() -> None:
             _pg.create_causal_mask = _ccm_shim
     except ImportError:
         pass
+
+    # SmolVLM's vision tower builds patch_attention_mask internally when it is
+    # omitted. Under torch.export + onnx-diagnostic FakeTensor tracing that
+    # internal path can produce a zero-length attention mask which later tries
+    # to broadcast against the real 1024-token vision sequence. LeRobot's
+    # SmolVLA always feeds dense, square images in this export path, so passing
+    # the equivalent all-true patch mask explicitly preserves semantics and
+    # keeps the mask shape concrete for export.
+    try:
+        from lerobot.policies.smolvla import modeling_smolvla as _smolvla
+
+        if not getattr(_smolvla.SmolVLMWithExpertModel.embed_image, "_reflex_patched", False):
+            def _embed_image_with_explicit_patch_mask(self, image):
+                patch_size = self.get_vlm_model().vision_model.patch_size
+                patch_attention_mask = torch.ones(
+                    (
+                        image.shape[0],
+                        image.shape[-2] // patch_size,
+                        image.shape[-1] // patch_size,
+                    ),
+                    dtype=torch.bool,
+                    device=image.device,
+                )
+                image_hidden_states = (
+                    self.get_vlm_model()
+                    .vision_model(
+                        pixel_values=image.to(dtype=self.get_vlm_model().vision_model.dtype),
+                        patch_attention_mask=patch_attention_mask,
+                    )
+                    .last_hidden_state
+                )
+                return self.get_vlm_model().connector(image_hidden_states)
+
+            _embed_image_with_explicit_patch_mask._reflex_patched = True
+            _smolvla.SmolVLMWithExpertModel.embed_image = _embed_image_with_explicit_patch_mask
+    except Exception as exc:
+        logger.debug("SmolVLA explicit patch-mask export patch not installed: %s", exc)
+
+    try:
+        from transformers.models.smolvlm import modeling_smolvlm as _smolvlm
+
+        if not getattr(_smolvlm.SmolVLMVisionAttention.forward, "_reflex_patched", False):
+            def _vision_attention_forward_no_dense_mask(self, hidden_states, attention_mask=None, **kwargs):
+                batch_size, seq_length, embed_dim = hidden_states.shape
+
+                queries = self.q_proj(hidden_states)
+                keys = self.k_proj(hidden_states)
+                values = self.v_proj(hidden_states)
+
+                queries = queries.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(1, 2)
+                keys = keys.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(1, 2)
+                values = values.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(1, 2)
+
+                attention_interface = _smolvlm.ALL_ATTENTION_FUNCTIONS.get_interface(
+                    self.config._attn_implementation,
+                    _smolvlm.eager_attention_forward,
+                )
+                attn_output, attn_weights = attention_interface(
+                    self,
+                    queries,
+                    keys,
+                    values,
+                    None,
+                    is_causal=False,
+                    scaling=self.scale,
+                    dropout=0.0 if not self.training else self.dropout,
+                )
+
+                attn_output = attn_output.reshape(batch_size, seq_length, embed_dim).contiguous()
+                attn_output = self.out_proj(attn_output)
+                return attn_output, attn_weights
+
+            _vision_attention_forward_no_dense_mask._reflex_patched = True
+            _smolvlm.SmolVLMVisionAttention.forward = _vision_attention_forward_no_dense_mask
+    except Exception as exc:
+        logger.debug("SmolVLM vision attention export patch not installed: %s", exc)
 
     # DynamicCache deepcopy bypass (FakeTensor can't be deepcopied)
     _orig_deepcopy = copy.deepcopy
@@ -516,6 +646,7 @@ def export_smolvla_monolithic(
         )
     logger.info("[smolvla] torch.export: %.1fs", time.time() - t0)
 
+    logger.info("[smolvla] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
         ep, tuple(dummy.values()), str(onnx_path),
@@ -638,6 +769,7 @@ def export_pi0_monolithic(
         )
     logger.info("[pi0] torch.export: %.1fs", time.time() - t0)
 
+    logger.info("[pi0] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
         ep, tuple(dummy.values()), str(onnx_path),
@@ -675,6 +807,7 @@ def _write_reflex_config(
     target: str = "desktop",
 ) -> None:
     """Write `reflex_config.json` + seed a VERIFICATION.md receipt."""
+    tokenizer_meta = _bundle_tokenizer(output_dir, model_type)
     cfg_dict = {
         "model_id": model_id,
         "model_type": model_type,
@@ -687,6 +820,7 @@ def _write_reflex_config(
         "opset": 19,
         "export_kind": "monolithic",
         "notes": _CCM_NONE_RATIONALE if num_steps > 1 else None,
+        **tokenizer_meta,
     }
     (output_dir / "reflex_config.json").write_text(
         json.dumps(cfg_dict, indent=2, default=str)
@@ -814,6 +948,7 @@ def export_pi05_monolithic(
         )
     logger.info("[pi05] torch.export: %.1fs", time.time() - t0)
 
+    logger.info("[pi05] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
         ep, tuple(dummy.values()), str(onnx_path),
@@ -1066,6 +1201,7 @@ def export_snapflow_student_monolithic(
         )
     logger.info("[snapflow-export] torch.export: %.1fs", time.time() - t0)
 
+    logger.info("[snapflow-export] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
         ep, tuple(dummy.values()), str(onnx_path),

--- a/src/reflex/exporters/weight_fusion.py
+++ b/src/reflex/exporters/weight_fusion.py
@@ -16,6 +16,8 @@ Usage:
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
 from pathlib import Path
 from typing import Sequence
 
@@ -29,10 +31,134 @@ def _load_onnx(path: Path):
     return onnx.load(str(path))
 
 
+def _iter_graph_tensors(graph):
+    """Yield every TensorProto reachable from a graph, including attributes."""
+    for tensor in graph.initializer:
+        yield tensor
+    for tensor in graph.sparse_initializer:
+        yield tensor.values
+        yield tensor.indices
+    for node in graph.node:
+        for attr in node.attribute:
+            yield from _iter_attribute_tensors(attr)
+
+
+def _iter_attribute_tensors(attr):
+    if attr.HasField("t"):
+        yield attr.t
+    yield from attr.tensors
+    if attr.HasField("g"):
+        yield from _iter_graph_tensors(attr.g)
+    for graph in attr.graphs:
+        yield from _iter_graph_tensors(graph)
+
+
+def _inline_tensor_bytes(tensor) -> int:
+    """Approximate protobuf payload bytes for TensorProto inline data fields."""
+    total = len(tensor.raw_data) if tensor.HasField("raw_data") else 0
+    total += len(tensor.float_data) * 4
+    total += len(tensor.int32_data) * 4
+    total += len(tensor.int64_data) * 8
+    total += len(tensor.double_data) * 8
+    total += len(tensor.uint64_data) * 8
+    total += sum(len(item) for item in tensor.string_data)
+    return total
+
+
+def _coerce_inline_tensor_data_to_raw(model, *, min_inline_bytes: int = 1024) -> tuple[int, int]:
+    """Convert repeated numeric TensorProto fields to raw_data before save.
+
+    ONNX's external-data conversion only externalizes tensors that use the
+    ``raw_data`` field. Some exporter paths leave large Constant attribute
+    tensors in repeated fields such as ``float_data`` or ``int64_data``; those
+    remain embedded in ``model.onnx`` even when ``convert_attribute=True`` is
+    passed to ``onnx.save``. Coercing them to raw_data lets the standard ONNX
+    writer move them into ``model.onnx.data``.
+    """
+    from onnx import numpy_helper
+
+    converted = 0
+    converted_bytes = 0
+    for tensor in _iter_graph_tensors(model.graph):
+        inline_bytes = _inline_tensor_bytes(tensor)
+        if inline_bytes < min_inline_bytes:
+            continue
+        if tensor.HasField("raw_data"):
+            continue
+        if len(tensor.string_data) > 0:
+            continue
+        try:
+            array = numpy_helper.to_array(tensor)
+            replacement = numpy_helper.from_array(array, name=tensor.name)
+            tensor.CopyFrom(replacement)
+        except Exception as exc:
+            logger.debug("Could not normalize inline ONNX tensor %s: %s", tensor.name, exc)
+            continue
+        converted += 1
+        converted_bytes += inline_bytes
+
+    if converted:
+        logger.info(
+            "Normalized %d inline ONNX tensor(s) (%.1f MB) to raw_data for external-data save",
+            converted,
+            converted_bytes / 1e6,
+        )
+    return converted, converted_bytes
+
+
 def _save_onnx(model, path: Path):
     import onnx
-    onnx.save(model, str(path))
-    logger.info("Saved fused ONNX: %s (%.1f MB)", path, path.stat().st_size / 1e6)
+    external_data = path.with_suffix(path.suffix + ".data")
+    _coerce_inline_tensor_data_to_raw(model)
+
+    with tempfile.TemporaryDirectory(prefix=f".{path.name}.", dir=path.parent) as tmp_dir:
+        tmp_model = Path(tmp_dir) / path.name
+        onnx.save(
+            model,
+            str(tmp_model),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=external_data.name,
+            size_threshold=1024,
+            convert_attribute=True,
+        )
+        # onnx.save writes external data relative to the temporary model path,
+        # but preserves the relative location string that will also be correct
+        # once the model file is moved back beside the final external file.
+        tmp_external = Path(tmp_dir) / external_data.name
+        proto_size = tmp_model.stat().st_size
+        max_proto_size = 2 * 1024 * 1024 * 1024
+        if proto_size >= max_proto_size:
+            raise RuntimeError(
+                f"Saved ONNX protobuf is still {proto_size / 1e9:.2f}GB after "
+                "external-data conversion. ONNX Runtime cannot load protobufs "
+                ">=2GB; inspect embedded Constant tensors before benchmarking."
+            )
+
+        os.replace(tmp_model, path)
+        if tmp_external.exists():
+            os.replace(tmp_external, external_data)
+
+    proto_size = path.stat().st_size
+    max_proto_size = 2 * 1024 * 1024 * 1024
+    if proto_size >= max_proto_size:
+        raise RuntimeError(
+            f"Saved ONNX protobuf is still {proto_size / 1e9:.2f}GB after "
+            "external-data conversion. ONNX Runtime cannot load protobufs "
+            ">=2GB; inspect embedded Constant tensors before benchmarking."
+        )
+    total_size = proto_size
+    external_size = 0
+    if external_data.exists():
+        external_size = external_data.stat().st_size
+        total_size += external_size
+    logger.info(
+        "Saved fused ONNX: %s (proto=%.1f MB external=%.1f MB total=%.1f MB)",
+        path,
+        proto_size / 1e6,
+        external_size / 1e6,
+        total_size / 1e6,
+    )
 
 
 def _get_initializer(model, name: str) -> np.ndarray | None:

--- a/src/reflex/runtime/hardware_probe.py
+++ b/src/reflex/runtime/hardware_probe.py
@@ -79,14 +79,26 @@ def _try_nvidia_smi(timeout_s: float = 5.0) -> tuple[str, str] | None:
 
 def _try_tegrastats(timeout_s: float = 3.0) -> tuple[str, str] | None:
     """Returns ('agx_orin' | 'orin_nano' | 'thor', raw_output) if tegrastats present."""
+    out = ""
     try:
         proc = subprocess.run(
             ["tegrastats", "--interval", "1000"],
             capture_output=True, text=True, timeout=timeout_s,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        out = proc.stdout or ""
+    except subprocess.TimeoutExpired as exc:
+        # tegrastats is a streaming monitor and normally does not exit on its
+        # own. subprocess.run preserves partial stdout on TimeoutExpired; use
+        # that first sample instead of treating a healthy Jetson as CPU-only.
+        partial = exc.stdout if exc.stdout is not None else exc.output
+        if isinstance(partial, bytes):
+            out = partial.decode(errors="ignore")
+        else:
+            out = partial or ""
+    except (FileNotFoundError, OSError):
         return None
-    out = proc.stdout or ""
+    if not out.strip():
+        return None
     # Heuristic: tegrastats output mentions hardware. Default to agx_orin if
     # we can't disambiguate; the override flag exists for edge cases.
     raw = out[:400]

--- a/src/reflex/runtime/model_resolver.py
+++ b/src/reflex/runtime/model_resolver.py
@@ -5,7 +5,7 @@ consults the in-package registry (`reflex.registry.REGISTRY`) and applies
 preference rules:
 
 1. If the user passed a fully-qualified registry id (e.g. `pi05-libero`), use
-   that exact entry — no further resolution.
+   that exact entry unless the device is a strict memory-constrained edge target.
 2. Otherwise interpret the model arg as a family name (`pi05` / `smolvla` /
    `pi0`) and pick the variant whose `supported_devices` includes the probed
    device_class AND whose `supported_embodiments` includes the requested
@@ -20,9 +20,13 @@ actually pulls + serves.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
-
 from reflex.registry import ModelEntry, REGISTRY, by_id
+
+
+_STRICT_DEVICE_MATCH_CLASSES = {"orin_nano"}
+_DEVICE_LABELS = {
+    "orin_nano": "Jetson Orin Nano",
+}
 
 
 @dataclass(frozen=True)
@@ -40,6 +44,38 @@ class ResolveResult:
 
 class ModelResolverError(Exception):
     """Raised when no entry matches the request."""
+
+
+def _device_label(device_class: str) -> str:
+    return _DEVICE_LABELS.get(device_class, device_class)
+
+
+def _alternatives_for_device(device_class: str, embodiment: str = "") -> list[str]:
+    return [
+        e.model_id for e in REGISTRY
+        if device_class in e.supported_devices
+        and (not embodiment or embodiment in e.supported_embodiments)
+    ]
+
+
+def _unsupported_device_error(
+    model: str,
+    device_class: str,
+    supported_devices: tuple[str, ...],
+    embodiment: str = "",
+) -> ModelResolverError:
+    alternatives = _alternatives_for_device(device_class, embodiment)
+    suggestion = (
+        f" Supported {_device_label(device_class)} choices: {alternatives}."
+        if alternatives else
+        f" Run `reflex models list --device {device_class}` to browse supported models."
+    )
+    return ModelResolverError(
+        f"{model!r} is not supported on {_device_label(device_class)} "
+        f"(supported devices: {list(supported_devices)})."
+        f" Refusing to fall back because this edge target is memory-constrained."
+        f"{suggestion}"
+    )
 
 
 def resolve_model(
@@ -67,6 +103,13 @@ def resolve_model(
     if entry is not None:
         notes: list[str] = []
         if device_class not in entry.supported_devices:
+            if device_class in _STRICT_DEVICE_MATCH_CLASSES:
+                raise _unsupported_device_error(
+                    model,
+                    device_class,
+                    entry.supported_devices,
+                    embodiment=embodiment,
+                )
             notes.append(
                 f"warning: {model!r} not listed as supported on {device_class!r} "
                 f"(supported: {list(entry.supported_devices)}). Proceeding because "
@@ -109,6 +152,18 @@ def resolve_model(
         and (not embodiment or embodiment in e.supported_embodiments)
     ]
     if family_only:
+        if device_class in _STRICT_DEVICE_MATCH_CLASSES:
+            supported_for_device = _alternatives_for_device(device_class, embodiment)
+            suffix = (
+                f" Supported {_device_label(device_class)} choices: {supported_for_device}."
+                if supported_for_device else
+                f" Run `reflex models list --device {device_class}` to browse supported models."
+            )
+            raise ModelResolverError(
+                f"No {family!r} variant explicitly supports {_device_label(device_class)}. "
+                f"Refusing family fallback because it can select an oversized model "
+                f"for an 8GB edge target.{suffix}"
+            )
         # Pick first by registry order (curated)
         picked = family_only[0]
         return ResolveResult(

--- a/src/reflex/runtime/ort_providers.py
+++ b/src/reflex/runtime/ort_providers.py
@@ -1,0 +1,356 @@
+"""ONNX Runtime provider planning shared by Reflex runtimes.
+
+The legacy decomposed server, monolithic pi0 server, monolithic SmolVLA
+server, and CLI benchmark path should all make the same GPU/provider choice.
+Keeping this logic in one place prevents a repeat of benchmark-only CUDA paths
+that bypass TensorRT engine/timing caches.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+_BLACKWELL_GPU_PATTERNS = (
+    "rtx 50",          # GeForce RTX 5070/5080/5090
+    "rtx pro 60",      # RTX PRO 6000 Blackwell
+    "blackwell",
+    "b200",            # B200 datacenter
+    "gb200",           # GB200 datacenter
+)
+
+_LARGE_EXTERNAL_DATA_BYTES = 8 * 1024 * 1024 * 1024
+
+
+def _as_bool(value: str | None, *, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def provider_name(provider: Any) -> str:
+    """Return provider name from ORT's string-or-(name, options) format."""
+    return provider[0] if isinstance(provider, tuple) else str(provider)
+
+
+def gpu_provider_requested(providers: list[Any]) -> bool:
+    names = {provider_name(p) for p in providers}
+    return bool(names & {"CUDAExecutionProvider", "TensorrtExecutionProvider"})
+
+
+def gpu_provider_active(active_providers: list[str]) -> bool:
+    return bool(set(active_providers) & {"CUDAExecutionProvider", "TensorrtExecutionProvider"})
+
+
+def gpu_is_blackwell() -> bool:
+    """Best-effort detection for GPUs where ORT-bundled TRT can segfault."""
+    import subprocess as _sub
+
+    try:
+        proc = _sub.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+        )
+    except (FileNotFoundError, _sub.TimeoutExpired, OSError):
+        return False
+    if proc.returncode != 0:
+        return False
+    names_lower = (proc.stdout or "").lower()
+    return any(pat in names_lower for pat in _BLACKWELL_GPU_PATTERNS)
+
+
+def log_blackwell_trt_warning() -> None:
+    bar = "=" * 72
+    logger.warning(
+        "\n%s\n"
+        "Blackwell GPU detected (RTX 50-series / B200 / GB200, sm_100)\n"
+        "%s\n"
+        "TensorRT EP is disabled because older ORT-bundled TensorRT builds can "
+        "segfault during session initialization on Blackwell. Reflex will use "
+        "CUDAExecutionProvider instead. Inference remains correct, but slower.\n"
+        "%s",
+        bar,
+        bar,
+        bar,
+    )
+
+
+@dataclass(frozen=True)
+class OrtProviderPlan:
+    providers: list[Any]
+    requested_device: str
+    available_providers: list[str]
+    used_trt: bool
+    trt_disabled_reason: str
+    trt_cache_dir: str
+    trt_engine_cache_dir: str
+    trt_timing_cache_dir: str
+    trt_ep_context_path: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def get_available_providers() -> list[str]:
+    try:
+        import onnxruntime as ort
+        return list(ort.get_available_providers())
+    except Exception:
+        return []
+
+
+def _large_external_data_threshold() -> int:
+    raw = os.environ.get("REFLEX_LARGE_EXTERNAL_DATA_BYTES")
+    if raw is None:
+        return _LARGE_EXTERNAL_DATA_BYTES
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return _LARGE_EXTERNAL_DATA_BYTES
+
+
+def onnx_external_data_bytes(onnx_path: str | Path | None) -> int:
+    """Return sibling external-data bytes for a model path.
+
+    Reflex exports use ``model.onnx.data``. Some conversion paths use ``.bin``.
+    This intentionally stays filesystem-based so it can run without loading a
+    multi-GB ModelProto into memory.
+    """
+    if onnx_path is None:
+        return 0
+    path = Path(onnx_path)
+    if not path.exists():
+        return 0
+    candidates = [
+        path.with_suffix(path.suffix + ".data"),
+        path.with_suffix(".bin"),
+    ]
+    total = 0
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate.exists() and candidate not in seen:
+            total += candidate.stat().st_size
+            seen.add(candidate)
+    for sibling in path.parent.glob(f"{path.stem}*.data"):
+        if sibling.exists() and sibling not in seen:
+            total += sibling.stat().st_size
+            seen.add(sibling)
+    return total
+
+
+def onnx_has_large_external_data(onnx_path: str | Path | None) -> bool:
+    return onnx_external_data_bytes(onnx_path) >= _large_external_data_threshold()
+
+
+def make_ort_session_options(onnx_path: str | Path | None = None) -> Any:
+    """Return shared ORT session options for Reflex runtime sessions.
+
+    ORT's default warning logs can flood stderr for graphs with repeated
+    ScatterND nodes. Keep runtime logs focused on errors unless a user asks for
+    more detail with REFLEX_ORT_LOG_SEVERITY=0|1|2.
+
+    Very large external-data graphs, such as pi0/pi0.5 monoliths, can trip ORT
+    or TensorRT graph-optimizer paths that materialize an optimized ModelProto
+    beyond protobuf's 2GB message limit. For those graphs, default to disabling
+    online graph optimizations; users can override with
+    REFLEX_ORT_GRAPH_OPT_LEVEL=disable|basic|extended|all.
+    """
+    import onnxruntime as ort
+
+    opts = ort.SessionOptions()
+    raw_level = os.environ.get("REFLEX_ORT_LOG_SEVERITY", "3")
+    try:
+        opts.log_severity_level = int(raw_level)
+    except ValueError:
+        opts.log_severity_level = 3
+
+    graph_opt_raw = os.environ.get("REFLEX_ORT_GRAPH_OPT_LEVEL")
+    levels = {
+        "disable": ort.GraphOptimizationLevel.ORT_DISABLE_ALL,
+        "disabled": ort.GraphOptimizationLevel.ORT_DISABLE_ALL,
+        "none": ort.GraphOptimizationLevel.ORT_DISABLE_ALL,
+        "0": ort.GraphOptimizationLevel.ORT_DISABLE_ALL,
+        "basic": ort.GraphOptimizationLevel.ORT_ENABLE_BASIC,
+        "1": ort.GraphOptimizationLevel.ORT_ENABLE_BASIC,
+        "extended": ort.GraphOptimizationLevel.ORT_ENABLE_EXTENDED,
+        "2": ort.GraphOptimizationLevel.ORT_ENABLE_EXTENDED,
+        "all": ort.GraphOptimizationLevel.ORT_ENABLE_ALL,
+        "3": ort.GraphOptimizationLevel.ORT_ENABLE_ALL,
+    }
+    if graph_opt_raw is not None:
+        opts.graph_optimization_level = levels.get(
+            graph_opt_raw.strip().lower(),
+            ort.GraphOptimizationLevel.ORT_ENABLE_ALL,
+        )
+    elif onnx_has_large_external_data(onnx_path):
+        opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+        logger.info(
+            "Disabled ORT graph optimizations for large external-data ONNX "
+            "(external_data=%.1f GB)",
+            onnx_external_data_bytes(onnx_path) / 1e9,
+        )
+    return opts
+
+
+def onnx_has_scatternd_reduction(onnx_path: str | Path | None) -> bool:
+    """Return True for ONNX graphs TensorRT 10.x cannot import efficiently.
+
+    TensorRT 10.5 rejects ScatterND nodes carrying the ONNX ``reduction``
+    attribute. ORT can still fall those nodes back to CUDA, but large VLA
+    graphs may spend minutes attempting many unsupported TRT subgraphs before
+    benching. Preflight lets us choose CUDA EP directly and report that
+    honestly instead of timing out during provider initialization.
+    """
+    if onnx_path is None:
+        return False
+    path = Path(onnx_path)
+    if not path.exists():
+        return False
+    try:
+        import onnx
+        model = onnx.load(str(path), load_external_data=False)
+    except Exception as exc:
+        logger.debug("TRT ScatterND preflight skipped for %s: %s", path, exc)
+        return False
+    for node in model.graph.node:
+        if node.op_type == "ScatterND" and any(attr.name == "reduction" for attr in node.attribute):
+            return True
+    return False
+
+
+def build_ort_provider_plan(
+    export_dir: str | Path,
+    *,
+    device: str = "cuda",
+    requested_providers: list[Any] | None = None,
+    available_providers: list[str] | None = None,
+    max_batch: int = 1,
+    prefer_trt: bool = True,
+    onnx_path: str | Path | None = None,
+    trt_workspace_bytes: int = 4 * 1024 * 1024 * 1024,
+    trt_cache_dirname: str = ".ort_trt",
+) -> OrtProviderPlan:
+    """Build a production ORT provider list.
+
+    Defaults:
+      - explicit caller providers always win
+      - CUDA requests prefer TensorRT EP when available and batch==1
+      - TensorRT EP gets engine + timing caches under the export directory
+      - CUDA EP remains second priority for unsupported TRT subgraphs
+      - CPU EP remains final fallback
+
+    Env toggles:
+      - REFLEX_TRT_EP=0 disables TensorRT preference
+      - REFLEX_TRT_TIMING_CACHE=0 disables TRT timing cache
+      - REFLEX_TRT_DUMP_EP_CONTEXT=1 asks ORT to dump an EPContext model
+    """
+    export_path = Path(export_dir)
+    available = list(available_providers or get_available_providers())
+    available_set = set(available)
+    device_norm = (device or "cpu").lower()
+
+    if requested_providers is not None:
+        return OrtProviderPlan(
+            providers=list(requested_providers),
+            requested_device=device_norm,
+            available_providers=available,
+            used_trt=any(provider_name(p) == "TensorrtExecutionProvider" for p in requested_providers),
+            trt_disabled_reason="explicit providers supplied",
+            trt_cache_dir="",
+            trt_engine_cache_dir="",
+            trt_timing_cache_dir="",
+            trt_ep_context_path="",
+        )
+
+    if device_norm != "cuda":
+        return OrtProviderPlan(
+            providers=["CPUExecutionProvider"],
+            requested_device=device_norm,
+            available_providers=available,
+            used_trt=False,
+            trt_disabled_reason="device is not cuda",
+            trt_cache_dir="",
+            trt_engine_cache_dir="",
+            trt_timing_cache_dir="",
+            trt_ep_context_path="",
+        )
+
+    trt_cache_dir = export_path / trt_cache_dirname
+    engine_cache_dir = trt_cache_dir / "engines"
+    timing_cache_dir = trt_cache_dir / "timing"
+    ep_context_path = trt_cache_dir / "model_ctx.onnx"
+
+    env_trt_enabled = _as_bool(os.environ.get("REFLEX_TRT_EP"), default=True)
+    timing_enabled = _as_bool(os.environ.get("REFLEX_TRT_TIMING_CACHE"), default=True)
+    dump_ep_context = _as_bool(os.environ.get("REFLEX_TRT_DUMP_EP_CONTEXT"), default=False)
+    blackwell = gpu_is_blackwell()
+    scatternd_reduction = onnx_has_scatternd_reduction(onnx_path)
+    large_external_data = onnx_has_large_external_data(onnx_path)
+
+    providers: list[Any] = []
+    used_trt = False
+    disabled_reason = ""
+    if not prefer_trt or not env_trt_enabled:
+        disabled_reason = "TensorRT disabled by configuration"
+    elif "TensorrtExecutionProvider" not in available_set:
+        disabled_reason = "TensorrtExecutionProvider unavailable"
+    elif max_batch > 1:
+        disabled_reason = f"max_batch={max_batch} > 1"
+    elif blackwell:
+        disabled_reason = "Blackwell GPU detected"
+        log_blackwell_trt_warning()
+    elif scatternd_reduction:
+        disabled_reason = "ScatterND reduction unsupported by TensorRT EP"
+    elif large_external_data:
+        disabled_reason = (
+            "large external-data ONNX; TensorRT EP/ORT graph optimizer can "
+            "materialize a >2GB protobuf"
+        )
+    else:
+        engine_cache_dir.mkdir(parents=True, exist_ok=True)
+        timing_cache_dir.mkdir(parents=True, exist_ok=True)
+        trt_options: dict[str, Any] = {
+            "device_id": 0,
+            "trt_fp16_enable": True,
+            "trt_engine_cache_enable": True,
+            "trt_engine_cache_path": str(engine_cache_dir),
+            "trt_max_workspace_size": trt_workspace_bytes,
+        }
+        if timing_enabled:
+            trt_options.update(
+                {
+                    "trt_timing_cache_enable": True,
+                    "trt_timing_cache_path": str(timing_cache_dir),
+                }
+            )
+        if dump_ep_context:
+            trt_options.update(
+                {
+                    "trt_dump_ep_context_model": True,
+                    "trt_ep_context_file_path": str(ep_context_path),
+                }
+            )
+        providers.append(("TensorrtExecutionProvider", trt_options))
+        used_trt = True
+
+    providers.append(("CUDAExecutionProvider", {"device_id": 0}))
+    providers.append("CPUExecutionProvider")
+
+    return OrtProviderPlan(
+        providers=providers,
+        requested_device=device_norm,
+        available_providers=available,
+        used_trt=used_trt,
+        trt_disabled_reason=disabled_reason,
+        trt_cache_dir=str(trt_cache_dir) if used_trt else "",
+        trt_engine_cache_dir=str(engine_cache_dir) if used_trt else "",
+        trt_timing_cache_dir=str(timing_cache_dir) if used_trt and timing_enabled else "",
+        trt_ep_context_path=str(ep_context_path) if used_trt and dump_ep_context else "",
+    )

--- a/src/reflex/runtime/pi05_onnx_server.py
+++ b/src/reflex/runtime/pi05_onnx_server.py
@@ -1,0 +1,34 @@
+"""Pi05OnnxServer — pi0.5 monolithic ONNX runtime.
+
+pi0.5's monolithic export has the same image/mask/lang/noise signature as pi0,
+except proprio state is already encoded into language and therefore no
+``state`` input exists. Pi0OnnxServer already filters feeds to ONNX input names,
+so this class only specializes metadata and public inference mode.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from reflex.runtime.pi0_onnx_server import Pi0OnnxServer
+
+
+class Pi05OnnxServer(Pi0OnnxServer):
+    def __init__(
+        self,
+        export_dir: str | Path,
+        onnx_path: str | Path | None = None,
+        providers: list[Any] | None = None,
+        device: str = "cpu",
+        max_batch: int = 1,
+        strict_providers: bool = True,
+    ):
+        super().__init__(
+            export_dir,
+            onnx_path=onnx_path,
+            providers=providers,
+            device=device,
+            max_batch=max_batch,
+            strict_providers=strict_providers,
+        )
+        self._inference_mode = "pi05_onnx_monolithic"

--- a/src/reflex/runtime/pi0_onnx_server.py
+++ b/src/reflex/runtime/pi0_onnx_server.py
@@ -42,16 +42,27 @@ class Pi0OnnxServer:
         self,
         export_dir: str | Path,
         onnx_path: str | Path | None = None,
-        providers: list[str] | None = None,
+        providers: list[Any] | None = None,
+        device: str = "cpu",
+        max_batch: int = 1,
         strict_providers: bool = True,
     ):
         self.export_dir = Path(export_dir)
         self._explicit_onnx_path = Path(onnx_path) if onnx_path else None
-        self.providers = providers or ["CPUExecutionProvider"]
+        self._requested_providers = providers
+        self._requested_device = device
+        self._max_batch = max_batch
+        self.providers: list[Any] = providers or ["CPUExecutionProvider"]
         self._session: Any = None
         self.config: dict[str, Any] = {}
         self._ready = False
         self._inference_mode = "pi0_onnx_monolithic"
+        self._provider_mode = "onnx_cpu"
+        self._active_providers: list[str] = []
+        self._provider_plan: Any = None
+        self._strict_providers = strict_providers
+        self._tokenizer: Any = None
+        self._tokenizer_unavailable = False
 
     def _find_onnx_path(self) -> Path:
         if self._explicit_onnx_path is not None:
@@ -71,12 +82,53 @@ class Pi0OnnxServer:
 
     def load(self) -> None:
         import onnxruntime as ort
+        from reflex.runtime.ort_providers import (
+            build_ort_provider_plan,
+            gpu_provider_active,
+            gpu_provider_requested,
+            make_ort_session_options,
+        )
 
         onnx_path = self._find_onnx_path()
         logger.info("Loading pi0 monolithic ONNX: %s", onnx_path)
+        self._provider_plan = build_ort_provider_plan(
+            self.export_dir,
+            device=self._requested_device,
+            requested_providers=self._requested_providers,
+            available_providers=list(ort.get_available_providers()),
+            max_batch=self._max_batch,
+            onnx_path=onnx_path,
+        )
+        self.providers = self._provider_plan.providers
+        logger.info(
+            "Requested providers: %s; available: %s; trt=%s reason=%s",
+            self.providers,
+            self._provider_plan.available_providers,
+            self._provider_plan.used_trt,
+            self._provider_plan.trt_disabled_reason,
+        )
         start = time.perf_counter()
-        self._session = ort.InferenceSession(str(onnx_path), providers=self.providers)
+        self._session = ort.InferenceSession(
+            str(onnx_path),
+            sess_options=make_ort_session_options(onnx_path),
+            providers=self.providers,
+        )
         elapsed = time.perf_counter() - start
+        self._active_providers = self._session.get_providers()
+        if gpu_provider_requested(self.providers) and not gpu_provider_active(self._active_providers):
+            msg = (
+                "CUDA/TensorRT provider requested for pi0 monolithic runtime, but "
+                f"ONNX Runtime activated {self._active_providers}."
+            )
+            if self._strict_providers:
+                raise RuntimeError(msg)
+            logger.warning(msg)
+        if "TensorrtExecutionProvider" in self._active_providers:
+            self._provider_mode = "onnx_trt_fp16"
+        elif gpu_provider_active(self._active_providers):
+            self._provider_mode = "onnx_gpu"
+        else:
+            self._provider_mode = "onnx_cpu"
 
         # Load config if present (optional — may not exist for ad-hoc ONNX)
         cfg_path = self.export_dir / "reflex_config.json"
@@ -86,10 +138,26 @@ class Pi0OnnxServer:
         # Extract expected inputs from the ONNX graph for validation
         self._input_names = [i.name for i in self._session.get_inputs()]
         logger.info(
-            "Pi0OnnxServer ready in %.2fs (inputs: %s)",
-            elapsed, self._input_names,
+            "Pi0OnnxServer ready in %.2fs (inputs: %s, active_providers=%s)",
+            elapsed, self._input_names, self._active_providers,
         )
         self._ready = True
+
+    def _get_tokenizer(self):
+        if self._tokenizer_unavailable:
+            return None
+        if self._tokenizer is None:
+            from reflex.runtime.tokenizers import load_export_tokenizer
+            self._tokenizer = load_export_tokenizer(
+                self.export_dir,
+                self.config,
+                default_ref="google/paligemma-3b-pt-224",
+            )
+            if self._tokenizer is None:
+                self._tokenizer_unavailable = True
+                logger.warning("Tokenizer unavailable; using dummy tokens")
+                return None
+        return self._tokenizer
 
     @property
     def ready(self) -> bool:
@@ -150,22 +218,20 @@ class Pi0OnnxServer:
 
         # Lang: take externally-supplied tokens or tokenize the instruction
         if lang_tokens is None:
-            try:
-                from transformers import AutoTokenizer
-                tok = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
+            tok = self._get_tokenizer()
+            if tok is not None:
                 enc = tok(instruction or " ", return_tensors="np", padding="max_length",
                           max_length=16, truncation=True)
                 lang_tokens = enc["input_ids"].astype(np.int64)
                 lang_masks = enc["attention_mask"].astype(np.bool_)
-            except Exception as e:
-                logger.warning("Tokenizer unavailable (%s); using dummy tokens", e)
+            else:
                 lang_tokens = np.zeros((1, 16), dtype=np.int64)
                 lang_masks = np.ones((1, 16), dtype=np.bool_)
         if lang_masks is None:
             lang_masks = np.ones_like(lang_tokens, dtype=np.bool_)
 
         # State: pad to 32 if needed
-        state_dim = 32  # pi0_base max_state_dim
+        state_dim = int(self.config.get("max_state_dim", 32))
         if state is None:
             state_arr = np.zeros((1, state_dim), dtype=np.float32)
         else:
@@ -178,8 +244,8 @@ class Pi0OnnxServer:
 
         # Noise
         if noise is None:
-            chunk = 50
-            action_dim = 32
+            chunk = int(self.config.get("chunk_size", 50))
+            action_dim = int(self.config.get("action_dim", 32))
             noise = np.random.RandomState(0).randn(1, chunk, action_dim).astype(np.float32)
         noise = np.asarray(noise, dtype=np.float32)
 
@@ -214,6 +280,8 @@ class Pi0OnnxServer:
             "latency_ms": round(elapsed_ms, 1),
             "hz": round(1000.0 / elapsed_ms, 1) if elapsed_ms > 0 else 0,
             "inference_mode": self._inference_mode,
+            "provider_mode": self._provider_mode,
+            "active_providers": list(self._active_providers),
             "denoising_steps": steps,
             "num_denoising_steps": steps,
         }

--- a/src/reflex/runtime/server.py
+++ b/src/reflex/runtime/server.py
@@ -336,8 +336,14 @@ class ReflexServer:
                             h.update(chunk)
                 except Exception:
                     pass
-            # External data files (.bin, .data) too — they hold the weights.
-            for p in sorted(self.export_dir.glob("*.bin")):
+            # External data files (.bin, .data, .onnx.data) too — they hold
+            # the weights for large ONNX exports.
+            data_files = (
+                list(self.export_dir.glob("*.bin"))
+                + list(self.export_dir.glob("*.data"))
+                + list(self.export_dir.glob("*.onnx.data"))
+            )
+            for p in sorted(set(data_files)):
                 try:
                     h.update(p.name.encode())
                     with p.open("rb") as f:
@@ -372,12 +378,20 @@ class ReflexServer:
         start = time.perf_counter()
 
         expert_meta = self.config.get("expert", {})
-        self.action_dim = expert_meta.get("action_dim", 32)
-        self.chunk_size = self.config.get("action_chunk_size", 50)
+        self.action_dim = self.config.get("action_dim", expert_meta.get("action_dim", 32))
+        self.chunk_size = self.config.get(
+            "action_chunk_size",
+            self.config.get("chunk_size", 50),
+        )
         self.expert_hidden = expert_meta.get("expert_hidden", 720)
 
         # Try ONNX runtime first, fall back to PyTorch
         onnx_path = self.export_dir / "expert_stack.onnx"
+        if not onnx_path.exists() and self.config.get("model_type") == "gr00t":
+            # GR00T monolithic export is a per-step velocity graph named
+            # model.onnx. ReflexServer already owns the denoise loop for
+            # velocity graphs, so it can serve/bench this artifact directly.
+            onnx_path = self.export_dir / "model.onnx"
         if onnx_path.exists():
             self._load_onnx(onnx_path)
         else:
@@ -466,81 +480,43 @@ class ReflexServer:
         # What the installed ORT actually supports on this machine
         available = set(ort.get_available_providers())
 
-        # Decide which providers to request
-        if self._requested_providers is not None:
-            providers = list(self._requested_providers)
-        elif self._requested_device == "cuda":
-            providers = []
-            # Prefer TensorRT EP when available — gives FP16 kernels and
-            # engine caching transparently. ORT falls back to CUDA EP for
-            # ops the TRT EP doesn't support.
-            #
-            # CRITICAL: TRT EP is incompatible with continuous batching when
-            # the source ONNX has static shapes (which our exporters bake).
-            # Apr-14 verification showed TRT rebuilds the engine on each new
-            # batch shape, causing 34-second latencies instead of milliseconds.
-            # When max_batch > 1, fall through to CUDAExecutionProvider which
-            # handles dynamic shapes natively and gives the 2.88x batching
-            # speedup measured in Phase III.
-            #
-            # ALSO: ORT's bundled TensorRT runtime predates Blackwell (RTX
-            # 50-series, sm_100). On Blackwell GPUs, TRT EP segfaults at
-            # session-init with a NULL function pointer — caught 2026-04-28
-            # by first-tester Rob (RTX 5090, exit code 139). Auto-disable
-            # TRT EP on Blackwell + print a loud warning so users know
-            # they're on the slower CUDA-EP path until ORT bundles new TRT.
-            blackwell_detected = _gpu_is_blackwell()
-            use_trt_ep = (
-                "TensorrtExecutionProvider" in available
-                and self._max_batch <= 1
-                and not blackwell_detected
-            )
-            if blackwell_detected and "TensorrtExecutionProvider" in available:
-                _print_blackwell_trt_warning()
-            if use_trt_ep:
-                # Use a per-export-dir engine cache so subsequent serve calls
-                # skip the engine-build cost.
-                trt_cache = str(self.export_dir / ".trt_cache")
-                Path(trt_cache).mkdir(parents=True, exist_ok=True)
-                providers.append((
-                    "TensorrtExecutionProvider",
-                    {
-                        "device_id": 0,
-                        "trt_fp16_enable": True,
-                        "trt_engine_cache_enable": True,
-                        "trt_engine_cache_path": trt_cache,
-                        "trt_max_workspace_size": 4 * 1024 * 1024 * 1024,  # 4GB
-                    },
-                ))
-            elif "TensorrtExecutionProvider" in available and self._max_batch > 1:
-                logger.info(
-                    "TRT EP available but disabled because --max-batch=%d > 1. "
-                    "TRT EP rebuilds engines per batch shape on static-shape "
-                    "ONNX, causing 34s+ latencies. Using CUDAExecutionProvider "
-                    "which handles dynamic batch natively. (Re-export with "
-                    "dynamic batch shapes + TRT shape profiles is a v0.2 fix.)",
-                    self._max_batch,
-                )
-            providers.append("CUDAExecutionProvider")
-            providers.append("CPUExecutionProvider")
-        else:
-            providers = ["CPUExecutionProvider"]
+        from reflex.runtime.ort_providers import (
+            build_ort_provider_plan,
+            gpu_provider_active,
+            gpu_provider_requested,
+            make_ort_session_options,
+        )
 
-        logger.info("Requested providers: %s; available: %s", providers, sorted(available))
+        plan = build_ort_provider_plan(
+            self.export_dir,
+            device=self._requested_device,
+            requested_providers=self._requested_providers,
+            available_providers=sorted(available),
+            max_batch=self._max_batch,
+            onnx_path=onnx_path,
+        )
+        providers = plan.providers
+        logger.info(
+            "Requested providers: %s; available: %s; trt=%s reason=%s",
+            providers,
+            plan.available_providers,
+            plan.used_trt,
+            plan.trt_disabled_reason,
+        )
 
         # Create session
-        self._ort_session = ort.InferenceSession(str(onnx_path), providers=providers)
+        self._ort_session = ort.InferenceSession(
+            str(onnx_path),
+            sess_options=make_ort_session_options(onnx_path),
+            providers=providers,
+        )
         active = self._ort_session.get_providers()
         logger.info("Loaded ONNX model: %s — active providers: %s", onnx_path.name, active)
 
         # Strict check: if caller asked for any GPU provider (CUDA or TRT) but
         # we ended up on CPU, fail loudly.
-        def _provider_name(p):
-            return p[0] if isinstance(p, tuple) else p
-
-        gpu_provider_names = {"CUDAExecutionProvider", "TensorrtExecutionProvider"}
-        cuda_requested = any(_provider_name(p) in gpu_provider_names for p in providers)
-        cuda_active = any(p in gpu_provider_names for p in active)
+        cuda_requested = gpu_provider_requested(providers)
+        cuda_active = gpu_provider_active(active)
         if cuda_requested and not cuda_active and self._strict_providers:
             install_hint = ""
             if "CUDAExecutionProvider" not in available:
@@ -1311,28 +1287,50 @@ def create_app(
         )
     elif _monolithic_cfg.get("export_kind") == "monolithic":
         _model_type = _monolithic_cfg.get("model_type", "smolvla")
-        _ort_providers = providers or (
-            ["CUDAExecutionProvider", "CPUExecutionProvider"]
-            if device == "cuda" else ["CPUExecutionProvider"]
-        )
         if _model_type == "pi0":
             from reflex.runtime.pi0_onnx_server import Pi0OnnxServer
             server = Pi0OnnxServer(
                 export_dir,
-                providers=_ort_providers,
+                providers=providers,
+                device=device,
+                max_batch=max_batch,
+                strict_providers=strict_providers,
+            )
+        elif _model_type == "pi05":
+            from reflex.runtime.pi05_onnx_server import Pi05OnnxServer
+            server = Pi05OnnxServer(
+                export_dir,
+                providers=providers,
+                device=device,
+                max_batch=max_batch,
                 strict_providers=strict_providers,
             )
         elif _model_type == "smolvla":
             from reflex.runtime.smolvla_onnx_server import SmolVLAOnnxServer
             server = SmolVLAOnnxServer(
                 export_dir,
-                providers=_ort_providers,
+                providers=providers,
+                device=device,
+                max_batch=max_batch,
                 strict_providers=strict_providers,
+            )
+        elif _model_type == "gr00t":
+            server = ReflexServer(
+                export_dir,
+                device=device,
+                providers=providers,
+                strict_providers=strict_providers,
+                safety_config=safety_config,
+                adaptive_steps=adaptive_steps,
+                cloud_fallback_url=cloud_fallback_url,
+                deadline_ms=deadline_ms,
+                max_batch=max_batch,
+                batch_timeout_ms=batch_timeout_ms,
             )
         else:
             raise ValueError(
                 f"Monolithic runtime for model_type={_model_type!r} not yet "
-                f"supported. v0.2 covers smolvla + pi0."
+                f"supported. v0.2 covers smolvla, pi0, pi05, and gr00t."
             )
     else:
         server = ReflexServer(

--- a/src/reflex/runtime/smolvla_onnx_server.py
+++ b/src/reflex/runtime/smolvla_onnx_server.py
@@ -30,16 +30,27 @@ class SmolVLAOnnxServer:
         self,
         export_dir: str | Path,
         onnx_path: str | Path | None = None,
-        providers: list[str] | None = None,
+        providers: list[Any] | None = None,
+        device: str = "cpu",
+        max_batch: int = 1,
         strict_providers: bool = True,
     ):
         self.export_dir = Path(export_dir)
         self._explicit_onnx_path = Path(onnx_path) if onnx_path else None
-        self.providers = providers or ["CPUExecutionProvider"]
+        self._requested_providers = providers
+        self._requested_device = device
+        self._max_batch = max_batch
+        self.providers: list[Any] = providers or ["CPUExecutionProvider"]
         self._session: Any = None
         self.config: dict[str, Any] = {}
         self._ready = False
         self._inference_mode = "smolvla_onnx_monolithic"
+        self._provider_mode = "onnx_cpu"
+        self._active_providers: list[str] = []
+        self._provider_plan: Any = None
+        self._strict_providers = strict_providers
+        self._tokenizer: Any = None
+        self._tokenizer_unavailable = False
 
     def _find_onnx_path(self) -> Path:
         if self._explicit_onnx_path is not None:
@@ -59,12 +70,53 @@ class SmolVLAOnnxServer:
 
     def load(self) -> None:
         import onnxruntime as ort
+        from reflex.runtime.ort_providers import (
+            build_ort_provider_plan,
+            gpu_provider_active,
+            gpu_provider_requested,
+            make_ort_session_options,
+        )
 
         onnx_path = self._find_onnx_path()
         logger.info("Loading SmolVLA monolithic ONNX: %s", onnx_path)
+        self._provider_plan = build_ort_provider_plan(
+            self.export_dir,
+            device=self._requested_device,
+            requested_providers=self._requested_providers,
+            available_providers=list(ort.get_available_providers()),
+            max_batch=self._max_batch,
+            onnx_path=onnx_path,
+        )
+        self.providers = self._provider_plan.providers
+        logger.info(
+            "Requested providers: %s; available: %s; trt=%s reason=%s",
+            self.providers,
+            self._provider_plan.available_providers,
+            self._provider_plan.used_trt,
+            self._provider_plan.trt_disabled_reason,
+        )
         start = time.perf_counter()
-        self._session = ort.InferenceSession(str(onnx_path), providers=self.providers)
+        self._session = ort.InferenceSession(
+            str(onnx_path),
+            sess_options=make_ort_session_options(onnx_path),
+            providers=self.providers,
+        )
         elapsed = time.perf_counter() - start
+        self._active_providers = self._session.get_providers()
+        if gpu_provider_requested(self.providers) and not gpu_provider_active(self._active_providers):
+            msg = (
+                "CUDA/TensorRT provider requested for SmolVLA monolithic runtime, "
+                f"but ONNX Runtime activated {self._active_providers}."
+            )
+            if self._strict_providers:
+                raise RuntimeError(msg)
+            logger.warning(msg)
+        if "TensorrtExecutionProvider" in self._active_providers:
+            self._provider_mode = "onnx_trt_fp16"
+        elif gpu_provider_active(self._active_providers):
+            self._provider_mode = "onnx_gpu"
+        else:
+            self._provider_mode = "onnx_cpu"
 
         cfg_path = self.export_dir / "reflex_config.json"
         if cfg_path.exists():
@@ -72,8 +124,8 @@ class SmolVLAOnnxServer:
 
         self._input_names = [i.name for i in self._session.get_inputs()]
         logger.info(
-            "SmolVLAOnnxServer ready in %.2fs (inputs: %s)",
-            elapsed, self._input_names,
+            "SmolVLAOnnxServer ready in %.2fs (inputs: %s, active_providers=%s)",
+            elapsed, self._input_names, self._active_providers,
         )
         self._ready = True
 
@@ -89,13 +141,24 @@ class SmolVLAOnnxServer:
         and the silent-fallback path zeros out the instruction. Customer
         dogfood 2026-04-19 caught this silent failure.
         """
+        if self._tokenizer_unavailable:
+            return None
         if getattr(self, "_tokenizer", None) is None:
-            from transformers import AutoTokenizer
-            tok = AutoTokenizer.from_pretrained("HuggingFaceTB/SmolLM2-135M")
-            # SmolLM2 ships without a pad_token. Set it to eos_token (standard HF pattern).
-            if tok.pad_token is None:
-                tok.pad_token = tok.eos_token
-            self._tokenizer = tok
+            from reflex.runtime.tokenizers import load_export_tokenizer
+            self._tokenizer = load_export_tokenizer(
+                self.export_dir,
+                self.config,
+                default_ref="HuggingFaceTB/SmolLM2-135M",
+                set_pad_to_eos=True,
+            )
+            if self._tokenizer is None:
+                self._tokenizer_unavailable = True
+                logger.error(
+                    "SEVERE: tokenizer failed. Instruction text will have NO "
+                    "effect until lang_tokens/lang_masks are supplied directly or "
+                    "the tokenizer is available.",
+                )
+                return None
         return self._tokenizer
 
     def predict(
@@ -142,8 +205,8 @@ class SmolVLAOnnxServer:
 
         # Lang: tokenize (SmolLM2 vocab ~49152) or use provided tokens
         if lang_tokens is None:
-            try:
-                tok = self._get_tokenizer()
+            tok = self._get_tokenizer()
+            if tok is not None:
                 enc = tok(
                     instruction or " ",
                     return_tensors="np", padding="max_length",
@@ -151,14 +214,7 @@ class SmolVLAOnnxServer:
                 )
                 lang_tokens = enc["input_ids"].astype(np.int64)
                 lang_masks = enc["attention_mask"].astype(np.bool_)
-            except Exception as e:
-                # Fall back silently BUT LOUDLY — this breaks instruction-following
-                # so we want it painfully visible in the log.
-                logger.error(
-                    "SEVERE: tokenizer failed (%s). Instruction '%s' has NO effect "
-                    "on the output — actions are a function of state+images only. "
-                    "Fix the tokenizer before trusting /act responses.", e, instruction,
-                )
+            else:
                 lang_tokens = np.zeros((1, 16), dtype=np.int64)
                 lang_masks = np.ones((1, 16), dtype=np.bool_)
         if lang_masks is None:
@@ -214,6 +270,8 @@ class SmolVLAOnnxServer:
             "latency_ms": round(elapsed_ms, 1),
             "hz": round(1000.0 / elapsed_ms, 1) if elapsed_ms > 0 else 0,
             "inference_mode": self._inference_mode,
+            "provider_mode": self._provider_mode,
+            "active_providers": list(self._active_providers),
             "denoising_steps": steps,
             "num_denoising_steps": steps,
         }

--- a/src/reflex/runtime/tokenizers.py
+++ b/src/reflex/runtime/tokenizers.py
@@ -1,0 +1,63 @@
+"""Tokenizer loading helpers for exported Reflex bundles."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def load_export_tokenizer(
+    export_dir: str | Path,
+    config: dict[str, Any],
+    *,
+    default_ref: str,
+    set_pad_to_eos: bool = False,
+) -> Any | None:
+    """Load tokenizer from an export bundle, then fall back to HF.
+
+    Preferred order:
+      1. ``reflex_config.json:tokenizer_path`` relative to export_dir
+      2. ``export_dir/tokenizer``
+      3. export_dir itself if tokenizer files were written at the root
+      4. ``reflex_config.json:tokenizer_ref`` or the provided default HF ref
+
+    Local sources use ``local_files_only=True`` so offline deployments do not
+    accidentally call Hugging Face during startup.
+    """
+    try:
+        from transformers import AutoTokenizer
+    except Exception as exc:
+        logger.warning("transformers unavailable; tokenizer cannot load: %s", exc)
+        return None
+
+    export_path = Path(export_dir)
+    sources: list[tuple[str | Path, bool]] = []
+    rel = config.get("tokenizer_path")
+    if rel:
+        sources.append((export_path / str(rel), True))
+    sources.append((export_path / "tokenizer", True))
+    if any((export_path / name).exists() for name in ("tokenizer.json", "tokenizer_config.json")):
+        sources.append((export_path, True))
+    sources.append((str(config.get("tokenizer_ref") or default_ref), False))
+
+    seen: set[str] = set()
+    errors: list[str] = []
+    for source, local_only in sources:
+        key = str(source)
+        if key in seen:
+            continue
+        seen.add(key)
+        if local_only and not Path(source).exists():
+            continue
+        try:
+            tok = AutoTokenizer.from_pretrained(source, local_files_only=local_only)
+            if set_pad_to_eos and getattr(tok, "pad_token", None) is None:
+                tok.pad_token = getattr(tok, "eos_token", None)
+            logger.info("Tokenizer loaded from %s", source)
+            return tok
+        except Exception as exc:
+            errors.append(f"{source}: {type(exc).__name__}: {exc}")
+    logger.warning("Tokenizer load failed; tried %s", errors)
+    return None

--- a/tests/test_bench_methodology.py
+++ b/tests/test_bench_methodology.py
@@ -154,6 +154,15 @@ class TestCaptureEnvironment:
             assert f["bytes"] > 0
             assert len(f["sha256_prefix"]) == 16
 
+    def test_capture_includes_external_data_files(self, tmp_path):
+        # Large monolithic exports save weights as model.onnx.data; the bench
+        # receipt must hash that file too, not only the lightweight protobuf.
+        (tmp_path / "model.onnx").write_bytes(b"protobuf")
+        (tmp_path / "model.onnx.data").write_bytes(b"external-weights")
+        env = capture_environment(export_dir=tmp_path)
+        names = {f["name"] for f in env.onnx_files}
+        assert names == {"model.onnx", "model.onnx.data"}
+
 
 # ---------- report rendering ----------
 

--- a/tests/test_one_command_deploy.py
+++ b/tests/test_one_command_deploy.py
@@ -18,6 +18,7 @@ import pytest
 from reflex.runtime.hardware_probe import (
     CANONICAL_DEVICE_CLASSES,
     ProbeResult,
+    _try_tegrastats,
     probe_device_class,
 )
 from reflex.runtime.model_resolver import (
@@ -92,6 +93,18 @@ class TestHardwareProbe:
         assert r.device_class == "orin_nano"
         assert r.detection_method == "tegrastats"
 
+    def test_tegrastats_uses_partial_output_on_timeout(self):
+        exc = subprocess.TimeoutExpired(
+            cmd=["tegrastats", "--interval", "1000"],
+            timeout=0.1,
+            output="RAM 1512/7620MB SWAP 0/3810MB CPU [0%@729] Orin Nano\n",
+        )
+        with patch("subprocess.run", side_effect=exc):
+            r = _try_tegrastats(timeout_s=0.1)
+        assert r is not None
+        assert r[0] == "orin_nano"
+        assert "Orin Nano" in r[1]
+
     def test_canonical_device_classes_immutable(self):
         # Lock the canonical set — every device class in registry MUST be in here
         from reflex.registry import REGISTRY
@@ -114,12 +127,17 @@ class TestModelResolver:
         assert r.entry.model_id == "pi05-base"
         assert r.matched_strategy == "exact-id"
 
-    def test_exact_id_warns_on_unsupported_device(self):
-        # pi05-base is NOT marked orin_nano-compatible
-        r = resolve_model(model="pi05-base", device_class="orin_nano")
-        assert r.entry.model_id == "pi05-base"
+    def test_exact_id_warns_on_unsupported_non_strict_device(self):
+        # pi05-libero is not marked h200-compatible, but h200 is not a strict
+        # edge target, so explicit pinning still gets a warning instead of a hard stop.
+        r = resolve_model(model="pi05-libero", device_class="h200")
+        assert r.entry.model_id == "pi05-libero"
         assert r.matched_strategy == "exact-id"
         assert any("not listed as supported" in n for n in r.notes)
+
+    def test_exact_id_refuses_oversized_model_on_orin_nano(self):
+        with pytest.raises(ModelResolverError, match="Jetson Orin Nano"):
+            resolve_model(model="pi05-base", device_class="orin_nano")
 
     def test_family_match_picks_smallest_for_edge(self):
         # Family smolvla on orin_nano: should pick smallest (smolvla-base + smolvla-libero
@@ -139,12 +157,15 @@ class TestModelResolver:
         # Only smolvla-base satisfies (so100 ∈ supported_embodiments)
         assert r.entry.model_id == "smolvla-base"
 
-    def test_family_fallback_when_no_device_match(self):
-        # pi0 family doesn't list orin_nano in seed registry
-        r = resolve_model(model="pi0", device_class="orin_nano")
-        assert r.entry.family == "pi0"
+    def test_family_fallback_when_no_device_match_on_non_strict_device(self):
+        r = resolve_model(model="dreamzero", device_class="a10g")
+        assert r.entry.family == "dreamzero"
         assert r.matched_strategy == "family-fallback"
         assert any("falling back" in n for n in r.notes)
+
+    def test_family_refuses_oversized_model_on_orin_nano(self):
+        with pytest.raises(ModelResolverError, match="oversized"):
+            resolve_model(model="pi0", device_class="orin_nano")
 
     def test_unknown_model_raises(self):
         with pytest.raises(ModelResolverError, match="No registry entry"):
@@ -214,6 +235,22 @@ class TestReflexGoCli:
         assert result.exit_code == 0, result.output
         assert "smolvla" in result.output
         assert "DRY RUN" in result.output
+
+    def test_dry_run_refuses_pi05_on_orin_nano(self, runner, cli_app):
+        result = runner.invoke(cli_app, [
+            "go", "--model", "pi05-base", "--device-class", "orin_nano", "--dry-run",
+        ])
+        assert result.exit_code == 2
+        assert "Orin Nano" in result.output
+
+    def test_go_on_jetson_requires_preexported_onnx(self, runner, cli_app):
+        with patch("reflex.cli._is_jetson_linux_aarch64", return_value=True):
+            result = runner.invoke(cli_app, [
+                "go", "--model", "smolvla-base", "--device-class", "orin_nano", "--dry-run",
+            ])
+        assert result.exit_code == 2
+        assert "cannot export" in result.output
+        assert "reflex serve" in result.output
 
     def test_dry_run_unknown_model_exits_2(self, runner, cli_app):
         result = runner.invoke(cli_app, [

--- a/tests/test_ort_providers.py
+++ b/tests/test_ort_providers.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reflex.runtime.ort_providers import (
+    build_ort_provider_plan,
+    onnx_external_data_bytes,
+    provider_name,
+)
+
+
+def test_cuda_prefers_trt_with_engine_and_timing_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr("reflex.runtime.ort_providers.gpu_is_blackwell", lambda: False)
+    plan = build_ort_provider_plan(
+        tmp_path,
+        device="cuda",
+        available_providers=[
+            "TensorrtExecutionProvider",
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ],
+    )
+
+    assert provider_name(plan.providers[0]) == "TensorrtExecutionProvider"
+    assert plan.used_trt is True
+    trt_opts = plan.providers[0][1]
+    assert trt_opts["trt_engine_cache_enable"] is True
+    assert trt_opts["trt_timing_cache_enable"] is True
+    assert Path(trt_opts["trt_engine_cache_path"]).is_dir()
+    assert Path(trt_opts["trt_timing_cache_path"]).is_dir()
+    assert [provider_name(p) for p in plan.providers[-2:]] == [
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+
+
+def test_cuda_disables_trt_when_batching_static_export(tmp_path, monkeypatch):
+    monkeypatch.setattr("reflex.runtime.ort_providers.gpu_is_blackwell", lambda: False)
+    plan = build_ort_provider_plan(
+        tmp_path,
+        device="cuda",
+        max_batch=4,
+        available_providers=[
+            "TensorrtExecutionProvider",
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ],
+    )
+
+    assert plan.used_trt is False
+    assert "max_batch=4" in plan.trt_disabled_reason
+    assert provider_name(plan.providers[0]) == "CUDAExecutionProvider"
+
+
+def test_explicit_providers_are_not_rewritten(tmp_path):
+    requested = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    plan = build_ort_provider_plan(
+        tmp_path,
+        device="cuda",
+        requested_providers=requested,
+        available_providers=[
+            "TensorrtExecutionProvider",
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ],
+    )
+
+    assert plan.providers == requested
+    assert plan.trt_disabled_reason == "explicit providers supplied"
+
+
+def test_env_can_disable_trt(tmp_path, monkeypatch):
+    monkeypatch.setenv("REFLEX_TRT_EP", "0")
+    monkeypatch.setattr("reflex.runtime.ort_providers.gpu_is_blackwell", lambda: False)
+    plan = build_ort_provider_plan(
+        tmp_path,
+        device="cuda",
+        available_providers=[
+            "TensorrtExecutionProvider",
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ],
+    )
+
+    assert plan.used_trt is False
+    assert "disabled" in plan.trt_disabled_reason.lower()
+    assert provider_name(plan.providers[0]) == "CUDAExecutionProvider"
+
+
+def test_scatternd_reduction_graph_disables_trt(tmp_path, monkeypatch):
+    onnx = pytest.importorskip("onnx")
+    from onnx import TensorProto, helper
+
+    onnx_path = tmp_path / "scatternd.onnx"
+    graph = helper.make_graph(
+        [
+            helper.make_node(
+                "ScatterND",
+                ["data", "indices", "updates"],
+                ["out"],
+                reduction="add",
+            )
+        ],
+        "scatternd_reduction",
+        [
+            helper.make_tensor_value_info("data", TensorProto.FLOAT, [1, 2]),
+            helper.make_tensor_value_info("indices", TensorProto.INT64, [1, 1]),
+            helper.make_tensor_value_info("updates", TensorProto.FLOAT, [1, 2]),
+        ],
+        [helper.make_tensor_value_info("out", TensorProto.FLOAT, [1, 2])],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 16)])
+    onnx.save(model, onnx_path)
+
+    monkeypatch.setattr("reflex.runtime.ort_providers.gpu_is_blackwell", lambda: False)
+    plan = build_ort_provider_plan(
+        tmp_path,
+        device="cuda",
+        available_providers=[
+            "TensorrtExecutionProvider",
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ],
+        onnx_path=onnx_path,
+    )
+
+    assert plan.used_trt is False
+    assert "ScatterND reduction" in plan.trt_disabled_reason
+    assert provider_name(plan.providers[0]) == "CUDAExecutionProvider"
+
+
+def test_session_options_default_to_error_logs(monkeypatch):
+    pytest.importorskip("onnxruntime")
+    from reflex.runtime.ort_providers import make_ort_session_options
+
+    monkeypatch.delenv("REFLEX_ORT_LOG_SEVERITY", raising=False)
+    opts = make_ort_session_options()
+
+    assert opts.log_severity_level == 3
+
+
+def test_large_external_data_disables_trt(tmp_path, monkeypatch):
+    monkeypatch.setenv("REFLEX_LARGE_EXTERNAL_DATA_BYTES", "10")
+    monkeypatch.setattr("reflex.runtime.ort_providers.gpu_is_blackwell", lambda: False)
+    onnx_path = tmp_path / "model.onnx"
+    onnx_path.write_bytes(b"onnx")
+    (tmp_path / "model.onnx.data").write_bytes(b"x" * 11)
+
+    plan = build_ort_provider_plan(
+        tmp_path,
+        device="cuda",
+        available_providers=[
+            "TensorrtExecutionProvider",
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ],
+        onnx_path=onnx_path,
+    )
+
+    assert onnx_external_data_bytes(onnx_path) == 11
+    assert plan.used_trt is False
+    assert "large external-data ONNX" in plan.trt_disabled_reason
+    assert provider_name(plan.providers[0]) == "CUDAExecutionProvider"
+
+
+def test_large_external_data_disables_graph_optimizations(tmp_path, monkeypatch):
+    ort = pytest.importorskip("onnxruntime")
+    from reflex.runtime.ort_providers import make_ort_session_options
+
+    monkeypatch.setenv("REFLEX_LARGE_EXTERNAL_DATA_BYTES", "10")
+    monkeypatch.delenv("REFLEX_ORT_GRAPH_OPT_LEVEL", raising=False)
+    onnx_path = tmp_path / "model.onnx"
+    onnx_path.write_bytes(b"onnx")
+    (tmp_path / "model.onnx.data").write_bytes(b"x" * 11)
+
+    opts = make_ort_session_options(onnx_path)
+
+    assert opts.graph_optimization_level == ort.GraphOptimizationLevel.ORT_DISABLE_ALL

--- a/tests/test_registry_completeness.py
+++ b/tests/test_registry_completeness.py
@@ -44,6 +44,7 @@ EXPORTERS_INTERNAL = {
     "vlm_prefix_exporter.py", # vlm prefix exporter; consumed via decomposed
     "_export_mode.py",        # parallel/sequential mode selector
     "trt_build.py",           # TensorRT engine builder; consumed by all primary exporters
+    "weight_fusion.py",       # RMSNorm→MatMul fusion + external-data ONNX save; consumed by monolithic export, not a standalone model family
     "__init__.py",
 }
 
@@ -54,6 +55,7 @@ EXPECTED_FAMILIES = {
     # Validation in models.py uses 'groot' (existing convention).
     # NVIDIA's brand is "GR00T" with zeros but our family slug stays
     # consistent with the validator until/unless we bump the validator.
+    "dreamzero.py": "dreamzero",  # lift #7: DreamZero WAM exporter; registry has family="dreamzero" (dreamzero-libero10)
     "gr00t.py": "groot",  # spine-based, lift #1 Day 7; gr00t_exporter.py was deleted at Day 11 sunset
     "openvla.py": "openvla",  # lift #1 Day 8: renamed from openvla_exporter.py; remains a shim per decision S-4
     "pi0.py": "pi0",  # renamed from pi0_exporter.py at lift #1 Day 11 sunset

--- a/tests/test_runtime_num_steps_10.py
+++ b/tests/test_runtime_num_steps_10.py
@@ -107,9 +107,78 @@ def test_smolvla_server_reports_num_steps_from_config(tmp_path):
     assert resp["inference_mode"] == "smolvla_onnx_monolithic"
 
 
+def test_pi05_server_uses_pi0_shape_without_state_input(tmp_path):
+    """Pi05OnnxServer reuses pi0-style camera/lang/noise inputs but should
+    not require a state input because pi0.5 carries proprio in language."""
+    from reflex.runtime.pi05_onnx_server import Pi05OnnxServer
+
+    (tmp_path / "reflex_config.json").write_text(json.dumps({
+        "model_type": "pi05",
+        "export_kind": "monolithic",
+        "num_denoising_steps": 10,
+        "chunk_size": 50,
+        "action_dim": 32,
+    }))
+
+    srv = Pi05OnnxServer(str(tmp_path))
+    srv._session = _mock_ort_session([
+        "img_base", "img_wrist_l", "img_wrist_r",
+        "mask_base", "mask_wrist_l", "mask_wrist_r",
+        "lang_tokens", "lang_masks", "noise",
+    ])
+    srv._input_names = [i.name for i in srv._session.get_inputs()]
+    srv._ready = True
+    srv.config = json.loads((tmp_path / "reflex_config.json").read_text())
+
+    resp = srv.predict(
+        image=np.zeros((224, 224, 3), dtype=np.uint8),
+        instruction="pick up",
+        noise=np.zeros((1, 50, 32), dtype=np.float32),
+        lang_tokens=np.zeros((1, 16), dtype=np.int64),
+        lang_masks=np.ones((1, 16), dtype=np.bool_),
+    )
+
+    assert resp["inference_mode"] == "pi05_onnx_monolithic"
+    assert resp["num_denoising_steps"] == 10
+    assert "state" not in srv._session.run.call_args.args[1]
+
+
+def test_reflex_server_uses_model_onnx_for_gr00t_monolithic(tmp_path, monkeypatch):
+    from reflex.runtime.server import ReflexServer
+
+    (tmp_path / "model.onnx").write_bytes(b"fake")
+    (tmp_path / "reflex_config.json").write_text(json.dumps({
+        "model_type": "gr00t",
+        "export_kind": "monolithic",
+        "chunk_size": 50,
+        "action_dim": 64,
+        "num_denoising_steps": 4,
+    }))
+
+    loaded = {}
+
+    def _fake_load_onnx(self, onnx_path):
+        loaded["path"] = Path(onnx_path)
+        self._ort_session = _mock_ort_session([
+            "noisy_actions", "timestep", "position_ids",
+        ], output_shape=(1, 50, 64))
+        self._inference_mode = "onnx_gpu"
+
+    monkeypatch.setattr(ReflexServer, "_load_onnx", _fake_load_onnx)
+    monkeypatch.setattr(ReflexServer, "_load_vlm_orchestrator", lambda self: None)
+
+    srv = ReflexServer(str(tmp_path), device="cpu")
+    srv.load()
+
+    assert loaded["path"] == tmp_path / "model.onnx"
+    assert srv.ready is True
+    assert srv.action_dim == 64
+
+
 def test_create_app_dispatch_monolithic(tmp_path, monkeypatch):
     """create_app routes to Pi0OnnxServer / SmolVLAOnnxServer when
     reflex_config.json declares `export_kind: monolithic`."""
+    pytest.importorskip("fastapi")
     from reflex.runtime import server as server_module
 
     # Write a fake model.onnx + config so _find_onnx_path succeeds

--- a/tests/test_runtime_tokenizers.py
+++ b/tests/test_runtime_tokenizers.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from reflex.runtime.tokenizers import load_export_tokenizer
+
+
+class _FakeTokenizer:
+    def __init__(self):
+        self.pad_token = None
+        self.eos_token = "</s>"
+
+
+def test_load_export_tokenizer_prefers_bundled_local_path(tmp_path, monkeypatch):
+    calls = []
+    fake_mod = types.ModuleType("transformers")
+
+    class _FakeAutoTokenizer:
+        @staticmethod
+        def from_pretrained(source, *, local_files_only=False):
+            calls.append((str(source), local_files_only))
+            return _FakeTokenizer()
+
+    fake_mod.AutoTokenizer = _FakeAutoTokenizer
+    monkeypatch.setitem(sys.modules, "transformers", fake_mod)
+
+    (tmp_path / "tokenizer").mkdir()
+    tok = load_export_tokenizer(
+        tmp_path,
+        {"tokenizer_ref": "remote/ref"},
+        default_ref="fallback/ref",
+        set_pad_to_eos=True,
+    )
+
+    assert tok is not None
+    assert tok.pad_token == "</s>"
+    assert calls == [(str(tmp_path / "tokenizer"), True)]
+
+
+def test_load_export_tokenizer_falls_back_to_remote_ref(tmp_path, monkeypatch):
+    calls = []
+    fake_mod = types.ModuleType("transformers")
+
+    class _FakeAutoTokenizer:
+        @staticmethod
+        def from_pretrained(source, *, local_files_only=False):
+            calls.append((str(source), local_files_only))
+            return _FakeTokenizer()
+
+    fake_mod.AutoTokenizer = _FakeAutoTokenizer
+    monkeypatch.setitem(sys.modules, "transformers", fake_mod)
+
+    tok = load_export_tokenizer(
+        tmp_path,
+        {"tokenizer_ref": "remote/ref"},
+        default_ref="fallback/ref",
+    )
+
+    assert tok is not None
+    assert calls == [("remote/ref", False)]

--- a/tests/test_weight_fusion_external_data.py
+++ b/tests/test_weight_fusion_external_data.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_save_onnx_externalizes_attribute_tensors(tmp_path, monkeypatch):
+    onnx = pytest.importorskip("onnx")
+    from onnx import helper
+
+    from reflex.exporters import weight_fusion
+
+    captured = {}
+
+    def _fake_save(model, path, **kwargs):
+        captured.update(kwargs)
+        out = Path(path)
+        out.write_bytes(b"onnx-protobuf")
+        (out.parent / kwargs["location"]).write_bytes(b"external-weights")
+
+    monkeypatch.setattr(onnx, "save", _fake_save)
+
+    # _save_onnx coerces inline tensors before save, so it needs a real model
+    # with a `.graph`; an empty graph keeps coercion a no-op while still
+    # exercising the external-data save kwargs this test asserts on.
+    model = helper.make_model(helper.make_graph([], "empty", [], []))
+    weight_fusion._save_onnx(model, tmp_path / "model.onnx")
+
+    assert captured["save_as_external_data"] is True
+    assert captured["convert_attribute"] is True
+    assert captured["location"] == "model.onnx.data"
+
+
+def test_inline_attribute_tensors_are_normalized_to_raw_data():
+    onnx = pytest.importorskip("onnx")
+    from onnx import TensorProto, helper
+
+    from reflex.exporters import weight_fusion
+
+    tensor = helper.make_tensor(
+        "constant_weights",
+        TensorProto.FLOAT,
+        [300],
+        [float(i) for i in range(300)],
+        raw=False,
+    )
+    node = helper.make_node("Constant", [], ["out"], value=tensor)
+    graph = helper.make_graph(
+        [node],
+        "inline-tensor-test",
+        [],
+        [helper.make_tensor_value_info("out", TensorProto.FLOAT, [300])],
+    )
+    model = helper.make_model(graph)
+    attr_tensor = model.graph.node[0].attribute[0].t
+
+    assert len(attr_tensor.float_data) == 300
+    assert not attr_tensor.HasField("raw_data")
+
+    converted, converted_bytes = weight_fusion._coerce_inline_tensor_data_to_raw(model)
+
+    attr_tensor = model.graph.node[0].attribute[0].t
+    assert converted == 1
+    assert converted_bytes >= 1200
+    assert attr_tensor.HasField("raw_data")
+    assert len(attr_tensor.float_data) == 0


### PR DESCRIPTION
## Summary
Consolidates the monolithic serve + bench hardening that had accumulated uncommitted on `main`, plus two pre-existing red-test fixes. Bumps 0.11.0 → 0.11.1.

**Runtime**
- `runtime/ort_providers.py` (new): single source of ORT execution-provider planning shared by the decomposed server, monolithic pi0/SmolVLA/pi0.5 servers, and the CLI bench path — so benchmarks stop taking a CUDA-only path that bypasses the TensorRT engine/timing caches the served path uses. Includes Blackwell detection + >8GB external-data handling.
- `runtime/pi05_onnx_server.py` (new): `Pi05OnnxServer` for pi0.5's monolithic export (pi0 signature minus the state input — proprio is in language).
- `runtime/tokenizers.py` (new): `load_export_tokenizer()` prefers in-bundle tokenizer files with `local_files_only=True`, so offline deploys never hit HF at startup.
- `server` / `pi0_onnx_server` / `smolvla_onnx_server` / `model_resolver` / `hardware_probe`: route through the unified provider plan, add pi0.5 resolution, use the offline tokenizer loader.

**Export correctness**
- `exporters/weight_fusion.py` + `monolithic.py`: coerce inline numeric tensors to `raw_data` before save so ONNX externalizes weights to a `.data` sidecar (inline `float_data`/`int64_data` is otherwise never externalized); guard the 2GB protobuf limit.

**Bench**
- `bench/report.py` + `modal_flashrt_bench.py` + `modal_verify_bench_all.py`: reporting + Modal verification harness.

**Pre-existing red-test fixes (d814032)**
- Route `connect_up` / `connect_status` errors to stderr so `2>/dev/null` no longer swallows the only error signal.
- Classify `dreamzero.py` (primary, family=dreamzero) + `weight_fusion.py` (internal) in the exporter-directory audit.

## Test plan
- [x] Full suite: 2854 passed, 27 skipped (4 ZMQ collection errors = pre-existing missing optional dep `msgpack`, unrelated)
- [x] New: `test_ort_providers`, `test_runtime_tokenizers`, `test_weight_fusion_external_data`
- [x] Extended: `test_bench_methodology`, `test_one_command_deploy`, `test_runtime_num_steps_10`
- [ ] Modal A100 monolithic serve+bench smoke (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
