### PR TITLE
fix: honest precision tiers + chat-online boundary + README perf reconciliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Filter dimensions: `--since` (`7d` / `24h` / `30m`), `--task` (case-insensitive 
 | Older NVIDIA (Turing RTX 20, GTX 16) | sm_7.5 | ⚠️ Best-effort | Should work but not in CI matrix |
 | Pre-Tensor-Core (Maxwell Jetson Nano 4GB, GTX 9-series) | sm_5.x | ❌ Not supported | NVIDIA EOL'd this hardware at JetPack 4.6 (Python 3.6) — too old for modern ML stacks regardless. The bootstrap installer auto-detects and bails fast with redirect instructions. |
 
-**For Blackwell users right now:** the bootstrap installer accepts your hardware and the package installs cleanly, but `reflex go` will segfault at server startup. The real fix requires ORT to ship Blackwell-aware bundled binaries (no published timeline). Workarounds: chat-only mode (no GPU needed), `reflex doctor`, `reflex models list` all work fine. `/act` and TRT-engine inference need a non-Blackwell GPU temporarily.
+**For Blackwell users right now:** the bootstrap installer accepts your hardware and the package installs cleanly, but `reflex go` will segfault at server startup. The real fix requires ORT to ship Blackwell-aware bundled binaries (no published timeline). Workarounds: chat mode (no GPU needed — **but requires network**; chat routes to a hosted model and is not part of the offline serving path), `reflex doctor`, `reflex models list` all work fine. `/act` and TRT-engine inference need a non-Blackwell GPU temporarily.
 
 A Blackwell-specific runtime path via TensorRT-LLM (which supports sm_100) is tracked upstream.
 
@@ -471,19 +471,21 @@ Four ONNX artifacts in production, measured against PyTorch on shared seeded inp
 | **pi0.5 ONNX, num_steps=10** (production default) | `sample_actions(num_steps=10)` | **2.38e-07** | ✅ **machine precision** |
 | **GR00T N1.6 ONNX, single-step DiT** (DDPM, loop external) | `GR00TFullStack.forward` | **8.34e-07** | ✅ **machine precision** |
 | **GR00T N1.6 end-to-end 4-step denoise loop** | Python loop over PyTorch ref | **4.77e-07** | ✅ **machine precision** |
-| **GR00T N1.6 Eagle VLM ONNX** (SigLIP + Qwen3 + mlp1, 1.87B) | `EagleExportStack` PyTorch | **4.25e-04** | ✅ machine precision |
-| **GR00T N1.6 DiT with real VLM KV** (5-input `expert_stack_with_vlm.onnx`) | `GR00TFullStack(state, vlm_kv)` | **1.78e-05** | ✅ machine precision |
+| **GR00T N1.6 Eagle VLM ONNX** (SigLIP + Qwen3 + mlp1, 1.87B) | `EagleExportStack` PyTorch | **4.25e-04** | ✅ **fp16 tolerance** (NOT fp32 machine precision) |
+| **GR00T N1.6 DiT with real VLM KV** (5-input `expert_stack_with_vlm.onnx`) | `GR00TFullStack(state, vlm_kv)` | **1.78e-05** | ✅ **tight tolerance** (fp32 accum, not machine precision) |
 | **GR00T N1.6 end-to-end two-ONNX chain** (Eagle → DiT) | same chain in PyTorch | **1.90e-05** | ✅ parity + image-driven sensitivity verified (max_abs=0.21 on actions when input image changes) |
 | SmolVLA ONNX, num_steps=1 | `sample_actions(num_steps=1)` | 1.55e-06 | ✅ machine precision |
 | pi0 ONNX, num_steps=1 | `sample_actions(num_steps=1)` | 1.43e-06 | ✅ machine precision |
+
+_**Precision tiers (honest labels):** **machine precision (fp32)** ≤ 2e-6 (round-off floor) · **tight tolerance (fp32 accum)** ≤ 1e-4 · **fp16 tolerance** ≤ 5e-3. Only ≤ 2e-6 rows are true fp32 machine precision — the four production flow-matching VLAs (first-action ~1e-7) qualify; the GR00T Eagle VLM stack at 4.25e-4 is fp16-level and is labeled as such, not "machine precision."_
 
 Plus PyTorch-level native-path sanity checks (`SmolVLAPolicy` with DecomposedRMSNorm swap vs reference = cos=1.0; `PI0Policy.predict_action_chunk` vs raw `sample_actions` = bit-exact).
 
 **About the production defaults**: flow-matching VLAs (SmolVLA, pi0, pi0.5) canonically integrate the velocity field with 10 Euler steps — the ONNX bakes in the unrolled loop. GR00T is DDPM-style diffusion with 4 canonical steps — the ONNX exports one velocity step, and `reflex serve` wraps it in the loop. All four match canonical PyTorch to machine precision. Getting pi0 / pi0.5 there required three interacting patches under `torch.export` (F.pad causal mask, frozen `DynamicLayer.update`, `past_kv.get_seq_length()` for mask assembly); GR00T's simpler DiT graph (no DynamicCache, no PaliGemma masking) traces cleanly via plain `torch.onnx.export(opset=19)` — no patches needed. Details in `reflex_context/01_architecture/pi0_monolithic_wrap_pattern.md`.
 
-Full ledger: [reflex_context/measured_numbers.md](reflex_context/measured_numbers.md).
+The full per-fixture ledger — with explicit precision tiers — is emitted into every export's `VERIFICATION.md` by `reflex validate` (the customer-facing trust receipt).
 
-**Latency numbers are intentionally not in the README yet** — earlier TRT FP16 tables were measured on a now-abandoned decomposed-ONNX path. `reflex bench <export_dir>` reproduces on any hardware.
+**Published latency:** the [Performance](#performance) table above (SmolVLA monolithic, A10G, TRT EP — 5.55× over ORT-CUDA, measured 2026-04-29) is the one measured latency number. Broader per-model / per-hardware tables are still being filled in; `reflex bench <export_dir>` reproduces on any hardware. (An earlier set of TRT FP16 tables measured on the now-abandoned decomposed-ONNX path was removed — do not cite those.)
 
 Reproduce on your own GPU with one command:
 
@@ -493,7 +495,7 @@ reflex bench ./pi0 --iterations 100
 
 ### Multi-robot batching (`reflex serve --max-batch N`)
 
-Continuous batching on the HTTP layer: each `/act` request enters an asyncio queue; the server flushes the queue every `--batch-timeout-ms` (default 5ms) into one batched ONNX inference. Earlier measurements on the decomposed-ONNX path showed 2.3-2.9x throughput scaling at batch sizes 4-16.
+Continuous batching on the HTTP layer: each `/act` request enters an asyncio queue; the server flushes the queue every `--batch-timeout-ms` (default 5ms) into one batched ONNX inference. **Throughput figure pending:** an earlier 2.3-2.9x scaling number (batch 4-16) was measured on the now-abandoned decomposed-ONNX path and is **deprecated** — monolithic-path batching has not been re-measured. `reflex bench` will publish the current number.
 
 ## Status
 

--- a/src/reflex/chat/backends.py
+++ b/src/reflex/chat/backends.py
@@ -1,4 +1,12 @@
-"""HTTP backend that talks to the FastCrest proxy (Cloudflare Worker)."""
+"""HTTP backend that talks to the FastCrest proxy (Cloudflare Worker).
+
+NOTE: `reflex chat` is an ONLINE convenience surface — it routes to a hosted
+model via this proxy and REQUIRES network. Reflex's offline / air-gapped
+guarantee is the *serving* path (`reflex serve` / `/act` inference runs fully
+on-device); it does NOT extend to chat. Network failures raise OfflineError
+that states this distinction. Set FASTCREST_PROXY_URL to self-host the proxy
+if you need chat inside a closed network.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +18,13 @@ from typing import Any, Callable, Iterator
 import httpx
 
 DEFAULT_PROXY_URL = "https://chat.fastcrest.com"
+
+_OFFLINE_MSG = (
+    "`reflex chat` needs network: it routes to a hosted model at {url}. "
+    "Reflex's offline/air-gapped guarantee covers `reflex serve` / `/act` "
+    "inference (fully on-device), NOT the chat helper. Self-host the proxy and "
+    "set FASTCREST_PROXY_URL to use chat inside a closed network."
+)
 
 
 @dataclass
@@ -30,8 +45,11 @@ class ChatBackend:
         if tools:
             body["tools"] = tools
             body["tool_choice"] = tool_choice
-        with httpx.Client(timeout=self.timeout_s) as client:
-            r = client.post(f"{self.proxy_url}/chat", json=body)
+        try:
+            with httpx.Client(timeout=self.timeout_s) as client:
+                r = client.post(f"{self.proxy_url}/chat", json=body)
+        except httpx.HTTPError as e:  # ConnectError / timeout / DNS — i.e. no network
+            raise OfflineError(_OFFLINE_MSG.format(url=self.proxy_url)) from e
         if r.status_code == 429:
             raise RateLimitError(r.json().get("message", "rate limit"))
         if r.status_code >= 400:
@@ -49,22 +67,25 @@ class ChatBackend:
         if tools:
             body["tools"] = tools
             body["tool_choice"] = tool_choice
-        with httpx.Client(timeout=self.timeout_s) as client:
-            with client.stream("POST", f"{self.proxy_url}/chat", json=body) as r:
-                if r.status_code == 429:
-                    raise RateLimitError(r.read().decode().strip())
-                if r.status_code >= 400:
-                    raise ProxyError(f"HTTP {r.status_code}: {r.read().decode()[:300]}")
-                for line in r.iter_lines():
-                    if not line or not line.startswith("data:"):
-                        continue
-                    payload = line[5:].strip()
-                    if payload == "[DONE]":
-                        return
-                    try:
-                        yield json.loads(payload)
-                    except json.JSONDecodeError:
-                        continue
+        try:
+            with httpx.Client(timeout=self.timeout_s) as client:
+                with client.stream("POST", f"{self.proxy_url}/chat", json=body) as r:
+                    if r.status_code == 429:
+                        raise RateLimitError(r.read().decode().strip())
+                    if r.status_code >= 400:
+                        raise ProxyError(f"HTTP {r.status_code}: {r.read().decode()[:300]}")
+                    for line in r.iter_lines():
+                        if not line or not line.startswith("data:"):
+                            continue
+                        payload = line[5:].strip()
+                        if payload == "[DONE]":
+                            return
+                        try:
+                            yield json.loads(payload)
+                        except json.JSONDecodeError:
+                            continue
+        except httpx.HTTPError as e:  # ConnectError / timeout / DNS — i.e. no network
+            raise OfflineError(_OFFLINE_MSG.format(url=self.proxy_url)) from e
 
     def health(self) -> dict[str, Any]:
         with httpx.Client(timeout=10.0) as client:
@@ -127,4 +148,14 @@ class ProxyError(RuntimeError):
 
 
 class RateLimitError(RuntimeError):
+    pass
+
+
+class OfflineError(RuntimeError):
+    """Raised when `reflex chat` can't reach the hosted proxy (no network).
+
+    Distinct from ProxyError (server reachable but errored): OfflineError means
+    the offline/air-gap boundary was hit. Its message states that Reflex's
+    offline guarantee is the serving path (`reflex serve` / `/act`), not chat.
+    """
     pass

--- a/src/reflex/verification_report.py
+++ b/src/reflex/verification_report.py
@@ -59,6 +59,25 @@ def _collect_files(export_dir: Path) -> list[dict[str, Any]]:
     return out
 
 
+def _precision_tier(max_abs: float) -> str:
+    """Classify a max_abs_diff into an HONEST precision tier.
+
+    "Machine precision" is the fp32 round-off floor (~1e-6). Looser values are
+    NOT machine precision and must not be labeled as such: a ~1e-4 diff is
+    fp16-level tolerance, which a QA reviewer will (correctly) pull as the first
+    row. A verification receipt that calls 4e-4 "machine precision" loses the
+    room. Keep the tiers honest.
+    """
+    a = abs(float(max_abs))
+    if a <= 2e-6:
+        return "machine precision (fp32)"
+    if a <= 1e-4:
+        return "tight tolerance (fp32 accum)"
+    if a <= 5e-3:
+        return "fp16 tolerance"
+    return "DIVERGENT — review"
+
+
 def _format_parity(parity: dict[str, Any] | None) -> str:
     if not parity:
         return (
@@ -76,19 +95,28 @@ def _format_parity(parity: dict[str, Any] | None) -> str:
         f"**Threshold:** {parity.get('threshold')}",
         f"**Fixtures:** {parity.get('num_test_cases')}",
         f"**Seed:** {parity.get('seed')}",
-        f"**max_abs_diff across all fixtures:** {max_abs:.3e}",
+        f"**max_abs_diff across all fixtures:** {max_abs:.3e} — {_precision_tier(max_abs)}",
         "",
-        "| Fixture | max_abs_diff | mean_abs_diff | Passed |",
-        "|---|---|---|---|",
+        "| Fixture | max_abs_diff | mean_abs_diff | Precision tier | Passed |",
+        "|---|---|---|---|---|",
     ]
     for r in results:
         ok = "PASS" if r.get("passed") else "FAIL"
+        r_max = float(r.get("max_abs_diff", 0))
         lines.append(
             f"| {r.get('fixture_idx', '?')} | "
-            f"{float(r.get('max_abs_diff', 0)):.3e} | "
+            f"{r_max:.3e} | "
             f"{float(r.get('mean_abs_diff', 0)):.3e} | "
+            f"{_precision_tier(r_max)} | "
             f"{ok} |"
         )
+    lines += [
+        "",
+        "_Precision tiers: **machine precision (fp32)** ≤ 2e-6 (round-off floor) · "
+        "**tight tolerance (fp32 accum)** ≤ 1e-4 · **fp16 tolerance** ≤ 5e-3 · "
+        "**DIVERGENT — review** otherwise. Only ≤ 2e-6 is true fp32 machine precision; "
+        "a ~1e-4 diff is fp16-level and is labeled as such._",
+    ]
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
Three honesty fixes — the kind that matter once VERIFICATION.md and the README are sales artifacts a QA/compliance team reads.

## 1. Verification ledger over-labeled precision
The ledger called everything from 6e-7 to **4.25e-4** "machine precision" — a ~700x spread under one green check. The Eagle VLM stack at 4.25e-4 is **fp16 tolerance**, not fp32 machine precision (the first row a QA reviewer pulls).
- Added `_precision_tier()` to `verification_report.py` so the **generated VERIFICATION.md self-classifies** each fixture: `<=2e-6 machine precision (fp32)` / `<=1e-4 tight tolerance` / `<=5e-3 fp16 tolerance` / else `DIVERGENT - review`.
- Retiered the README ledger rows (Eagle 4.25e-4 -> fp16 tolerance; DiT 1.78e-5 -> tight tolerance) + added a legend. Fixed the dead `measured_numbers.md` link.

## 2. `reflex chat` silently required network (contradicts offline/private pitch)
`chat` routes to `chat.fastcrest.com` (GPT-5 Mini). For the defense/legal/offline positioning that is the inverse of the promise.
- `chat` now raises **`OfflineError`** on network failure, stating plainly that the offline/air-gap guarantee is the **serving path** (`reflex serve` / `/act`, fully on-device), **not** the chat helper; self-host via `FASTCREST_PROXY_URL`.
- Corrected the README Blackwell "chat-only mode (no GPU needed)" workaround to note it **requires network**.
- (Follow-up option: a local chat fallback if we want chat itself air-gappable - flagged, not built.)

## 3. README perf self-contradiction
The Performance section publishes a 5.55x TRT table, but a later line said "latency numbers intentionally not in the README yet," and the only batching figure (2.3-2.9x) was on the abandoned decomposed-ONNX path.
- The "no latency yet" line now points at the real published Performance number; the 2.3-2.9x batching figure is marked **deprecated** (abandoned path, not re-measured).

## Test plan
- [x] `155 passed` across chat/verification/backend/report tests
- [x] Python compiles; `_precision_tier` maps 4.25e-4 -> "fp16 tolerance"
- [x] No behavior change to other verbs

Co-Authored-By: Claude Opus 4.7 (1M context)
