### PR TITLE
feat(verify): outcome-conditioned distributional parity + rich verdict

### DIFF
--- a/scripts/modal_verify_parity_cert.py
+++ b/scripts/modal_verify_parity_cert.py
@@ -25,6 +25,11 @@ import modal
 
 app = modal.App("reflex-verify-parity-cert")
 
+# Persist raw per-episode actions/eef/success so future verdict-logic experiments
+# (conditioning, parity_pass thresholds) run OFFLINE on this data — no GPU re-run.
+# Retrieve: modal volume get reflex-verify-cert-data <file> .
+cert_data_vol = modal.Volume.from_name("reflex-verify-cert-data", create_if_missing=True)
+
 
 def _repo_head_sha() -> str:
     pin = os.environ.get("REFLEX_PIN_SHA", "").strip()
@@ -102,7 +107,8 @@ image = (
 )
 
 
-@app.function(image=image, gpu="A100-40GB", timeout=10800, secrets=[_hf_secret()])
+@app.function(image=image, gpu="A100-40GB", timeout=10800, secrets=[_hf_secret()],
+              volumes={"/data": cert_data_vol})
 def cert(model_id: str, n_episodes: int, task_idx: int) -> dict:
     import json
     import threading
@@ -131,7 +137,7 @@ def cert(model_id: str, n_episodes: int, task_idx: int) -> dict:
 
     from reflex.verify import (
         _collect_eef_and_steps,
-        _collect_step_actions,
+        _collect_paired_succeeded_step_actions,
         gather_paired_samples,
     )
     from reflex.verify_metrics import aggregate_embodied, two_sample_test
@@ -147,6 +153,15 @@ def cert(model_id: str, n_episodes: int, task_idx: int) -> dict:
     )
     _stop.set()
 
+    # Persist the raw per-episode results (actions/eef/success) so any future
+    # verdict-logic experiment runs OFFLINE — this is the LAST GPU run we should
+    # need to tune conditioning / parity_pass thresholds.
+    raw_path = f"/data/cert_raw_n{n_episodes}_task{task_idx}.json"
+    with open(raw_path, "w") as fh:
+        json.dump({"original": orig, "optimized": opt}, fh)
+    cert_data_vol.commit()
+    print(f"[persist] raw results -> {raw_path}", flush=True)
+
     def _succ(res):
         s = sum(tk.get("success", 0) for tk in res.get("per_task", []))
         t = sum(tk.get("total", 0) for tk in res.get("per_task", []))
@@ -155,8 +170,12 @@ def cert(model_id: str, n_episodes: int, task_idx: int) -> dict:
     o_s, o_t = _succ(orig)
     c_s, c_t = _succ(opt)
 
-    base_actions, base_groups = _collect_step_actions(orig)
-    cand_actions, cand_groups = _collect_step_actions(opt)
+    # Outcome-conditioned: compare per-step actions only on episodes BOTH arms
+    # succeeded — isolates the policy shift from the outcome shift (an arm that
+    # fails more injects flailing actions that differ for a non-policy reason).
+    base_actions, base_groups, cand_actions, cand_groups, n_common = (
+        _collect_paired_succeeded_step_actions(orig, opt)
+    )
 
     # Thin each episode to <= STEP_CAP steps (uniform stride) before the test.
     # The full N=30 pooled matrix is ~18k rows => a ~2.6 GB (N,N) kernel + slow
@@ -204,15 +223,18 @@ def cert(model_id: str, n_episodes: int, task_idx: int) -> dict:
             baseline_completion_steps=bs, candidate_completion_steps=cs,
         ).to_dict()
 
-    n_base_eps = len(np.unique(base_groups)) if base_groups.size else 0
-    n_cand_eps = len(np.unique(cand_groups)) if cand_groups.size else 0
-    # Overall parity PASS = success-rate parity held AND no distributional shift
-    # AND no embodied regression (the three non-bypassable signals).
+    embodied_ok = emb is not None and not emb["embodied_regressed"]
+    cand_better_or_equal = (c_s / c_t if c_t else 0.0) >= (o_s / o_t if o_t else 0.0)
+    # Rich verdict: a "different but better" export (>= success, no embodied
+    # regression) is legible at a glance, even when the distributional test flags
+    # a shift. parity_pass stays STRICT for now (any distributional differ =>
+    # fail); the effect-size/direction-aware threshold is deferred pending a
+    # design-partner signal that defines what "parity" means commercially.
+    candidate_not_worse = cand_better_or_equal and embodied_ok
     verdict_pass = (
         ts is not None
         and not ts["distributions_differ"]
-        and emb is not None
-        and not emb["embodied_regressed"]
+        and embodied_ok
     )
 
     out = {
@@ -225,7 +247,7 @@ def cert(model_id: str, n_episodes: int, task_idx: int) -> dict:
             "native_rate": (o_s / o_t) if o_t else None,
             "optimized_rate": (c_s / c_t) if c_t else None,
         },
