### PR TITLE
fix(lift5): run L3 side-by-side through the proven libero_rollout loop

### DIFF
--- a/scripts/modal_fast_kernels_l3_side_by_side.py
+++ b/scripts/modal_fast_kernels_l3_side_by_side.py
@@ -1,15 +1,28 @@
-"""Lift #5 L3 side-by-side — native lerobot vs Triton on same LIBERO tasks.
+"""Lift #5 L3 side-by-side — native lerobot vs Triton on the SAME proven loop.
 
-Root-cause diagnostic for the 0/2 L3 diagnostic result. Runs BOTH arms:
-  ARM A: native lerobot (PI05Policy.predict_action_chunk, fp32)
-  ARM B: Triton (Pi05FastKernelsInference via TritonLIBEROAdapter, bf16)
+Quality-parity gate for the `--fast-kernels` Triton path. Runs BOTH arms through
+`reflex.eval.libero_rollout.run_libero_rollout` — the exact primitive the proven
+native eval (`modal_libero_lerobot_native.py`, 80%+ on libero_10 task 0 at N=20)
+uses — so the ONLY thing that differs between arms is the inference backend:
 
-Same tasks × same episodes × same init states. Compares success rates +
-prints first-action values to diagnose systematic drift.
+  ARM A (native): use_native=True  → policy.select_action (proven path)
+  ARM B (triton): inference=TritonLIBEROAdapter, use_native=False
+
+Identical preprocessing (cv2 INTER_AREA resize + 180° flip), identical seed,
+identical task set, identical centrally-generated noise, identical bool(done)
+success criterion. This REPLACES the earlier bespoke loop whose PIL-BILINEAR
+resize + seed-42 + hard-task-set [3,4,6] produced a spurious 0/9 "baseline"
+(see 03_experiments/2026-05-24-lift5-l3-sbs-baseline-zero.md). There was never
+a proven native run at that config to compare against.
 
 Usage:
     modal profile activate novarepmarketing
