### PR TITLE
feat(verify): MMD + embodied parity + tamper-evident audit chain

### DIFF
--- a/src/reflex/eval/libero_rollout.py
+++ b/src/reflex/eval/libero_rollout.py
@@ -105,6 +105,7 @@ def run_libero_rollout(
     save_video_dir: str = "",
     label: str = "rollout",
     use_native: bool = False,
+    capture_trajectories: bool = False,
 ) -> dict[str, Any]:
     """Run LIBERO rollouts through the given inference + processor pipeline.
 
@@ -293,6 +294,8 @@ def run_libero_rollout(
                 t = 0
                 done = False
                 video_frames = [] if save_video_dir else None
+                ep_action_chunks: list = []  # populated only when capture_trajectories
+                ep_eef_positions: list = []
                 if video_frames is not None:
                     video_frames.append(
                         np.ascontiguousarray(obs["agentview_image"][::-1, ::-1])
@@ -331,6 +334,8 @@ def run_libero_rollout(
                                 if chunk_np_post.ndim == 1:
                                     chunk_np_post = chunk_np_post[np.newaxis, :]
                                 chunk_np_post = chunk_np_post[:, :7]
+                                if capture_trajectories:
+                                    ep_action_chunks.append(np.asarray(chunk_np_post, dtype=np.float32))
                                 action_plan.extend(chunk_np_post[:replan_steps])
                             else:
                                 with torch.no_grad():
@@ -372,10 +377,14 @@ def run_libero_rollout(
                                 if chunk_np_post.ndim == 3:
                                     chunk_np_post = chunk_np_post[0]
                                 chunk_np_post = chunk_np_post[:, :7]
+                                if capture_trajectories:
+                                    ep_action_chunks.append(np.asarray(chunk_np_post, dtype=np.float32))
                                 action_plan.extend(chunk_np_post[:replan_steps])
 
                         action = action_plan.popleft()
                         obs, _, done, info = env.step(np.asarray(action).tolist())
+                        if capture_trajectories and "robot0_eef_pos" in obs:
+                            ep_eef_positions.append(np.asarray(obs["robot0_eef_pos"], dtype=np.float32))
                         if video_frames is not None:
                             video_frames.append(
                                 np.ascontiguousarray(obs["agentview_image"][::-1, ::-1])
@@ -394,9 +403,11 @@ def run_libero_rollout(
                         raise
 
                 success = bool(done)
-                task_result["episodes"].append({
-                    "ep": ep, "success": success, "steps": t,
-                })
+                episode_rec = {"ep": ep, "success": success, "steps": t}
+                if capture_trajectories:
+                    episode_rec["action_chunks"] = [c.tolist() for c in ep_action_chunks]
+                    episode_rec["eef_positions"] = [p.tolist() for p in ep_eef_positions]
+                task_result["episodes"].append(episode_rec)
                 task_result["total"] += 1
                 if success:
                     task_result["success"] += 1

--- a/src/reflex/runtime/record.py
+++ b/src/reflex/runtime/record.py
@@ -125,6 +125,36 @@ def _redact_image(
     return out
 
 
+def _chain_hash(prev_hash: str, record: dict[str, Any]) -> str:
+    """``sha256(prev_hash || canonical(record without the chain fields))``.
+
+    Excludes ``prev_record_hash`` / ``record_hash`` so the hash covers only the
+    record's own content; the link to the previous record is carried by
+    ``prev_hash``. Deterministic (sorted keys, no whitespace).
+    """
+    payload = {k: v for k, v in record.items() if k not in ("prev_record_hash", "record_hash")}
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(prev_hash.encode("ascii") + canonical).hexdigest()
+
+
+def verify_record_chain(records: list[dict[str, Any]]) -> tuple[bool, int | None]:
+    """Verify a recorded trace's tamper-evident chain.
+
+    Returns ``(ok, first_broken_index)``: ``ok`` is True iff every record's
+    ``prev_record_hash`` links to the prior ``record_hash`` and every
+    ``record_hash`` matches the recomputed content hash. Any insert / edit /
+    reorder breaks it at the offending index.
+    """
+    prev = "0" * 64
+    for i, rec in enumerate(records):
+        if rec.get("prev_record_hash") != prev:
+            return False, i
+        if rec.get("record_hash") != _chain_hash(prev, rec):
+            return False, i
+        prev = rec["record_hash"]
+    return True, None
+
+
 class RecordWriter:
     """JSONL recorder for /act calls. One instance per recording session."""
 
@@ -223,6 +253,7 @@ class RecordWriter:
         self._fh: io.TextIOBase | None = None
         self._header_written = False
         self._seq = 0
+        self._prev_record_hash = "0" * 64  # tamper-evident hash-chain head
         self.degraded = False  # set on first OSError; recorder stops writing
         # Curate dual-write: when a FreeContributorCollector is attached,
         # write_request emits to BOTH the JSONL trace (audit) AND the
@@ -269,6 +300,12 @@ class RecordWriter:
         self._open_if_needed()
         if self.degraded or self._fh is None:
             return
+        # Tamper-evident hash chain: each record carries the previous record's
+        # hash plus a hash of its own content (excluding the chain fields), so an
+        # auditor can detect any insertion, edit, or reorder of the trace.
+        record["prev_record_hash"] = self._prev_record_hash
+        record["record_hash"] = _chain_hash(self._prev_record_hash, record)
+        self._prev_record_hash = record["record_hash"]
         try:
             self._fh.write(json.dumps(record, separators=(",", ":")) + "\n")
             self._fh.flush()

--- a/src/reflex/verify.py
+++ b/src/reflex/verify.py
@@ -41,6 +41,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable
 
+import numpy as np
+
 from reflex.pro.eval_gate import (
     EvalGate,
     EvalReport,
@@ -48,6 +50,12 @@ from reflex.pro.eval_gate import (
     GateThresholds,
     InsufficientEpisodes,
     MIN_EPISODES_TO_EVALUATE,
+)
+from reflex.verify_metrics import (
+    EmbodiedParity,
+    TwoSampleResult,
+    aggregate_embodied,
+    two_sample_test,
 )
 
 logger = logging.getLogger(__name__)
@@ -90,6 +98,8 @@ class ParityVerdict:
             "%Y-%m-%d %H:%M:%S UTC"
         )
     )
+    two_sample: TwoSampleResult | None = None  # distributional parity (None if no per-step data)
+    embodied: EmbodiedParity | None = None  # kinematic parity (None if no per-step data)
 
     @property
     def success_rate_delta(self) -> float:
@@ -114,6 +124,8 @@ class ParityVerdict:
             "success_rate_delta": self.success_rate_delta,
             "first_failing_gate_id": self.first_failing_gate_id,
             "generated_at": self.generated_at,
+            "two_sample": self.two_sample.to_dict() if self.two_sample else None,
+            "embodied": self.embodied.to_dict() if self.embodied else None,
             "eval_report": self.eval_report.to_dict(),
         }
 
@@ -168,6 +180,36 @@ def _success_rate(samples: list[EvalSample]) -> float:
     if not samples:
         return 0.0
     return sum(1 for s in samples if s.success) / len(samples)
+
+
+def _collect_action_chunks(results: dict[str, Any]) -> np.ndarray:
+    """Stack every captured per-step action chunk (flattened) into ``(N, D)``.
+
+    Returns ``(0, 0)`` when the rollout didn't capture trajectories (tap off or
+    older results) — the two-sample test then no-ops.
+    """
+    rows: list[np.ndarray] = []
+    for task in results.get("per_task", []) or []:
+        for ep in task.get("episodes", []) or []:
+            for chunk in ep.get("action_chunks", []) or []:
+                rows.append(np.asarray(chunk, dtype=np.float64).reshape(-1))
+    if not rows:
+        return np.empty((0, 0))
+    width = min(r.shape[0] for r in rows)
+    return np.vstack([r[:width] for r in rows]) if width else np.empty((0, 0))
+
+
+def _collect_eef_and_steps(results: dict[str, Any]) -> tuple[list[np.ndarray], list[float]]:
+    """Per-episode end-effector position trajectories + completion-step counts."""
+    positions: list[np.ndarray] = []
+    steps: list[float] = []
+    for task in results.get("per_task", []) or []:
+        for ep in task.get("episodes", []) or []:
+            eef = ep.get("eef_positions") or []
+            if len(eef) > 1:
+                positions.append(np.asarray(eef, dtype=np.float64))
+            steps.append(float(ep.get("steps", 0) or 0))
+    return positions, steps
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +270,7 @@ def gather_paired_samples(
         num_episodes=num_episodes,
         task_indices=task_indices,
         seed=seed,
+        capture_trajectories=True,
     )
 
     # ARM A — original: native lerobot select_action (the reference behavior).
@@ -333,27 +376,39 @@ def run_verify(
         bypass_audit=None,
     )
 
-    # TODO(reflex-verify): distributional two-sample engine. The v0 gate scores
-    # success-rate parity (S3/P1/P5) + sentinel-passes the distribution gates.
-    # The real parity engine slots in HERE as an additional, non-bypassable
-    # check before the verdict is finalized:
-    #   - MMD (maximum mean discrepancy) two-sample test on the paired action
-    #     chunk distributions (original vs optimized), with a permutation-test
-    #     p-value threshold — detects distribution shift the mean hides.
-    #   - Energy-distance two-sample test as a second, kernel-free estimator.
-    # Both consume the per-step action chunks that the rollout primitive must
-    # first be widened to capture (see _rollout_results_to_samples TODO).
-    #
-    # TODO(reflex-verify): embodied / kinematic parity metrics, scored per
-    # paired episode and aggregated:
-    #   - jerk (3rd derivative of joint position) — smoothness regressions are
-    #     invisible to success rate but wreck real hardware.
-    #   - completion-time delta — an export that succeeds but is slower.
-    #   - motion-energy (sum of squared joint velocities) — energy-per-task
-    #     parity. These need per-step joint state from the rollout loop.
+    # Distributional + embodied parity — the v0 TODOs, now wired. Computed from
+    # the per-step trajectories the widened rollout tap captures. When the tap
+    # is off / older results lack them, these stay None and only success-rate
+    # parity applies (no silent degrade — the verdict records which ran).
+    base_chunks = _collect_action_chunks(original_results)
+    cand_chunks = _collect_action_chunks(optimized_results)
+    two_sample: TwoSampleResult | None = None
+    if base_chunks.size and cand_chunks.size and base_chunks.shape[1] == cand_chunks.shape[1]:
+        two_sample = two_sample_test(base_chunks, cand_chunks)
+
+    base_pos, base_steps = _collect_eef_and_steps(original_results)
+    cand_pos, cand_steps = _collect_eef_and_steps(optimized_results)
+    embodied: EmbodiedParity | None = None
+    if base_pos and cand_pos:
+        embodied = aggregate_embodied(
+            baseline_positions=base_pos,
+            candidate_positions=cand_pos,
+            baseline_velocities=[np.diff(p, axis=0) for p in base_pos],
+            candidate_velocities=[np.diff(p, axis=0) for p in cand_pos],
+            baseline_completion_steps=base_steps,
+            candidate_completion_steps=cand_steps,
+        )
+
+    # Non-bypassable: a shifted action distribution or an embodied regression
+    # fails the verdict even when success-rate parity passed.
+    passed = report.overall_passed
+    if two_sample is not None and two_sample.distributions_differ:
+        passed = False
+    if embodied is not None and embodied.regressed():
+        passed = False
 
     return ParityVerdict(
-        passed=report.overall_passed,
+        passed=passed,
         eval_report=report,
         optimized_ref=optimized_ref,
         original_ref=original_ref or optimized_ref,
@@ -362,6 +417,8 @@ def run_verify(
         n_episodes=len(candidate_samples),
         original_success_rate=_success_rate(baseline_samples),
         optimized_success_rate=_success_rate(candidate_samples),
+        two_sample=two_sample,
+        embodied=embodied,
     )
 
 

--- a/src/reflex/verify_metrics.py
+++ b/src/reflex/verify_metrics.py
@@ -1,0 +1,274 @@
+"""Distributional + embodied parity metrics for `reflex verify`.
+
+`reflex verify` v0 scores *success-rate* parity (does the optimized export pass
+the same tasks as the original). That is table stakes: an export can match
+success rate while shifting the action distribution or moving in a way that
+wrecks real hardware. This module adds the two deeper, non-bypassable signals
+flagged in ``verify.py``:
+
+* **Distributional parity** — a two-sample test on the paired per-step action
+  chunks (original vs optimized). We ship two estimators:
+  - **MMD** (maximum mean discrepancy) with a multi-bandwidth RBF kernel and a
+    permutation-test p-value (Model Equality Testing, arXiv 2410.20247).
+  - **Energy distance** as a second, kernel-free estimator.
+  A *low* p-value means the optimized policy's action distribution differs from
+  the original beyond sampling noise — a regression success rate hides.
+
+* **Embodied / kinematic parity** — scored per paired episode and aggregated:
+  - **jerk** (RMS of the 3rd derivative of joint position): smoothness
+    regressions are invisible to success rate but destroy real actuators.
+  - **motion energy** (sum of squared joint velocities): energy-per-task parity.
+  - **completion time**: an export that succeeds but is slower.
+
+Everything here is pure NumPy (a core dep) and fully unit-testable on synthetic
+arrays — no GPU, no rollout. ``verify.py`` feeds it the per-step trajectories
+once the rollout primitive is widened to capture them.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+ArrayLike = Sequence[Sequence[float]] | np.ndarray
+
+
+# ---------------------------------------------------------------------------
+# Distributional two-sample tests
+# ---------------------------------------------------------------------------
+
+
+def _as_2d(samples: ArrayLike) -> np.ndarray:
+    """Coerce a collection of vectors into a float ``(n, d)`` matrix."""
+    arr = np.asarray(samples, dtype=np.float64)
+    if arr.ndim == 1:
+        arr = arr.reshape(-1, 1)
+    if arr.ndim != 2:
+        raise ValueError(f"expected 2D (n_samples, n_features), got shape {arr.shape}")
+    return arr
+
+
+def _pairwise_sq_dists(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Squared Euclidean distances between rows of ``a`` and rows of ``b``."""
+    a_sq = np.sum(a * a, axis=1)[:, None]
+    b_sq = np.sum(b * b, axis=1)[None, :]
+    sq = a_sq + b_sq - 2.0 * (a @ b.T)
+    return np.maximum(sq, 0.0)  # clamp tiny negatives from float error
+
+
+def _median_bandwidth(pooled: np.ndarray) -> float:
+    """Median-heuristic length scale: median of pairwise distances on the pool."""
+    sq = _pairwise_sq_dists(pooled, pooled)
+    iu = np.triu_indices_from(sq, k=1)
+    med_sq = float(np.median(sq[iu])) if iu[0].size else 1.0
+    return med_sq if med_sq > 1e-12 else 1.0
+
+
+def _mmd2_unbiased(X: np.ndarray, Y: np.ndarray, gammas: Sequence[float]) -> float:
+    """Unbiased MMD^2 with a multi-bandwidth RBF kernel (summed over gammas)."""
+    m, n = X.shape[0], Y.shape[0]
+    if m < 2 or n < 2:
+        return 0.0
+    kxx = np.zeros((m, m))
+    kyy = np.zeros((n, n))
+    kxy = np.zeros((m, n))
+    dxx = _pairwise_sq_dists(X, X)
+    dyy = _pairwise_sq_dists(Y, Y)
+    dxy = _pairwise_sq_dists(X, Y)
+    for g in gammas:
+        kxx += np.exp(-g * dxx)
+        kyy += np.exp(-g * dyy)
+        kxy += np.exp(-g * dxy)
+    # Unbiased: exclude the diagonal (self-similarity) from the within-sample terms.
+    np.fill_diagonal(kxx, 0.0)
+    np.fill_diagonal(kyy, 0.0)
+    term_xx = kxx.sum() / (m * (m - 1))
+    term_yy = kyy.sum() / (n * (n - 1))
+    term_xy = kxy.sum() * (2.0 / (m * n))
+    return float(term_xx + term_yy - term_xy)
+
+
+@dataclass(frozen=True)
+class TwoSampleResult:
+    mmd2: float
+    mmd_p_value: float  # P(MMD^2 >= observed | same distribution); low => differ
+    energy_distance: float
+    n_baseline: int
+    n_candidate: int
+    n_permutations: int
+
+    @property
+    def distributions_differ(self) -> bool:
+        """True when the permutation test rejects the null at p < 0.05."""
+        return self.mmd_p_value < 0.05
+
+    def to_dict(self) -> dict[str, float | int | bool]:
+        return {
+            "mmd2": self.mmd2,
+            "mmd_p_value": self.mmd_p_value,
+            "energy_distance": self.energy_distance,
+            "n_baseline": self.n_baseline,
+            "n_candidate": self.n_candidate,
+            "n_permutations": self.n_permutations,
+            "distributions_differ": self.distributions_differ,
+        }
+
+
+def energy_distance(X: ArrayLike, Y: ArrayLike) -> float:
+    """Two-sample energy distance: ``2 E|x-y| - E|x-x'| - E|y-y'|`` (>= 0)."""
+    a, b = _as_2d(X), _as_2d(Y)
+    if a.shape[0] == 0 or b.shape[0] == 0:
+        return 0.0
+    d_ab = np.sqrt(_pairwise_sq_dists(a, b)).mean()
+    d_aa = np.sqrt(_pairwise_sq_dists(a, a)).mean()
+    d_bb = np.sqrt(_pairwise_sq_dists(b, b)).mean()
+    return float(max(2.0 * d_ab - d_aa - d_bb, 0.0))
+
+
+def two_sample_test(
+    baseline: ArrayLike,
+    candidate: ArrayLike,
+    *,
+    n_permutations: int = 200,
+    seed: int = 7,
+) -> TwoSampleResult:
+    """MMD + energy-distance two-sample test with a permutation p-value.
+
+    ``baseline`` / ``candidate`` are ``(n_samples, n_features)`` action-chunk
+    matrices (e.g. flattened per-step action chunks from the original vs the
+    optimized policy). A low ``mmd_p_value`` means the action distributions
+    differ beyond sampling noise.
+    """
+    X, Y = _as_2d(baseline), _as_2d(candidate)
+    m, n = X.shape[0], Y.shape[0]
+    if m < 2 or n < 2:
+        # Not enough samples to test; report a non-significant result rather
+        # than fabricate a verdict (the success-rate gate still applies).
+        return TwoSampleResult(0.0, 1.0, energy_distance(X, Y), m, n, 0)
+
+    pooled = np.vstack([X, Y])
+    med_sq = _median_bandwidth(pooled)
+    base_gamma = 1.0 / (2.0 * med_sq)
+    gammas = [base_gamma * s for s in (0.5, 1.0, 2.0)]
+
+    observed = _mmd2_unbiased(X, Y, gammas)
+
+    rng = np.random.default_rng(seed)
+    ge = 0
+    for _ in range(n_permutations):
+        perm = rng.permutation(m + n)
+        Xp = pooled[perm[:m]]
+        Yp = pooled[perm[m:]]
+        if _mmd2_unbiased(Xp, Yp, gammas) >= observed:
+            ge += 1
+    p_value = (1.0 + ge) / (1.0 + n_permutations)
+
+    return TwoSampleResult(
+        mmd2=observed,
+        mmd_p_value=p_value,
+        energy_distance=energy_distance(X, Y),
+        n_baseline=m,
+        n_candidate=n,
+        n_permutations=n_permutations,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Embodied / kinematic metrics
+# ---------------------------------------------------------------------------
+
+
+def jerk_rms(positions: ArrayLike, *, dt: float = 1.0) -> float:
+    """RMS jerk (3rd time-derivative of joint position) over a trajectory.
+
+    ``positions`` is ``(T, n_joints)``. Returns 0 for trajectories too short to
+    take three derivatives, or for constant-velocity (linear) motion.
+    """
+    p = _as_2d(positions)
+    if p.shape[0] < 4 or dt <= 0:
+        return 0.0
+    jerk = np.diff(p, n=3, axis=0) / (dt ** 3)
+    return float(np.sqrt(np.mean(jerk * jerk)))
+
+
+def motion_energy(velocities: ArrayLike) -> float:
+    """Sum of squared joint velocities over a trajectory (``(T, n_joints)``)."""
+    v = _as_2d(velocities)
+    if v.size == 0:
+        return 0.0
+    return float(np.sum(v * v))
+
+
+@dataclass(frozen=True)
+class EmbodiedParity:
+    baseline_jerk_rms: float
+    candidate_jerk_rms: float
+    baseline_motion_energy: float
+    candidate_motion_energy: float
+    baseline_completion_steps: float
+    candidate_completion_steps: float
+
+    def regressed(self, *, jerk_tol: float = 1.5, energy_tol: float = 1.5, time_tol: float = 1.5) -> bool:
+        """True if the candidate is materially worse on any embodied axis.
+
+        ``*_tol`` are allowed ratios (candidate / baseline). Default 1.5 => a
+        50% increase in jerk, motion energy, or completion time fails.
+        """
+        def worse(cand: float, base: float, tol: float) -> bool:
+            if base <= 1e-9:
+                return cand > 1e-6  # baseline ~0, any candidate motion is a regression
+            return (cand / base) > tol
+        return (
+            worse(self.candidate_jerk_rms, self.baseline_jerk_rms, jerk_tol)
+            or worse(self.candidate_motion_energy, self.baseline_motion_energy, energy_tol)
+            or worse(self.candidate_completion_steps, self.baseline_completion_steps, time_tol)
+        )
+
+    def to_dict(self) -> dict[str, float | bool]:
+        return {
+            "baseline_jerk_rms": self.baseline_jerk_rms,
+            "candidate_jerk_rms": self.candidate_jerk_rms,
+            "baseline_motion_energy": self.baseline_motion_energy,
+            "candidate_motion_energy": self.candidate_motion_energy,
+            "baseline_completion_steps": self.baseline_completion_steps,
+            "candidate_completion_steps": self.candidate_completion_steps,
+            "embodied_regressed": self.regressed(),
+        }
+
+
+def _mean(values: Sequence[float]) -> float:
+    vals = [float(v) for v in values if v is not None]
+    return float(np.mean(vals)) if vals else 0.0
+
+
+def aggregate_embodied(
+    *,
+    baseline_positions: Sequence[ArrayLike],
+    candidate_positions: Sequence[ArrayLike],
+    baseline_velocities: Sequence[ArrayLike],
+    candidate_velocities: Sequence[ArrayLike],
+    baseline_completion_steps: Sequence[float],
+    candidate_completion_steps: Sequence[float],
+    dt: float = 1.0,
+) -> EmbodiedParity:
+    """Aggregate per-episode embodied metrics into a baseline-vs-candidate parity."""
+    return EmbodiedParity(
+        baseline_jerk_rms=_mean([jerk_rms(p, dt=dt) for p in baseline_positions]),
+        candidate_jerk_rms=_mean([jerk_rms(p, dt=dt) for p in candidate_positions]),
+        baseline_motion_energy=_mean([motion_energy(v) for v in baseline_velocities]),
+        candidate_motion_energy=_mean([motion_energy(v) for v in candidate_velocities]),
+        baseline_completion_steps=_mean(baseline_completion_steps),
+        candidate_completion_steps=_mean(candidate_completion_steps),
+    )
+
+
+__all__ = [
+    "EmbodiedParity",
+    "TwoSampleResult",
+    "aggregate_embodied",
+    "energy_distance",
+    "jerk_rms",
+    "motion_energy",
+    "two_sample_test",
+]

--- a/tests/test_record_chain.py
+++ b/tests/test_record_chain.py
@@ -1,0 +1,76 @@
+"""Tests for the tamper-evident hash chain in the runtime trace recorder.
+
+Validates the chain functions directly, and that ``RecordWriter._emit`` writes a
+trace that ``verify_record_chain`` accepts and that any tamper breaks.
+"""
+from __future__ import annotations
+
+import json
+
+from reflex.runtime.record import RecordWriter, _chain_hash, verify_record_chain
+
+
+def _build_chain(payloads):
+    """Mirror RecordWriter._emit's chaining over a list of record payloads."""
+    prev = "0" * 64
+    out = []
+    for p in payloads:
+        rec = dict(p)
+        rec["prev_record_hash"] = prev
+        rec["record_hash"] = _chain_hash(prev, rec)
+        prev = rec["record_hash"]
+        out.append(rec)
+    return out
+
+
+def test_intact_chain_verifies():
+    recs = _build_chain([{"kind": "header"}, {"kind": "request", "seq": 1}, {"kind": "footer"}])
+    ok, idx = verify_record_chain(recs)
+    assert ok is True and idx is None
+
+
+def test_content_edit_is_detected():
+    recs = _build_chain([{"kind": "header"}, {"kind": "request", "seq": 1, "action_sha256": "a"}])
+    recs[1]["action_sha256"] = "TAMPERED"  # edit a request's content
+    ok, idx = verify_record_chain(recs)
+    assert ok is False and idx == 1
+
+
+def test_record_insertion_is_detected():
+    recs = _build_chain([{"kind": "header"}, {"kind": "request", "seq": 1}])
+    forged = {"kind": "request", "seq": 99, "prev_record_hash": recs[-1]["record_hash"]}
+    forged["record_hash"] = _chain_hash(forged["prev_record_hash"], forged)
+    recs.insert(1, forged)  # splice a record into the middle
+    ok, idx = verify_record_chain(recs)
+    assert ok is False and idx == 1
+
+
+def test_reorder_is_detected():
+    recs = _build_chain([{"kind": "header"}, {"kind": "request", "seq": 1}, {"kind": "request", "seq": 2}])
+    recs[1], recs[2] = recs[2], recs[1]
+    ok, idx = verify_record_chain(recs)
+    assert ok is False
+
+
+def test_recordwriter_emits_a_verifiable_chain(tmp_path):
+    w = RecordWriter(
+        tmp_path,
+        model_hash="m0",
+        config_hash="c0",
+        export_dir=str(tmp_path),
+        model_type="pi05",
+        export_kind="decomposed",
+        providers=["CPUExecutionProvider"],
+        gzip_output=False,
+    )
+    w._emit({"kind": "header", "schema_version": 1})
+    w._emit({"kind": "request", "seq": 0})
+    w._emit({"kind": "footer"})
+    lines = [json.loads(line) for line in open(w.filepath) if line.strip()]
+    assert len(lines) == 3
+    ok, idx = verify_record_chain(lines)
+    assert ok is True and idx is None
+    # And tampering the persisted trace is caught.
+    lines[1]["seq"] = 7
+    ok2, idx2 = verify_record_chain(lines)
+    assert ok2 is False and idx2 == 1

--- a/tests/test_verify_integration.py
+++ b/tests/test_verify_integration.py
@@ -1,0 +1,73 @@
+"""Integration tests for `run_verify`'s distributional + embodied checks.
+
+Uses a synthetic ``gather_fn`` returning rollout-shaped result dicts WITH the
+per-step trajectories the widened tap captures (``action_chunks`` +
+``eef_positions``). No GPU, no real rollout — validates that run_verify wires
+MMD + embodied parity into the verdict as non-bypassable checks.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from reflex.verify import run_verify
+
+
+def _make_results(n_eps, *, chunk_mean, eef_jitter, rng, n_chunks=6, steps=100):
+    episodes = []
+    for e in range(n_eps):
+        chunks = [
+            rng.normal(chunk_mean, 0.1, size=(5, 7)).tolist() for _ in range(n_chunks)
+        ]
+        eef = np.cumsum(np.full((40, 3), 0.01), axis=0)  # smooth linear motion
+        if eef_jitter:
+            eef = eef + rng.normal(0.0, eef_jitter, size=(40, 3))
+        episodes.append({
+            "ep": e, "success": True, "steps": steps,
+            "action_chunks": chunks, "eef_positions": eef.tolist(),
+        })
+    return {"per_task": [{"task_idx": 0, "task_description": "t", "episodes": episodes}]}
+
+
+def _gather_returning(orig, opt):
+    def gather(**_kwargs):
+        return orig, opt
+    return gather
+
+
+def test_run_verify_passes_when_distributions_and_motion_match():
+    rng = np.random.default_rng(0)
+    orig = _make_results(32, chunk_mean=0.0, eef_jitter=0.0, rng=rng)
+    opt = _make_results(32, chunk_mean=0.0, eef_jitter=0.0, rng=rng)
+    v = run_verify(optimized_ref="exp", gather_fn=_gather_returning(orig, opt), num_episodes=32)
+    assert v.two_sample is not None and v.two_sample.distributions_differ is False
+    assert v.embodied is not None and v.embodied.regressed() is False
+    assert v.passed is True
+
+
+def test_run_verify_fails_on_action_distribution_shift():
+    rng = np.random.default_rng(0)
+    orig = _make_results(32, chunk_mean=0.0, eef_jitter=0.0, rng=rng)
+    opt = _make_results(32, chunk_mean=2.0, eef_jitter=0.0, rng=rng)  # shifted chunks
+    v = run_verify(optimized_ref="exp", gather_fn=_gather_returning(orig, opt), num_episodes=32)
+    assert v.two_sample.distributions_differ is True
+    assert v.passed is False  # non-bypassable, even though success parity matched
+
+
+def test_run_verify_fails_on_embodied_regression():
+    rng = np.random.default_rng(1)
+    orig = _make_results(32, chunk_mean=0.0, eef_jitter=0.0, rng=rng)
+    opt = _make_results(32, chunk_mean=0.0, eef_jitter=0.5, rng=rng)  # jittery motion
+    v = run_verify(optimized_ref="exp", gather_fn=_gather_returning(orig, opt), num_episodes=32)
+    assert v.embodied.regressed() is True
+    assert v.passed is False
+
+
+def test_run_verify_without_trajectories_is_backward_compatible():
+    # Older results / tap off: no action_chunks / eef_positions => checks no-op.
+    def bare(n):
+        return {"per_task": [{"task_idx": 0, "episodes": [
+            {"ep": i, "success": True, "steps": 100} for i in range(n)
+        ]}]}
+    v = run_verify(optimized_ref="exp", gather_fn=_gather_returning(bare(32), bare(32)), num_episodes=32)
+    assert v.two_sample is None and v.embodied is None
+    assert v.passed is True  # falls back to success-rate parity only

--- a/tests/test_verify_metrics.py
+++ b/tests/test_verify_metrics.py
@@ -1,0 +1,126 @@
+"""Unit tests for the distributional + embodied parity metrics (no GPU).
+
+Deterministic: data is drawn from a seeded RNG and ``two_sample_test`` uses a
+fixed internal permutation seed, so the permutation p-values are reproducible.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from reflex.verify_metrics import (
+    EmbodiedParity,
+    aggregate_embodied,
+    energy_distance,
+    jerk_rms,
+    motion_energy,
+    two_sample_test,
+)
+
+
+# --- distributional two-sample test ---------------------------------------
+
+
+def test_mmd_false_positive_rate_is_controlled():
+    # The correct, non-flaky way to validate a two-sample test: over many
+    # same-distribution trials it must RARELY reject (false-positive rate near
+    # alpha=0.05). Asserting one draw's p-value would flake ~5% of the time.
+    trials, rejections = 16, 0
+    for s in range(trials):
+        rng = np.random.default_rng(100 + s)
+        X = rng.normal(0, 1, size=(60, 5))
+        Y = rng.normal(0, 1, size=(60, 5))  # same distribution
+        if two_sample_test(X, Y, n_permutations=150, seed=s).distributions_differ:
+            rejections += 1
+    # Expected ~0.8 under the null; <=4 is robust (and deterministic via seeds).
+    assert rejections <= 4, f"{rejections}/{trials} false positives — calibration off"
+
+
+def test_mmd_shifted_distribution_is_rejected():
+    rng = np.random.default_rng(0)
+    X = rng.normal(0, 1, size=(80, 6))
+    Y = rng.normal(2.0, 1, size=(80, 6))  # mean-shifted => different
+    r = two_sample_test(X, Y, n_permutations=200)
+    assert r.mmd_p_value < 0.05
+    assert r.distributions_differ is True
+    assert r.mmd2 > 0.1
+
+
+def test_shift_has_larger_mmd_and_energy_than_same():
+    rng = np.random.default_rng(1)
+    base = rng.normal(0, 1, size=(60, 4))
+    same = rng.normal(0, 1, size=(60, 4))
+    shifted = rng.normal(1.5, 1, size=(60, 4))
+    r_same = two_sample_test(base, same, n_permutations=200)
+    r_shift = two_sample_test(base, shifted, n_permutations=200)
+    assert r_shift.mmd2 > r_same.mmd2
+    assert r_shift.energy_distance > r_same.energy_distance
+    assert r_shift.mmd_p_value < r_same.mmd_p_value
+
+
+def test_two_sample_test_handles_tiny_samples():
+    r = two_sample_test([[0.0, 0.0]], [[1.0, 1.0]], n_permutations=50)
+    assert r.mmd_p_value == 1.0  # not enough data to reject
+    assert r.distributions_differ is False
+    assert r.n_permutations == 0
+
+
+def test_energy_distance_zero_for_identical_set():
+    X = [[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]]
+    assert energy_distance(X, X) == 0.0
+
+
+# --- embodied / kinematic metrics -----------------------------------------
+
+
+def test_jerk_zero_for_linear_motion():
+    # Constant velocity => position is linear in t => 3rd derivative is 0.
+    t = np.arange(20).reshape(-1, 1)
+    positions = np.hstack([t * 0.1, t * -0.2, t * 0.05])
+    assert jerk_rms(positions, dt=1.0) < 1e-9
+
+
+def test_jerk_positive_for_jittery_motion():
+    rng = np.random.default_rng(2)
+    positions = np.cumsum(rng.normal(0, 1, size=(30, 3)), axis=0)
+    assert jerk_rms(positions, dt=1.0) > 0.0
+
+
+def test_jerk_too_short_returns_zero():
+    assert jerk_rms([[0.0], [1.0], [2.0]], dt=1.0) == 0.0  # need >= 4 steps
+
+
+def test_motion_energy_sum_of_squares():
+    v = np.ones((10, 3))
+    assert motion_energy(v) == 30.0
+    assert motion_energy(np.zeros((5, 4))) == 0.0
+
+
+def test_embodied_regression_detected():
+    smooth = [np.cumsum(np.full((30, 3), 0.1), axis=0)]  # linear => low jerk
+    rng = np.random.default_rng(3)
+    jittery = [np.cumsum(rng.normal(0, 1, size=(30, 3)), axis=0)]  # high jerk
+    parity = aggregate_embodied(
+        baseline_positions=smooth,
+        candidate_positions=jittery,
+        baseline_velocities=[np.full((30, 3), 0.1)],
+        candidate_velocities=[rng.normal(0, 1, size=(30, 3))],
+        baseline_completion_steps=[100.0],
+        candidate_completion_steps=[105.0],
+    )
+    assert parity.candidate_jerk_rms > parity.baseline_jerk_rms
+    assert parity.regressed() is True
+
+
+def test_embodied_no_regression_for_identical():
+    pos = [np.cumsum(np.full((30, 3), 0.1), axis=0)]
+    vel = [np.full((30, 3), 0.1)]
+    parity = aggregate_embodied(
+        baseline_positions=pos,
+        candidate_positions=pos,
+        baseline_velocities=vel,
+        candidate_velocities=vel,
+        baseline_completion_steps=[100.0],
+        candidate_completion_steps=[100.0],
+    )
+    assert parity.regressed() is False
+    assert isinstance(parity, EmbodiedParity)


### PR DESCRIPTION
## Summary
Deepens `reflex verify` from success-rate parity (table stakes) to the **distributional + embodied parity engine** the Cloud/Comply products need, and adds the **tamper-evident audit chain** Comply's evidence rests on. All unit-tested (no GPU).

## What's in it
- **`verify_metrics.py`** — MMD (multi-bandwidth RBF + permutation p-value) + energy distance two-sample tests on paired action-chunk distributions (Model Equality Testing 2410.20247); embodied parity (RMS jerk, motion energy, completion-time). 11 tests, MMD calibration validated.
- **Rollout tap + verify wiring** — default-off `capture_trajectories` tap (zero behavior change when off) feeds per-step action chunks + EEF trajectories into `run_verify`, which runs MMD + embodied as **non-bypassable** checks (a shifted action distribution or a motion regression fails the verdict even when success rate matched). Backward compatible. 4 integration tests.
- **Tamper-evident audit chain** — `RecordWriter._emit` chains every record (`prev_record_hash`/`record_hash`); `verify_record_chain()` detects insert/edit/reorder. 5 tests; existing record + comply suites unaffected.

## Tests
76+ green across verify, verify_metrics, verify_integration, record_chain, record, record_policy_versioning, comply, pro_eval_gate. No GPU.

## Follow-up (not in this PR)
Real-rollout GPU validation of the tap (adapting the A100 LIBERO harness, attended + watchdog-guarded) confirms the tap captures real per-step data end-to-end. The code is non-invasive (verify-opt-in), so this lands safely ahead of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
