### PR TITLE
fix(verify-cert): make raw-results persistence non-fatal + numpy-safe

### DIFF
--- a/scripts/modal_verify_parity_cert.py
+++ b/scripts/modal_verify_parity_cert.py
@@ -156,11 +156,17 @@ def cert(model_id: str, n_episodes: int, task_idx: int) -> dict:
     # Persist the raw per-episode results (actions/eef/success) so any future
     # verdict-logic experiment runs OFFLINE — this is the LAST GPU run we should
     # need to tune conditioning / parity_pass thresholds.
+    # Best-effort: a persistence failure must NEVER lose the verdict after a ~2h
+    # run. Wrap it; default=str makes json robust to any stray numpy scalar.
     raw_path = f"/data/cert_raw_n{n_episodes}_task{task_idx}.json"
-    with open(raw_path, "w") as fh:
-        json.dump({"original": orig, "optimized": opt}, fh)
-    cert_data_vol.commit()
-    print(f"[persist] raw results -> {raw_path}", flush=True)
+    try:
+        with open(raw_path, "w") as fh:
+            json.dump({"original": orig, "optimized": opt}, fh, default=str)
+        cert_data_vol.commit()
+        print(f"[persist] raw results -> {raw_path}", flush=True)
+    except Exception as exc:  # noqa: BLE001 — never fatal
+        raw_path = None
+        print(f"[persist] WARNING raw-results dump failed (non-fatal): {exc}", flush=True)
 
     def _succ(res):
         s = sum(tk.get("success", 0) for tk in res.get("per_task", []))


### PR DESCRIPTION
The Volume dump from #205 sat right after the ~2h rollout — an exception there would crash the function after the expensive part and lose the verdict. Wrap in try/except (never fatal) + `json default=str`. Caught before the re-cert (ap-ih5ySLIYUQPZktH3XL6Kjt) burned 2h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)