-        "episodes_used": {"native": n_base_eps, "optimized": n_cand_eps},
+        "two_sample_conditioned_on_episodes": int(n_common),  # both arms succeeded
         "step_cap_per_episode": STEP_CAP,
         "action_matrix_shapes": {
             "baseline": list(base_actions.shape),
@@ -233,7 +255,10 @@ def cert(model_id: str, n_episodes: int, task_idx: int) -> dict:
         },
         "two_sample": ts,
         "embodied": emb,
+        "candidate_not_worse": candidate_not_worse,
         "parity_pass": verdict_pass,
+        "raw_results_volume": "reflex-verify-cert-data",
+        "raw_results_path": raw_path,
     }
     print("CERT_RESULT " + json.dumps(out), flush=True)
     return out

--- a/src/reflex/verify.py
+++ b/src/reflex/verify.py
@@ -99,7 +99,17 @@ class ParityVerdict:
         )
     )
     two_sample: TwoSampleResult | None = None  # distributional parity (None if no per-step data)
+    two_sample_episodes: int = 0  # # episodes the distributional test compared (both arms succeeded)
     embodied: EmbodiedParity | None = None  # kinematic parity (None if no per-step data)
+
+    @property
+    def candidate_not_worse(self) -> bool:
+        """Rich-verdict helper: candidate is >= baseline on success AND has no
+        embodied regression. A 'different but not worse' export is True here even
+        when ``two_sample.distributions_differ`` (the distributional flag alone
+        doesn't make the candidate worse — it surfaces a shift for review)."""
+        no_embodied_regress = self.embodied is None or not self.embodied.regressed()
+        return self.success_rate_delta >= 0.0 and no_embodied_regress
 
     @property
     def success_rate_delta(self) -> float:
@@ -125,6 +135,8 @@ class ParityVerdict:
             "first_failing_gate_id": self.first_failing_gate_id,
             "generated_at": self.generated_at,
             "two_sample": self.two_sample.to_dict() if self.two_sample else None,
+            "two_sample_episodes": self.two_sample_episodes,
+            "candidate_not_worse": self.candidate_not_worse,
             "embodied": self.embodied.to_dict() if self.embodied else None,
             "eval_report": self.eval_report.to_dict(),
         }