-    modal run scripts/modal_fast_kernels_l3_side_by_side.py
+    # cheap baseline diagnostic — native arm only, confirm baseline > 0:
+    modal run scripts/modal_fast_kernels_l3_side_by_side.py --arms native \
+        --task-indices 0 --num-episodes 2
+    # full paired parity gate:
+    modal run scripts/modal_fast_kernels_l3_side_by_side.py --arms both \
+        --task-indices 0,1,2 --num-episodes 10
 """
 import os
 import subprocess
@@ -98,52 +111,55 @@ image = (
 )
 def run_side_by_side(
     model_id: str = "lerobot/pi05_libero_finetuned_v044",
+    task_suite_name: str = "libero_10",
     task_indices: list[int] | None = None,
-    num_episodes: int = 3,
+    num_episodes: int = 10,
+    seed: int = 7,
+    arms: str = "both",  # "native" | "triton" | "both"
 ) -> dict:
-    """Side-by-side: native lerobot vs Triton on same LIBERO tasks."""
-    import collections
-    import math
+    """Native vs Triton on the shared proven rollout loop. See module docstring."""
     import time
 
-    import numpy as np
     import torch
 
-    # torch.load patch for LIBERO init states
+    # PyTorch 2.6+ defaults torch.load to weights_only=True; LIBERO init-state
+    # pickles need weights_only=False. (run_libero_rollout patches this too, but
+    # the policy load below happens first.)
     _orig_torch_load = torch.load
+
     def _compat_load(*args, **kwargs):
         kwargs.setdefault("weights_only", False)
         return _orig_torch_load(*args, **kwargs)
+
     torch.load = _compat_load
 
     if task_indices is None:
-        task_indices = [3, 4, 6]  # single-object tasks with higher baseline success
+        # Anchor on task 0 (proven ~80%+ native at N=20) + 1,2 for breadth.
+        task_indices = [0, 1, 2]
 
-    # Disable PyTorch's Triton autotuner — it blocks the GPU for 30+ seconds
-    # per matmul shape on first call, causing Modal to kill the task for
-    # "failed to respond to cancellation." Set before any torch operations.
+    # PyTorch Inductor autotuner blocks the GPU 30+s per matmul shape on first
+    # call → Modal kills the task for "failed to respond to cancellation".
     os.environ["TORCHINDUCTOR_DISABLE"] = "1"
     torch.backends.cuda.matmul.allow_tf32 = True
 
-    print(f"[sbs] Side-by-side — model={model_id}, tasks={task_indices}, N={num_episodes}", flush=True)
+    print(
+        f"[sbs] suite={task_suite_name} tasks={task_indices} "
+        f"N={num_episodes} seed={seed} arms={arms}",
+        flush=True,
+    )
     print(f"[sbs] CUDA: {torch.cuda.get_device_name(0)}", flush=True)
     t_total = time.time()
 
-    # ── Load policy (CPU — shared for native ARM + preprocessing) ─────
+    from reflex.eval.libero_rollout import run_libero_rollout
+
+    # ── Load policy (fp32 cuda — native baseline quality + shared preprocessing)
     t0 = time.time()
     from lerobot.policies.pi05.modeling_pi05 import PI05Policy
-    policy = PI05Policy.from_pretrained(model_id)
-    policy = policy.to(dtype=torch.float32).cpu()
+    policy = PI05Policy.from_pretrained(model_id).to(dtype=torch.float32).to("cuda")
     policy.eval()
-    print(f"[sbs] [{time.time()-t0:.1f}s] PI05Policy loaded (CPU)", flush=True)
+    print(f"[sbs] [{time.time()-t0:.1f}s] PI05Policy loaded (cuda fp32)", flush=True)
 
-    # ── Build Triton adapter ─────────────────────────────────────────
-    t0 = time.time()
-    from reflex.runtime.fast_inference.libero_adapter import TritonLIBEROAdapter
-    adapter = TritonLIBEROAdapter.from_policy(policy, capture=True)
-    print(f"[sbs] [{time.time()-t0:.1f}s] Triton adapter ready", flush=True)
-
-    # ── Load preprocessor / postprocessor ─────────────────────────────
+    # ── Pre/post processors (shared by both arms via the rollout) ─────
     from lerobot.processor.pipeline import PolicyProcessorPipeline
     from lerobot.processor.converters import (
         policy_action_to_transition,
@@ -161,212 +177,100 @@ def run_side_by_side(
         to_transition=policy_action_to_transition,
         to_output=transition_to_policy_action,
     )
-    print(f"[sbs] Pre/post processors loaded", flush=True)
+    print("[sbs] pre/post processors loaded", flush=True)
 
-    # ── LIBERO setup ──────────────────────────────────────────────────
-    np.random.seed(42)
-    from libero.libero import benchmark, get_libero_path
-    from libero.libero.envs import OffScreenRenderEnv
-    from pathlib import Path
+    common = dict(
+        policy=policy,
+        preprocessor=preprocessor,
+        postprocessor=postprocessor,
+        task_suite_name=task_suite_name,
+        num_episodes=num_episodes,
+        task_indices=task_indices,
+        seed=seed,
+        replan_steps=5,
+        num_steps_wait=10,
+    )
 
-    max_steps = 520
-    resize_size = 224
-    replan_steps = 5
-    num_steps_wait = 10
-    LIBERO_DUMMY_ACTION = np.zeros(7)
+    native = None
+    triton = None
 
-    def _quat2axisangle(quat):
-        if quat[3] > 1.0: quat[3] = 1.0
-        elif quat[3] < -1.0: quat[3] = -1.0
-        den = np.sqrt(1.0 - quat[3] * quat[3])
-        if math.isclose(den, 0.0):
-            return np.zeros(3)
-        return (quat[:3] * 2.0 * math.acos(quat[3])) / den
-
-    def _resize_with_pad(img, size):
-        from PIL import Image as PILImage
-        h, w = img.shape[:2]
-        if h > w:
-            pad = (h - w) // 2
-            img = np.pad(img, [(0, 0), (pad, h - w - pad), (0, 0)], mode="constant")
-        elif w > h:
-            pad = (w - h) // 2
-            img = np.pad(img, [(pad, w - h - pad), (0, 0), (0, 0)], mode="constant")
-        pil = PILImage.fromarray(img)
-        pil = pil.resize((size, size), PILImage.BILINEAR)
-        return np.asarray(pil)
-
-    def _build_env(task):
-        task_bddl = Path(get_libero_path("bddl_files")) / task.problem_folder / task.bddl_file
-        env = OffScreenRenderEnv(
-            bddl_file_name=str(task_bddl),
-            camera_heights=256, camera_widths=256,
+    # ── ARM A: native (proven select_action path) ────────────────────
+    if arms in ("native", "both"):
+        print(f"\n[sbs] {'='*60}", flush=True)
+        print("[sbs] ARM A: native lerobot (select_action, fp32)", flush=True)
+        print(f"[sbs] {'='*60}", flush=True)
+        native = run_libero_rollout(
+            inference=None, use_native=True, label="NATIVE", **common,
         )
-        env.seed(42)
-        return env
 
-    def _build_batch(obs, task_description):
-        img = np.ascontiguousarray(obs["agentview_image"][::-1, ::-1])
-        wrist_img = np.ascontiguousarray(obs["robot0_eye_in_hand_image"][::-1, ::-1])
-        img = _resize_with_pad(img, resize_size)
-        wrist_img = _resize_with_pad(wrist_img, resize_size)
-        def _to_tensor(arr):
-            t = torch.from_numpy(arr.astype(np.float32) / 255.0)
-            return t.permute(2, 0, 1).unsqueeze(0).to("cuda")
-        state = np.concatenate([
-            np.asarray(obs["robot0_eef_pos"], dtype=np.float32),
-            _quat2axisangle(np.asarray(obs["robot0_eef_quat"], dtype=np.float32).copy()),
-            np.asarray(obs["robot0_gripper_qpos"], dtype=np.float32),
-        ]).astype(np.float32)
-        return {
-            "observation.images.image": _to_tensor(img),
-            "observation.images.image2": _to_tensor(wrist_img),
-            "observation.state": torch.from_numpy(state).unsqueeze(0).to("cuda"),
-            "task": [task_description],
-        }
-
-    benchmark_dict = benchmark.get_benchmark_dict()
-    task_suite = benchmark_dict["libero_10"]()
-
-    # ── Run both ARMs ─────────────────────────────────────────────────
-    def _run_arm(arm_name, get_action_chunk):
-        """Generic LIBERO eval loop. get_action_chunk(batch_pp) -> np.ndarray."""
-        arm_results = {"tasks": [], "total_success": 0, "total_eps": 0}
-        for task_idx in task_indices:
-            task = task_suite.get_task(task_idx)
-            task_desc = task.language
-            initial_states = task_suite.get_task_init_states(task_idx)
-            env = _build_env(task)
-            task_success = 0
-            print(f"\n[sbs] [{arm_name}] TASK {task_idx}: {task_desc!r}", flush=True)
-
-            for ep in range(num_episodes):
-                try:
-                    env.reset()
-                    obs = env.set_init_state(initial_states[ep % len(initial_states)])
-                    policy.reset()
-                    action_plan = collections.deque()
-                    t = 0
-                    first_action_logged = False
-
-                    while t < max_steps + num_steps_wait:
-                        if t < num_steps_wait:
-                            obs, _, done, info = env.step(LIBERO_DUMMY_ACTION)
-                            t += 1
-                            continue
-
-                        if not action_plan:
-                            batch = _build_batch(obs, task_desc)
-                            batch_pp = preprocessor(batch)
-                            batch_pp = {
-                                k: (v.to("cuda") if isinstance(v, torch.Tensor) else v)
-                                for k, v in batch_pp.items()
-                            }
-                            chunk_np = get_action_chunk(batch_pp)
-                            action_plan.extend(chunk_np[:replan_steps])
-
-                            if not first_action_logged:
-                                print(f"[sbs] [{arm_name}] first action: {chunk_np[0][:4]}...", flush=True)
-                                first_action_logged = True
-
-                        action = action_plan.popleft()
-                        obs, _, done, info = env.step(action)
-                        t += 1
-
-                        # Progress logging every 100 steps
-                        if t % 100 == 0:
-                            elapsed = time.time() - t_total
-                            print(f"[sbs] [{arm_name}] task {task_idx} ep {ep} step {t}/{max_steps+num_steps_wait} ({elapsed:.0f}s elapsed)", flush=True)
-
-                        if done:
-                            break
-
-                    success = bool(env.is_success()["task"]) if hasattr(env, "is_success") else False
-                    task_success += int(success)
-                    print(f"[sbs] [{arm_name}] ep {ep}: {'SUCCESS' if success else 'FAIL'} (t={t})", flush=True)
-                except Exception as e:
-                    import traceback
-                    print(f"[sbs] [{arm_name}] ep {ep} ERROR: {e}", flush=True)
-                    traceback.print_exc()
-
-            env.close()
-            rate = task_success / max(num_episodes, 1)
-            arm_results["tasks"].append({
-                "task_idx": task_idx, "task_desc": task_desc,
-                "success": task_success, "total": num_episodes, "rate": rate,
-            })
-            arm_results["total_success"] += task_success
-            arm_results["total_eps"] += num_episodes
-            print(f"[sbs] [{arm_name}] TASK {task_idx}: {task_success}/{num_episodes} ({rate:.0%})", flush=True)
-        return arm_results
-
-    # ── ARM A: native lerobot ─────────────────────────────────────────
-    print(f"\n[sbs] {'='*60}", flush=True)
-    print(f"[sbs] ARM A: native lerobot (PI05Policy.predict_action_chunk, fp32)", flush=True)
-    print(f"[sbs] {'='*60}", flush=True)
-
-    # Move policy to CUDA for native ARM
-    policy.to("cuda")
-
-    def _native_action_chunk(batch_pp):
-        with torch.no_grad():
-            chunk = policy.predict_action_chunk(batch_pp)
-        post = postprocessor(chunk.detach().cpu())
-        chunk_np = post.detach().cpu().numpy() if hasattr(post, "detach") else np.asarray(post)
-        if chunk_np.ndim == 3:
-            chunk_np = chunk_np[0]
-        return chunk_np[:, :7]
-
-    native_results = _run_arm("NATIVE", _native_action_chunk)
-
-    # Move policy back to CPU to free VRAM for Triton ARM
-    policy.to("cpu")
-    torch.cuda.empty_cache()
-
-    # ── ARM B: Triton ─────────────────────────────────────────────────
-    print(f"\n[sbs] {'='*60}", flush=True)
-    print(f"[sbs] ARM B: Triton (Pi05FastKernelsInference, bf16)", flush=True)
-    print(f"[sbs] {'='*60}", flush=True)
-
-    def _triton_action_chunk(batch_pp):
-        chunk = adapter.predict_chunk(batch_pp)
-        post = postprocessor(chunk.detach().cpu())
-        chunk_np = post.detach().cpu().numpy() if hasattr(post, "detach") else np.asarray(post)
-        if chunk_np.ndim == 3:
-            chunk_np = chunk_np[0]
-        return chunk_np[:, :7]
-
-    triton_results = _run_arm("TRITON", _triton_action_chunk)
+    # ── ARM B: Triton fast-kernels ───────────────────────────────────
+    if arms in ("triton", "both"):
+        print(f"\n[sbs] {'='*60}", flush=True)
+        print("[sbs] ARM B: Triton fast-kernels (Pi05FastKernelsInference, bf16)", flush=True)
+        print(f"[sbs] {'='*60}", flush=True)
+        from reflex.runtime.fast_inference.libero_adapter import TritonLIBEROAdapter
+        adapter = TritonLIBEROAdapter.from_policy(policy, capture=True)
+        triton = run_libero_rollout(
+            inference=adapter, use_native=False, label="TRITON", **common,
+        )
 
     # ── Compare ───────────────────────────────────────────────────────
-    native_rate = native_results["total_success"] / max(native_results["total_eps"], 1)
-    triton_rate = triton_results["total_success"] / max(triton_results["total_eps"], 1)
-    delta = triton_rate - native_rate
-
+    out: dict = {
+        "native": native,
+        "triton": triton,
+        "task_indices": task_indices,
+        "num_episodes": num_episodes,
+        "seed": seed,
+        "arms": arms,
+    }
     print(f"\n[sbs] {'='*60}", flush=True)
-    print(f"[sbs] NATIVE:  {native_results['total_success']}/{native_results['total_eps']} ({native_rate:.0%})", flush=True)
-    print(f"[sbs] TRITON:  {triton_results['total_success']}/{triton_results['total_eps']} ({triton_rate:.0%})", flush=True)
-    print(f"[sbs] Delta:   {delta:+.0%}", flush=True)
+    if native is not None:
+        nr = native.get("success_rate_pct", 0.0)
+        out["native_rate_pct"] = nr
+        print(f"[sbs] NATIVE:  {native['total_success']}/{native['total_eps']} ({nr:.1f}%)", flush=True)
+    if triton is not None:
+        tr = triton.get("success_rate_pct", 0.0)
+        out["triton_rate_pct"] = tr
+        print(f"[sbs] TRITON:  {triton['total_success']}/{triton['total_eps']} ({tr:.1f}%)", flush=True)
+    if native is not None and triton is not None:
+        delta = out["triton_rate_pct"] - out["native_rate_pct"]
+        out["delta_pp"] = delta
+        print(
+            f"[sbs] Delta:   {delta:+.1f}pp  "
+            f"(kill-trigger: native−triton regression > 5pp)",
+            flush=True,
+        )
     print(f"[sbs] Total time: {time.time()-t_total:.1f}s", flush=True)
     print(f"[sbs] {'='*60}", flush=True)
-
-    return {
-        "native": native_results,
-        "triton": triton_results,
-        "native_rate": native_rate,
-        "triton_rate": triton_rate,
-        "delta": delta,
-    }
+    return out
 
 
 @app.local_entrypoint()
-def main():
+def main(
+    suite: str = "libero_10",
+    task_indices: str = "",
+    num_episodes: int = 10,
+    seed: int = 7,
+    arms: str = "both",
+):
     print("=" * 70)
-    print("Lift #5 L3 side-by-side: native lerobot vs Triton")
+    print("Lift #5 L3 side-by-side: native lerobot vs Triton (proven rollout loop)")
     print("=" * 70)
-    result = run_side_by_side.remote()
+    idx = [int(x) for x in task_indices.split(",") if x.strip()] or None
+    result = run_side_by_side.remote(
+        task_suite_name=suite,
+        task_indices=idx,
+        num_episodes=num_episodes,
+        seed=seed,
+        arms=arms,
+    )
     print("\n" + "=" * 70)
-    print(f"NATIVE: {result['native']['total_success']}/{result['native']['total_eps']} ({result['native_rate']:.0%})")
-    print(f"TRITON: {result['triton']['total_success']}/{result['triton']['total_eps']} ({result['triton_rate']:.0%})")
-    print(f"DELTA:  {result['delta']:+.0%}")
+    n = result.get("native")
+    tr = result.get("triton")
+    if n is not None:
+        print(f"NATIVE: {n['total_success']}/{n['total_eps']} ({result.get('native_rate_pct', 0.0):.1f}%)")
+    if tr is not None:
+        print(f"TRITON: {tr['total_success']}/{tr['total_eps']} ({result.get('triton_rate_pct', 0.0):.1f}%)")
+    if "delta_pp" in result:
+        print(f"DELTA:  {result['delta_pp']:+.1f}pp")
     print("=" * 70)

--- a/src/reflex/runtime/fast_inference/libero_adapter.py
+++ b/src/reflex/runtime/fast_inference/libero_adapter.py
@@ -123,8 +123,13 @@ class TritonLIBEROAdapter:
         images, img_masks = self._policy._preprocess_images(batch_for_pp)
         # Move images back to CUDA for the Triton runtime
         images = [img.to("cuda") for img in images]
-        lang_tokens = batch_pp[OBS_LANGUAGE_TOKENS]
-        lang_masks = batch_pp[OBS_LANGUAGE_ATTENTION_MASK]
+        # Device-align the language tensors with images/noise/states (all cuda).
+        # batch_pp may live on CPU (or the policy's device) depending on the
+        # caller; without this explicit move the Triton runtime saw a CPU/CUDA
+        # mismatch that crashed longer-prompt LIBERO tasks while shorter ones
+        # happened to pass — a latent bug surfaced by the L3 side-by-side.
+        lang_tokens = batch_pp[OBS_LANGUAGE_TOKENS].to("cuda")
+        lang_masks = batch_pp[OBS_LANGUAGE_ATTENTION_MASK].to("cuda")
 
         # Concat multi-view images: list of [B, C, H, W] → [B, N*C, H, W]
         images_concat = torch.cat(images, dim=1)
@@ -158,6 +163,88 @@ class TritonLIBEROAdapter:
             actions = actions[:, :, : orig_dim.shape[0]]
 
         return actions
+
+    # ─── InferenceProtocol (reflex.eval.libero_rollout) ──────────────────
+    # Implementing this lets the fast-kernels runtime be a drop-in ``inference=``
+    # for ``run_libero_rollout`` so BOTH the native and Triton arms run through
+    # the identical proven loop (same cv2 resize, seed, 180° flip, centrally
+    # generated noise, ``bool(done)`` criterion). The rollout already runs
+    # ``policy._preprocess_images`` and hands us numpy, so — unlike the
+    # ``predict_chunk(batch_pp)`` path — there is no device-placement ambiguity:
+    # everything is moved to cuda explicitly here.
+
+    def reset_cache(self) -> None:
+        """No cross-call cache: the Triton runtime is stateless per chunk."""
+
+    def get_stats(self) -> dict[str, Any]:
+        """No cache stats — empty dict satisfies InferenceProtocol."""
+        return {}
+
+    def predict_action_chunk(
+        self,
+        *,
+        img_base: Any,
+        img_wrist_l: Any,
+        img_wrist_r: Any,
+        mask_base: Any,
+        mask_wrist_l: Any,
+        mask_wrist_r: Any,
+        lang_tokens: Any,
+        lang_masks: Any,
+        noise: Any,
+        state: Any,
+        episode_id: str,
+    ) -> Any:
+        """Numpy-in / numpy-out chunk predictor matching Pi05DecomposedInference.
+
+        Mirrors the proven ``predict_chunk`` runtime call exactly (same
+        ``images``/``lang``/``states``/``noise`` contract) but is fed the
+        already-preprocessed per-view numpy arrays produced by the rollout's
+        ``policy._preprocess_images`` step. ``mask_*``/``state``/``episode_id``
+        are accepted for protocol compatibility and unused (pi0.5 is
+        state-in-language; ``predict_action`` derives prompt_len from
+        ``lang_masks`` and ignores ``img_masks``).
+
+        Args:
+            img_base / img_wrist_l / img_wrist_r: ``[B, 3, H, W]`` float views.
+            lang_tokens / lang_masks: ``[B, L]``.
+            noise: ``[B, chunk_size, max_action_dim]``.
+
+        Returns:
+            ``[B, chunk_size, max_action_dim]`` numpy chunk (raw; the rollout
+            denormalizes via the same postprocessor as the native arm).
+        """
+        import numpy as np
+
+        def _t(x: Any, dtype: "torch.dtype") -> "torch.Tensor":
+            return torch.as_tensor(np.asarray(x), dtype=dtype, device="cuda")
+
+        # Concat the 3 views → [B, num_views*3, H, W] (matches predict_chunk).
+        images_concat = torch.cat(
+            [
+                _t(img_base, torch.float32),
+                _t(img_wrist_l, torch.float32),
+                _t(img_wrist_r, torch.float32),
+            ],
+            dim=1,
+        )
+        lang_tok = _t(lang_tokens, torch.long)
+        lang_msk = _t(lang_masks, torch.long)
+        noise_t = _t(noise, torch.float32)
+        bsize = images_concat.shape[0]
+        # State-in-language: kernel ignores states; zeros match predict_chunk.
+        states = torch.zeros(bsize, 32, dtype=torch.float32, device="cuda")
+
+        with torch.no_grad():
+            actions = self._runtime.predict_action(
+                images=images_concat,
+                lang_tokens=lang_tok,
+                states=states,
+                lang_masks=lang_msk,
+                noise=noise_t,
+            )
+
+        return actions.detach().cpu().numpy()
 
 
 __all__ = ["TritonLIBEROAdapter"]


### PR DESCRIPTION
## Summary
Fixes the spurious **0/9 "baseline"** that blocked the Lift #5 `--fast-kernels` L3 LIBERO quality-parity gate (see `03_experiments/2026-05-24-lift5-l3-sbs-baseline-zero.md`).

**Root cause** — the bespoke rollout in `modal_fast_kernels_l3_side_by_side.py` diverged from the proven native eval (`modal_libero_lerobot_native.py`, 80%+ on libero_10 task 0 at N=20) on three axes, then reported the resulting 0/9 as a "baseline" that was never actually run natively for comparison:
- PIL-BILINEAR resize vs the proven cv2 INTER_AREA
- seed 42 vs the proven seed 7
- hard task set `[3,4,6]` (with a false "higher baseline success" comment) vs task 0

**Fix** — both arms now run through `reflex.eval.libero_rollout.run_libero_rollout`, the exact primitive the proven native eval uses, so the **only** difference between arms is the inference backend:
- ARM A (native): `use_native=True` → `policy.select_action`
- ARM B (triton): `inference=TritonLIBEROAdapter`, `use_native=False`

Identical cv2 INTER_AREA resize, seed, 180° flip, centrally-generated noise, and `bool(done)` success criterion.

To drop the Triton runtime into that loop, `TritonLIBEROAdapter` now implements the `InferenceProtocol` (`reset_cache` / `get_stats` / `predict_action_chunk`). Also fixes a **latent device bug** in `predict_chunk`: `lang_tokens`/`lang_masks` are now `.to("cuda")` so they align with the cuda images/noise/states — the CPU/CUDA mismatch crashed longer-prompt LIBERO tasks while shorter ones happened to pass.

Scope: 2 files. No production-serving code path changed — `TritonLIBEROAdapter` is used only by the two L3 eval scripts.

## Test plan
- [x] `tests/test_fast_kernels_runtime.py` (7/7) + full suite (2854 passed) — no regression
- [x] `TritonLIBEROAdapter.predict_action_chunk` signature matches `InferenceProtocol` exactly
- [ ] **Modal A100 L3 gate** (firing next): native-only baseline spike (`--arms native --task-indices 0 --num-episodes 2`) to confirm baseline > 0, then paired parity (`--arms both --task-indices 0,1,2 --num-episodes 10`). Kill-trigger: native−triton regression > 5pp (ADR `2026-05-20-fast-kernels-kill-triggers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