@@ -219,6 +231,69 @@ def _collect_step_actions(results: dict[str, Any]) -> tuple[np.ndarray, np.ndarr
     if not width:
         return np.empty((0, 0)), np.empty((0,))
     return np.vstack([r[:width] for r in rows]), np.asarray(groups)
+
+
+def _collect_paired_succeeded_step_actions(
+    original_results: dict[str, Any], optimized_results: dict[str, Any]
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, int]:
+    """Per-step applied actions for both arms, RESTRICTED to episodes BOTH arms
+    succeeded (matched by ``(task_idx, ep)``).
+
+    Conditioning on commonly-succeeded episodes isolates the *policy* shift
+    (e.g. bf16 vs fp32 numerics) from the *outcome* shift. If one arm fails more
+    episodes, those failures inject very different actions (a robot flailing for
+    520 steps) that make the pooled action distributions differ for a reason
+    unrelated to per-step policy fidelity — i.e. the distributional test would
+    flag a difference that is really just "this arm succeeds less", which the
+    success-rate gate already measures. Comparing actions only where both arms
+    accomplished the same task answers the question the gate actually wants:
+    *given the same successful outcome, does the optimized policy act the same?*
+
+    Returns ``(base_actions, base_groups, cand_actions, cand_groups,
+    n_episodes)``. Each arm carries its own per-episode group ids (the
+    two-sample test offsets them so the arms' episodes stay distinct units);
+    a shared id per commonly-succeeded episode keeps the bookkeeping simple.
+    Returns empties + 0 when no episode succeeded in both arms (the two-sample
+    test then no-ops and only success-rate parity applies).
+    """
+    def _index(results: dict[str, Any]) -> dict:
+        idx = {}
+        for task in results.get("per_task", []) or []:
+            ti = task.get("task_idx")
+            for ep in task.get("episodes", []) or []:
+                idx[(ti, ep.get("ep"))] = ep
+        return idx
+
+    oi, ci = _index(original_results), _index(optimized_results)
+    b_rows: list[np.ndarray] = []
+    c_rows: list[np.ndarray] = []
+    b_g: list[int] = []
+    c_g: list[int] = []
+    uid = 0
+    for key in sorted(oi.keys() & ci.keys()):
+        oe, ce = oi[key], ci[key]
+        if not (oe.get("success") and ce.get("success")):
+            continue
+        oa = oe.get("actions") or []
+        ca = ce.get("actions") or []
+        if not oa or not ca:
+            continue
+        for a in oa:
+            b_rows.append(np.asarray(a, dtype=np.float64).reshape(-1))
+            b_g.append(uid)
+        for a in ca:
+            c_rows.append(np.asarray(a, dtype=np.float64).reshape(-1))
+            c_g.append(uid)
+        uid += 1
+    empty = (np.empty((0, 0)), np.empty((0,)), np.empty((0, 0)), np.empty((0,)), 0)
+    if not b_rows or not c_rows:
+        return empty
+    width = min(min(r.shape[0] for r in b_rows), min(r.shape[0] for r in c_rows))
+    if not width:
+        return empty
+    base = np.vstack([r[:width] for r in b_rows])
+    cand = np.vstack([r[:width] for r in c_rows])
+    return base, np.asarray(b_g), cand, np.asarray(c_g), uid
 
 
 def _collect_eef_and_steps(results: dict[str, Any]) -> tuple[list[np.ndarray], list[float]]:
@@ -402,16 +477,19 @@ def run_verify(
     # the per-step trajectories the widened rollout tap captures. When the tap
     # is off / older results lack them, these stay None and only success-rate
     # parity applies (no silent degrade — the verdict records which ran).
-    base_actions, base_groups = _collect_step_actions(original_results)
-    cand_actions, cand_groups = _collect_step_actions(optimized_results)
+    base_actions, base_groups, cand_actions, cand_groups, n_cmp = (
+        _collect_paired_succeeded_step_actions(original_results, optimized_results)
+    )
     two_sample: TwoSampleResult | None = None
     if (
         base_actions.size
         and cand_actions.size
         and base_actions.shape[1] == cand_actions.shape[1]
     ):
-        # Episode-aware: permute whole episodes (per-step actions are
-        # autocorrelated; step-level permutation over-rejects ~100%).
+        # Episode-aware + outcome-conditioned: permute whole episodes (per-step
+        # actions are autocorrelated → step-level permutation over-rejects ~100%)
+        # over ONLY episodes both arms succeeded (isolates the per-step policy
+        # shift from the outcome shift — see the collector docstring).
         two_sample = two_sample_test(
             base_actions,
             cand_actions,
@@ -442,6 +520,7 @@ def run_verify(
 
     return ParityVerdict(
         passed=passed,
+        two_sample_episodes=n_cmp,
         eval_report=report,
         optimized_ref=optimized_ref,
         original_ref=original_ref or optimized_ref,

--- a/tests/test_verify_integration.py
+++ b/tests/test_verify_integration.py
@@ -62,6 +62,41 @@ def test_run_verify_fails_on_embodied_regression():
     assert v.passed is False
 
 
+def test_run_verify_conditions_distributional_test_on_commonly_succeeded():
+    # Outcome confound: if one arm fails more episodes, those failures inject
+    # flailing actions that make the POOLED distributions differ for a reason
+    # unrelated to per-step policy fidelity. The gate must condition on episodes
+    # BOTH arms succeeded, so the distributional test sees only the policy shift.
+    rng = np.random.default_rng(0)
+
+    def arm(fail_from):
+        # eps [0, fail_from) succeed (mean 0); [fail_from, 32) fail (mean 5 flail)
+        eps = []
+        for e in range(32):
+            ok = e < fail_from
+            acts = rng.normal(0.0 if ok else 5.0, 0.1, size=(30, 7)).tolist()
+            eps.append({"ep": e, "success": ok, "steps": 100 if ok else 200, "actions": acts})
+        return {"per_task": [{"task_idx": 0, "episodes": eps}]}
+
+    orig = arm(16)  # 16 succeed, 16 flailing failures
+    opt = arm(30)   # 30 succeed, 2 flailing failures (candidate is *better*)
+    v = run_verify(optimized_ref="exp", gather_fn=_gather_returning(orig, opt), num_episodes=32)
+
+    # Conditioned on the 16 commonly-succeeded episodes (both mean 0): no shift.
+    assert v.two_sample is not None
+    assert v.two_sample_episodes == 16
+    assert v.two_sample.distributions_differ is False
+
+    # Contrast: pooling ALL actions (the old, confounded way) WOULD flag a diff,
+    # purely because orig carries more mean-5 flailing actions than opt.
+    from reflex.verify import _collect_step_actions
+    from reflex.verify_metrics import two_sample_test
+    ba, bg = _collect_step_actions(orig)
+    ca, cg = _collect_step_actions(opt)
+    unconditioned = two_sample_test(ba, ca, baseline_groups=bg, candidate_groups=cg)
+    assert unconditioned.distributions_differ is True
+
+
 def test_run_verify_without_trajectories_is_backward_compatible():
     # Older results / tap off: no actions / eef_positions => checks no-op.
     def bare(n):


### PR DESCRIPTION
The N=30 cert (PR #202 harness) surfaced a real methodology gap: the distributional MMD pooled per-step actions across arms with **different success rates**, conflating *policy shifted* with *outcomes differ* (an arm that fails more injects 520-step flailing actions). Not a calibration bug — #201's episode-block calibration is correct.

**Fix:** condition the two-sample test on episodes **both arms succeeded** (matched by `(task_idx, ep)`). New integration test proves it removes the confound: a candidate that fails fewer episodes flags `differ=True` when actions are pooled, `differ=False` once conditioned.

**Rich verdict:** `ParityVerdict` gains `two_sample_episodes` + a `candidate_not_worse` helper (>= success AND no embodied regression) so a *different-but-better* export is legible even when the distributional flag fires. `parity_pass` stays strict; the effect-size/direction threshold policy is **deferred** pending a design-partner signal.

**Cert harness:** conditioned collector + persists raw per-episode results to a Modal Volume so future verdict-logic tuning runs **offline** (no GPU re-run).

26/26 verify tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)