### PR TITLE
[codex] Add Tether Agent daemon and CLI

### DIFF
--- a/src/tether/agent/__init__.py
+++ b/src/tether/agent/__init__.py
@@ -1,0 +1,31 @@
+"""Tether Agent v0.1 core primitives."""
+
+from tether.agent.client import AgentClient
+from tether.agent.config import AgentConfig, default_config_path, load_config, save_config
+from tether.agent.hardware import collect_hardware_profile
+from tether.agent.models import (
+    AgentCommand,
+    CommandAck,
+    CommandResult,
+    EnrollRequest,
+    EnrollResponse,
+    HeartbeatPayload,
+)
+
+AGENT_VERSION = "0.1.0"
+
+__all__ = [
+    "AGENT_VERSION",
+    "AgentClient",
+    "AgentCommand",
+    "AgentConfig",
+    "CommandAck",
+    "CommandResult",
+    "EnrollRequest",
+    "EnrollResponse",
+    "HeartbeatPayload",
+    "collect_hardware_profile",
+    "default_config_path",
+    "load_config",
+    "save_config",
+]

--- a/src/tether/agent/client.py
+++ b/src/tether/agent/client.py
@@ -1,0 +1,154 @@
+"""Cloud client for the Tether Agent v0.1 API."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Mapping
+
+from tether.agent.models import (
+    AgentCommand,
+    CommandAck,
+    EnrollRequest,
+    EnrollResponse,
+    HeartbeatPayload,
+    JsonDict,
+)
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+
+class AgentClientError(RuntimeError):
+    """Raised for failed Cloud API calls."""
+
+
+class AgentClient:
+    def __init__(
+        self,
+        cloud_url: str,
+        *,
+        device_token: str | None = None,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        session: Any | None = None,
+    ) -> None:
+        self.cloud_url = cloud_url.rstrip("/")
+        self.device_token = device_token
+        self.timeout_seconds = timeout_seconds
+        self._session = session if session is not None else self._make_httpx_session(timeout_seconds)
+
+    def enroll(self, request: EnrollRequest) -> EnrollResponse:
+        data = self._request("POST", "/agent/enroll", json_body=request.to_dict(), auth=False)
+        return EnrollResponse.from_dict(data)
+
+    def heartbeat(self, device_id: str, payload: HeartbeatPayload) -> JsonDict:
+        return self._request(
+            "POST",
+            f"/agent/devices/{urllib.parse.quote(device_id, safe='')}/heartbeat",
+            json_body=payload.to_dict(),
+            auth=True,
+        )
+
+    def poll_commands(self, device_id: str, *, after: str | None = None) -> list[AgentCommand]:
+        params = {"after": after} if after else None
+        data = self._request(
+            "GET",
+            f"/agent/devices/{urllib.parse.quote(device_id, safe='')}/commands",
+            params=params,
+            auth=True,
+        )
+        commands = data if isinstance(data, list) else data.get("commands", [])
+        return [AgentCommand.from_dict(command) for command in commands]
+
+    def ack_command(self, device_id: str, command_id: str, ack: CommandAck) -> JsonDict:
+        return self._request(
+            "POST",
+            (
+                f"/agent/devices/{urllib.parse.quote(device_id, safe='')}/commands/"
+                f"{urllib.parse.quote(command_id, safe='')}/ack"
+            ),
+            json_body=ack.to_dict(),
+            auth=True,
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Mapping[str, Any] | None = None,
+        params: Mapping[str, Any] | None = None,
+        auth: bool,
+    ) -> Any:
+        url = self._url(path, params)
+        headers = {"Content-Type": "application/json"}
+        if auth:
+            if not self.device_token:
+                raise AgentClientError("device token is required for authenticated agent calls")
+            headers["Authorization"] = f"Bearer {self.device_token}"
+
+        if self._session is not None:
+            response = self._session.request(
+                method,
+                url,
+                headers=headers,
+                json=dict(json_body) if json_body is not None else None,
+                timeout=self.timeout_seconds,
+            )
+            return self._decode_response(response)
+        return self._urllib_request(method, url, headers, json_body)
+
+    def _url(self, path: str, params: Mapping[str, Any] | None = None) -> str:
+        url = f"{self.cloud_url}{path}"
+        if params:
+            query = urllib.parse.urlencode({key: value for key, value in params.items() if value is not None})
+            if query:
+                url = f"{url}?{query}"
+        return url
+
+    def _decode_response(self, response: Any) -> Any:
+        status_code = int(getattr(response, "status_code", 200))
+        if status_code >= 400:
+            text = getattr(response, "text", "")
+            raise AgentClientError(f"agent API request failed with HTTP {status_code}: {text}")
+        if hasattr(response, "json"):
+            return response.json()
+        text = getattr(response, "text", "")
+        return json.loads(text) if text else {}
+
+    def _urllib_request(
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        json_body: Mapping[str, Any] | None,
+    ) -> Any:
+        body = None
+        if json_body is not None:
+            body = json.dumps(dict(json_body)).encode("utf-8")
+        request = urllib.request.Request(url, data=body, headers=dict(headers), method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                text = response.read().decode("utf-8")
+                return json.loads(text) if text else {}
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise AgentClientError(f"agent API request failed with HTTP {exc.code}: {detail}") from exc
+
+    @staticmethod
+    def _make_httpx_session(timeout_seconds: float) -> Any | None:
+        try:
+            import httpx
+        except Exception:
+            return None
+        return httpx.Client(timeout=timeout_seconds)
+
+
+def make_default_client(
+    cloud_url: str,
+    *,
+    device_token: str | None = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> AgentClient:
+    return AgentClient(cloud_url, device_token=device_token, timeout_seconds=timeout_seconds)

--- a/src/tether/agent/commands.py
+++ b/src/tether/agent/commands.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from collections.abc import Callable, Mapping
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+DEFAULT_DOCTOR_TIMEOUT_SECONDS = 60.0
+DEFAULT_SERVE_URL = "http://127.0.0.1:8000"
+MAX_OUTPUT_BYTES = 16 * 1024
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+HttpGetJson = Callable[[str, float], tuple[int, Any]]
+
+
+def execute_command(
+    command: Mapping[str, Any],
+    *,
+    config: Any | None = None,
+    runner: Runner | None = None,
+    http_get_json: HttpGetJson | None = None,
+    now: Callable[[], float] | None = None,
+) -> dict[str, Any]:
+    command_type = _command_type(command)
+    started_at = _timestamp(now)
+    command_id = _command_id(command)
+
+    if command_type == "noop":
+        result = _result(
+            command_id=command_id,
+            command_type=command_type,
+            succeeded=True,
+            started_at=started_at,
+            finished_at=_timestamp(now),
+            output={"message": "ok"},
+        )
+    elif command_type == "doctor":
+        result = run_doctor_command(
+            command,
+            command_id=command_id,
+            started_at=started_at,
+            runner=runner,
+            now=now,
+        )
+    elif command_type == "serve_status":
+        result = run_serve_status_command(
+            command,
+            config=config,
+            command_id=command_id,
+            started_at=started_at,
+            http_get_json=http_get_json,
+            now=now,
+        )
+    else:
+        result = _result(
+            command_id=command_id,
+            command_type=command_type,
+            succeeded=False,
+            started_at=started_at,
+            finished_at=_timestamp(now),
+            error={"reason": "unsupported_command", "command_type": command_type},
+        )
+    return bound_result(result)
+
+
+def run_doctor_command(
+    command: Mapping[str, Any],
+    *,
+    command_id: str | None = None,
+    started_at: float | None = None,
+    runner: Runner | None = None,
+    now: Callable[[], float] | None = None,
+) -> dict[str, Any]:
+    options = _command_options(command)
+    timeout = float(options.get("timeout_seconds", DEFAULT_DOCTOR_TIMEOUT_SECONDS))
+    argv = list(options.get("argv") or ["tether", "doctor", "--format", "json"])
+    run = runner or _subprocess_runner
+
+    try:
+        completed = run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return _result(
+            command_id=command_id,
+            command_type="doctor",
+            succeeded=False,
+            started_at=started_at,
+            finished_at=_timestamp(now),
+            stdout=_to_text(exc.stdout),
+            stderr=_to_text(exc.stderr),
+            error={"reason": "timeout", "timeout_seconds": timeout},
+        )
+    except OSError as exc:
+        return _result(
+            command_id=command_id,
+            command_type="doctor",
+            succeeded=False,
+            started_at=started_at,
+            finished_at=_timestamp(now),
+            error={"reason": "process_start_failed", "message": str(exc), "argv": argv},
+        )
+
+    stdout = _to_text(getattr(completed, "stdout", ""))
+    stderr = _to_text(getattr(completed, "stderr", ""))
+    returncode = int(getattr(completed, "returncode", 1))
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        return _result(
+            command_id=command_id,
+            command_type="doctor",
+            succeeded=False,
+            started_at=started_at,
+            finished_at=_timestamp(now),
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=returncode,
+            error={"reason": "malformed_json", "message": str(exc)},
+        )
+
+    summary = _normalize_doctor_summary(payload)
+    if returncode != 0:
+        return _result(
+            command_id=command_id,
+            command_type="doctor",
+            succeeded=False,
+            started_at=started_at,
+            finished_at=_timestamp(now),
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=returncode,
+            output={"summary": summary, "doctor": payload},
+            error={"reason": "doctor_exit_nonzero", "exit_code": returncode},
+        )
+
+    return _result(
+        command_id=command_id,
+        command_type="doctor",
+        succeeded=True,
+        started_at=started_at,
+        finished_at=_timestamp(now),
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=returncode,
+        output={"summary": summary, "doctor": payload},
+    )
+
+
+def run_serve_status_command(
+    command: Mapping[str, Any],
+    *,
+    config: Any | None = None,
+    command_id: str | None = None,
+    started_at: float | None = None,
+    http_get_json: HttpGetJson | None = None,
+    now: Callable[[], float] | None = None,
+) -> dict[str, Any]:
+    base_url = _serve_url(command, config)
+    timeout = float(_command_options(command).get("timeout_seconds", 3.0))
+    get_json = http_get_json or _http_get_json
+
+    health = _probe_json(get_json, f"{base_url}/health", timeout)
+    config_probe = _probe_json(get_json, f"{base_url}/config", timeout)
+    reachable = health["ok"] or config_probe["ok"]
+    ready = bool(
+        health["ok"]
+        and isinstance(health.get("body"), Mapping)
+        and health["body"].get("status") == "ok"
+    )
+
+    return _result(
+        command_id=command_id,
+        command_type="serve_status",
+        succeeded=True,
+        started_at=started_at,
+        finished_at=_timestamp(now),
+        output={
+            "url": base_url,
+            "reachable": reachable,
+            "ready": ready,
+            "health": health,
+            "config": config_probe,
+        },
+    )
+
+
+def bound_result(result: Mapping[str, Any], *, max_bytes: int = MAX_OUTPUT_BYTES) -> dict[str, Any]:
+    bounded = dict(result)
+    for key in ("stdout", "stderr"):
+        if key in bounded:
+            bounded[key] = _truncate_text(_to_text(bounded[key]), max_bytes=max_bytes)
+    for key in ("output", "error"):
+        if key in bounded and bounded[key] is not None:
+            bounded[key] = _truncate_jsonish(bounded[key], max_bytes=max_bytes)
+    return bounded
+
+
+def _subprocess_runner(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, **kwargs)
+
+
+def _http_get_json(url: str, timeout: float) -> tuple[int, Any]:
+    request = Request(url, headers={"Accept": "application/json"})
+    with urlopen(request, timeout=timeout) as response:
+        body = response.read(MAX_OUTPUT_BYTES + 1)
+        text = body.decode("utf-8", errors="replace")
+        return int(response.status), json.loads(text)
+
+
+def _probe_json(get_json: HttpGetJson, url: str, timeout: float) -> dict[str, Any]:
+    try:
+        status_code, body = get_json(url, timeout)
+    except HTTPError as exc:
+        raw = exc.read(MAX_OUTPUT_BYTES + 1).decode("utf-8", errors="replace")
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            body = raw
+        return {
+            "ok": False,
+            "status_code": exc.code,
+            "body": _truncate_jsonish(body, max_bytes=MAX_OUTPUT_BYTES),
+            "error": {"reason": "http_error"},
+        }
+    except (URLError, TimeoutError, OSError) as exc:
+        return {
+            "ok": False,
+            "status_code": None,
+            "body": None,
+            "error": {"reason": "unreachable", "message": str(exc)},
+        }
+    except json.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "status_code": None,
+            "body": None,
+            "error": {"reason": "malformed_json", "message": str(exc)},
+        }
+    return {"ok": 200 <= int(status_code) < 300, "status_code": status_code, "body": body}
+
+
+def _normalize_doctor_summary(payload: Mapping[str, Any]) -> dict[str, int]:
+    raw_summary = payload.get("summary") if isinstance(payload, Mapping) else None
+    if isinstance(raw_summary, Mapping):
+        return {key: int(raw_summary.get(key, 0) or 0) for key in ("pass", "fail", "warn", "skip")}
+
+    counts = {"pass": 0, "fail": 0, "warn": 0, "skip": 0}
+    checks = payload.get("checks") if isinstance(payload, Mapping) else []
+    if isinstance(checks, list):
+        for check in checks:
+            if isinstance(check, Mapping):
+                status = str(check.get("status", "")).lower()
+                if status in counts:
+                    counts[status] += 1
+    return counts
+
+
+def _result(
+    *,
+    command_id: str | None,
+    command_type: str,
+    succeeded: bool,
+    started_at: float | None,
+    finished_at: float,
+    output: Any | None = None,
+    error: Any | None = None,
+    stdout: str | None = None,
+    stderr: str | None = None,
+    exit_code: int | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "command_id": command_id,
+        "command_type": command_type,
+        "succeeded": succeeded,
+        "status": "succeeded" if succeeded else "failed",
+        "started_at": started_at,
+        "finished_at": finished_at,
+    }
+    if output is not None:
+        result["output"] = output
+    if error is not None:
+        result["error"] = error
+    if stdout is not None:
+        result["stdout"] = stdout
+    if stderr is not None:
+        result["stderr"] = stderr
+    if exit_code is not None:
+        result["exit_code"] = exit_code
+    return result
+
+
+def _command_type(command: Mapping[str, Any]) -> str:
+    return str(command.get("type") or command.get("command_type") or command.get("name") or "")
+
+
+def _command_id(command: Mapping[str, Any]) -> str | None:
+    value = command.get("id") or command.get("command_id")
+    return str(value) if value is not None else None
+
+
+def _serve_url(command: Mapping[str, Any], config: Any | None) -> str:
+    options = _command_options(command)
+    value = options.get("serve_url") or options.get("local_serve_url")
+    if not value and config is not None:
+        value = getattr(config, "serve_url", None) or getattr(config, "local_serve_url", None)
+    return str(value or DEFAULT_SERVE_URL).rstrip("/")
+
+
+def _command_options(command: Mapping[str, Any]) -> dict[str, Any]:
+    options = dict(command)
+    payload = command.get("payload")
+    if isinstance(payload, Mapping):
+        options.update(payload)
+    return options
+
+
+def _timestamp(now: Callable[[], float] | None) -> float:
+    if now is None:
+        return time.time()
+    return float(now())
+
+
+def _to_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _truncate_text(text: str, *, max_bytes: int) -> str:
+    raw = text.encode("utf-8")
+    if len(raw) <= max_bytes:
+        return text
+    return raw[:max_bytes].decode("utf-8", errors="ignore") + "...[truncated]"
+
+
+def _truncate_jsonish(value: Any, *, max_bytes: int) -> Any:
+    text = json.dumps(value, sort_keys=True, default=str)
+    if len(text.encode("utf-8")) <= max_bytes:
+        return value
+    return {"truncated": True, "text": _truncate_text(text, max_bytes=max_bytes)}

--- a/src/tether/agent/config.py
+++ b/src/tether/agent/config.py
@@ -1,0 +1,96 @@
+"""Local Tether Agent configuration storage."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from tether.agent.models import CommandResult, JsonDict
+
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30
+
+
+@dataclass(slots=True)
+class AgentConfig:
+    device_id: str | None = None
+    cloud_url: str | None = None
+    workspace_id: str | None = None
+    device_token: str | None = None
+    heartbeat_interval_seconds: int = DEFAULT_HEARTBEAT_INTERVAL_SECONDS
+    last_heartbeat_at: str | None = None
+    last_command_id: str | None = None
+    last_command_result: CommandResult | JsonDict | None = None
+
+    def to_dict(self) -> JsonDict:
+        data = asdict(self)
+        result = self.last_command_result
+        if isinstance(result, CommandResult):
+            data["last_command_result"] = result.to_dict()
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AgentConfig":
+        result = data.get("last_command_result")
+        parsed_result: CommandResult | JsonDict | None
+        if isinstance(result, Mapping) and "succeeded" in result:
+            parsed_result = CommandResult.from_dict(result)
+        elif isinstance(result, Mapping):
+            parsed_result = dict(result)
+        else:
+            parsed_result = None
+        return cls(
+            device_id=data.get("device_id"),
+            cloud_url=data.get("cloud_url"),
+            workspace_id=data.get("workspace_id"),
+            device_token=data.get("device_token"),
+            heartbeat_interval_seconds=int(
+                data.get("heartbeat_interval_seconds", DEFAULT_HEARTBEAT_INTERVAL_SECONDS)
+            ),
+            last_heartbeat_at=data.get("last_heartbeat_at"),
+            last_command_id=data.get("last_command_id"),
+            last_command_result=parsed_result,
+        )
+
+
+def default_config_path() -> Path:
+    return Path.home() / ".tether" / "agent.json"
+
+
+def load_config(path: str | os.PathLike[str] | None = None) -> AgentConfig | None:
+    config_path = Path(path) if path is not None else default_config_path()
+    if not config_path.exists():
+        return None
+    with config_path.open("r", encoding="utf-8") as fh:
+        return AgentConfig.from_dict(json.load(fh))
+
+
+def save_config(config: AgentConfig, path: str | os.PathLike[str] | None = None) -> Path:
+    config_path = Path(path) if path is not None else default_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    _chmod_if_posix(config_path.parent, 0o700)
+
+    payload = json.dumps(config.to_dict(), indent=2, sort_keys=True) + "\n"
+    tmp_path = config_path.with_name(f".{config_path.name}.tmp")
+    fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        _chmod_if_posix(tmp_path, 0o600)
+        os.replace(tmp_path, config_path)
+        _chmod_if_posix(config_path, 0o600)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+    return config_path
+
+
+def _chmod_if_posix(path: Path, mode: int) -> None:
+    if os.name != "posix":
+        return
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass

--- a/src/tether/agent/daemon.py
+++ b/src/tether/agent/daemon.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import inspect
+import signal
+import threading
+import time
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any
+
+from tether.agent.commands import execute_command
+
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30.0
+MAX_SLEEP_SECONDS = 5.0
+
+CommandRunner = Callable[[Mapping[str, Any]], dict[str, Any]]
+
+
+def run_once(
+    config: Any,
+    client: Any,
+    command_runner: CommandRunner | None = None,
+    now: Callable[[], float] | None = None,
+) -> dict[str, Any]:
+    timestamp = _timestamp(now)
+    heartbeat_payload = _heartbeat_payload(config, timestamp)
+    heartbeat_response = _client_heartbeat(client, config, heartbeat_payload)
+
+    raw_commands = _client_poll_commands(client, config)
+    commands = _normalize_commands(raw_commands)
+    runner = command_runner or (lambda command: execute_command(command, config=config, now=now))
+
+    results: list[dict[str, Any]] = []
+    for command in commands:
+        result = runner(command)
+        if "command_id" not in result or result.get("command_id") is None:
+            command_id = _command_id(command)
+            if command_id is not None:
+                result = dict(result)
+                result["command_id"] = command_id
+        _ack_command(client, config, command, result)
+        results.append(result)
+
+    return {
+        "heartbeat": heartbeat_response,
+        "commands_polled": len(commands),
+        "commands_executed": len(results),
+        "results": results,
+    }
+
+
+def run_forever(
+    config: Any,
+    client: Any,
+    interval: float | None = None,
+    stop_event: Any | None = None,
+    command_runner: CommandRunner | None = None,
+    now: Callable[[], float] | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> None:
+    heartbeat_interval = _resolve_interval(config, interval)
+    sleeper = sleep or time.sleep
+    should_stop = False
+    old_handler = None
+
+    def _handle_sigint(signum: int, frame: Any) -> None:
+        nonlocal should_stop
+        should_stop = True
+
+    if threading.current_thread() is threading.main_thread():
+        old_handler = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, _handle_sigint)
+    try:
+        while not should_stop and not _event_is_set(stop_event):
+            started = _timestamp(now)
+            run_once(config, client, command_runner=command_runner, now=now)
+            elapsed = max(0.0, _timestamp(now) - started)
+            remaining = max(0.0, heartbeat_interval - elapsed)
+            _bounded_sleep(remaining, sleeper, stop_event, lambda: should_stop)
+    finally:
+        if old_handler is not None:
+            signal.signal(signal.SIGINT, old_handler)
+
+
+def _heartbeat_payload(config: Any, observed_at: float) -> dict[str, Any]:
+    payload = {
+        "device_id": getattr(config, "device_id", None),
+        "observed_at": observed_at,
+    }
+    hardware_profile = _collect_hardware_profile()
+    if hardware_profile is not None:
+        payload["hardware_profile"] = hardware_profile
+    for attr in ("cloud_url", "agent_version", "tether_version"):
+        value = getattr(config, attr, None)
+        if value is not None:
+            payload[attr] = value
+    return payload
+
+
+def _collect_hardware_profile() -> Any | None:
+    try:
+        from tether.agent.hardware import collect_hardware_profile
+    except ImportError:
+        return None
+    return collect_hardware_profile()
+
+
+def _normalize_commands(raw: Any) -> list[Mapping[str, Any]]:
+    if raw is None:
+        return []
+    if isinstance(raw, Mapping):
+        raw = raw.get("commands", [])
+    if not isinstance(raw, Iterable) or isinstance(raw, (str, bytes)):
+        return []
+    commands: list[Mapping[str, Any]] = []
+    for command in raw:
+        if isinstance(command, Mapping):
+            commands.append(command)
+        elif hasattr(command, "to_dict"):
+            commands.append(command.to_dict())
+    return commands
+
+
+def _ack_command(client: Any, config: Any, command: Mapping[str, Any], result: Mapping[str, Any]) -> Any:
+    command_id = _command_id(command) or result.get("command_id")
+    device_id = _config_device_id(config) or command.get("device_id") or result.get("device_id")
+    if device_id is not None:
+        ack_model = _command_ack(command_id, result)
+        try:
+            return client.ack_command(str(device_id), str(command_id), ack_model)
+        except TypeError:
+            pass
+    try:
+        return client.ack_command(command_id, result)
+    except TypeError:
+        return _call_flexible(client.ack_command, {"command_id": command_id, "result": result})
+
+
+def _client_heartbeat(client: Any, config: Any, payload: Mapping[str, Any]) -> Any:
+    device_id = _config_device_id(config)
+    if device_id is not None:
+        try:
+            return client.heartbeat(device_id, _heartbeat_model(payload))
+        except TypeError:
+            pass
+    return _call_flexible(client.heartbeat, payload)
+
+
+def _client_poll_commands(client: Any, config: Any) -> Any:
+    device_id = _config_device_id(config)
+    if device_id is not None:
+        try:
+            return client.poll_commands(device_id)
+        except TypeError:
+            pass
+    return _call_flexible(client.poll_commands)
+
+
+def _heartbeat_model(payload: Mapping[str, Any]) -> Any:
+    try:
+        from tether.agent.models import HeartbeatPayload
+    except ImportError:
+        return dict(payload)
+    return HeartbeatPayload.from_dict(payload)
+
+
+def _command_ack(command_id: Any, result: Mapping[str, Any]) -> Any:
+    try:
+        from tether.agent.models import CommandAck
+    except ImportError:
+        return dict(result)
+    payload = dict(result)
+    payload["command_id"] = str(command_id)
+    return CommandAck.from_dict(payload)
+
+
+def _config_device_id(config: Any) -> str | None:
+    value = getattr(config, "device_id", None)
+    return str(value) if value is not None else None
+
+
+def _call_flexible(method: Callable[..., Any], payload: Any | None = None) -> Any:
+    signature = inspect.signature(method)
+    required_positionals = [
+        parameter
+        for parameter in signature.parameters.values()
+        if parameter.default is inspect.Parameter.empty
+        and parameter.kind
+        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    variadic = any(
+        parameter.kind == inspect.Parameter.VAR_POSITIONAL
+        for parameter in signature.parameters.values()
+    )
+    if payload is not None and (required_positionals or variadic):
+        return method(payload)
+    return method()
+
+
+def _resolve_interval(config: Any, interval: float | None) -> float:
+    if interval is not None:
+        return float(interval)
+    return float(
+        getattr(config, "heartbeat_interval_seconds", DEFAULT_HEARTBEAT_INTERVAL_SECONDS)
+        or DEFAULT_HEARTBEAT_INTERVAL_SECONDS
+    )
+
+
+def _bounded_sleep(
+    seconds: float,
+    sleep: Callable[[float], None],
+    stop_event: Any | None,
+    should_stop: Callable[[], bool],
+) -> None:
+    deadline = time.monotonic() + seconds
+    while not should_stop() and not _event_is_set(stop_event):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        sleep(min(remaining, MAX_SLEEP_SECONDS))
+
+
+def _event_is_set(stop_event: Any | None) -> bool:
+    return bool(stop_event is not None and stop_event.is_set())
+
+
+def _timestamp(now: Callable[[], float] | None) -> float:
+    if now is None:
+        return time.time()
+    return float(now())
+
+
+def _command_id(command: Mapping[str, Any]) -> str | None:
+    value = command.get("id") or command.get("command_id")
+    return str(value) if value is not None else None

--- a/src/tether/agent/hardware.py
+++ b/src/tether/agent/hardware.py
@@ -1,0 +1,114 @@
+"""Best-effort hardware profile collection for Agent heartbeats."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import platform
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def collect_hardware_profile() -> JsonDict:
+    profile: JsonDict = {
+        "hostname": _safe(socket.gethostname),
+        "platform": platform.platform(),
+        "python": sys.version.split()[0],
+        "agent_version": _agent_version(),
+        "tether_version": _package_version("tether"),
+        "gpu_name": None,
+        "cuda": None,
+        "jetpack": None,
+        "tensorrt": _package_version("tensorrt"),
+    }
+    _add_nvidia_smi(profile)
+    _add_nvcc(profile)
+    _add_jetpack(profile)
+    return _json_safe(profile)
+
+
+def _agent_version() -> str | None:
+    try:
+        from tether.agent import AGENT_VERSION
+
+        return AGENT_VERSION
+    except Exception:
+        return None
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def _add_nvidia_smi(profile: JsonDict) -> None:
+    output = _run(["nvidia-smi", "--query-gpu=name,driver_version,cuda_version", "--format=csv,noheader"])
+    if not output:
+        return
+    first = output.splitlines()[0]
+    parts = [part.strip() for part in first.split(",")]
+    if parts:
+        profile["gpu_name"] = parts[0] or None
+    if len(parts) >= 3 and parts[2]:
+        profile["cuda"] = parts[2]
+    if len(parts) >= 2 and parts[1]:
+        profile["nvidia_driver"] = parts[1]
+
+
+def _add_nvcc(profile: JsonDict) -> None:
+    if profile.get("cuda"):
+        return
+    output = _run(["nvcc", "--version"])
+    if not output:
+        return
+    marker = "release "
+    for line in output.splitlines():
+        if marker in line:
+            profile["cuda"] = line.split(marker, 1)[1].split(",", 1)[0].strip()
+            return
+
+
+def _add_jetpack(profile: JsonDict) -> None:
+    marker_path = Path("/etc/nv_tegra_release")
+    try:
+        if marker_path.exists():
+            profile["jetpack"] = marker_path.read_text(encoding="utf-8", errors="replace").strip()
+    except Exception:
+        return
+
+
+def _run(command: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2.0,
+        )
+    except Exception:
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
+def _safe(fn):
+    try:
+        return fn()
+    except Exception:
+        return None
+
+
+def _json_safe(value: JsonDict) -> JsonDict:
+    return json.loads(json.dumps(value, sort_keys=True, default=str))

--- a/src/tether/agent/models.py
+++ b/src/tether/agent/models.py
@@ -1,0 +1,185 @@
+"""Dataclass models for the Tether Agent control-plane contract."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping
+
+JsonDict = dict[str, Any]
+
+
+def _dict(value: Mapping[str, Any] | None) -> JsonDict:
+    return dict(value or {})
+
+
+@dataclass(slots=True)
+class EnrollRequest:
+    enroll_token: str
+    hostname: str | None = None
+    agent_version: str | None = None
+    tether_version: str | None = None
+    hardware_profile: JsonDict = field(default_factory=dict)
+
+    def to_dict(self) -> JsonDict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "EnrollRequest":
+        return cls(
+            enroll_token=str(data["enroll_token"]),
+            hostname=data.get("hostname"),
+            agent_version=data.get("agent_version"),
+            tether_version=data.get("tether_version"),
+            hardware_profile=_dict(data.get("hardware_profile")),
+        )
+
+
+@dataclass(slots=True)
+class EnrollResponse:
+    device_id: str
+    device_token: str
+    workspace_id: str
+    heartbeat_interval_seconds: int = 30
+
+    def to_dict(self) -> JsonDict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "EnrollResponse":
+        return cls(
+            device_id=str(data["device_id"]),
+            device_token=str(data["device_token"]),
+            workspace_id=str(data["workspace_id"]),
+            heartbeat_interval_seconds=int(data.get("heartbeat_interval_seconds", 30)),
+        )
+
+
+@dataclass(slots=True)
+class CommandResult:
+    succeeded: bool
+    output: JsonDict = field(default_factory=dict)
+    error: str | None = None
+
+    def to_dict(self) -> JsonDict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CommandResult":
+        return cls(
+            succeeded=bool(data["succeeded"]),
+            output=_dict(data.get("output")),
+            error=data.get("error"),
+        )
+
+
+@dataclass(slots=True)
+class HeartbeatPayload:
+    device_id: str
+    workspace_id: str | None = None
+    agent_version: str | None = None
+    tether_version: str | None = None
+    hardware_profile: JsonDict = field(default_factory=dict)
+    last_command_id: str | None = None
+    last_command_result: CommandResult | JsonDict | None = None
+    last_heartbeat_at: str | None = None
+
+    def to_dict(self) -> JsonDict:
+        data = asdict(self)
+        result = self.last_command_result
+        if isinstance(result, CommandResult):
+            data["last_command_result"] = result.to_dict()
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "HeartbeatPayload":
+        result = data.get("last_command_result")
+        parsed_result: CommandResult | JsonDict | None
+        if isinstance(result, Mapping) and "succeeded" in result:
+            parsed_result = CommandResult.from_dict(result)
+        elif isinstance(result, Mapping):
+            parsed_result = dict(result)
+        else:
+            parsed_result = None
+        return cls(
+            device_id=str(data["device_id"]),
+            workspace_id=data.get("workspace_id"),
+            agent_version=data.get("agent_version"),
+            tether_version=data.get("tether_version"),
+            hardware_profile=_dict(data.get("hardware_profile")),
+            last_command_id=data.get("last_command_id"),
+            last_command_result=parsed_result,
+            last_heartbeat_at=data.get("last_heartbeat_at"),
+        )
+
+
+@dataclass(slots=True)
+class AgentCommand:
+    command_id: str
+    type: str
+    payload: JsonDict = field(default_factory=dict)
+    created_at: str | None = None
+    cursor: str | None = None
+
+    def to_dict(self) -> JsonDict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AgentCommand":
+        command_id = data.get("command_id", data.get("id"))
+        if command_id is None:
+            raise ValueError("command is missing command_id")
+        command_type = data.get("type", data.get("command_type"))
+        if command_type is None:
+            raise ValueError("command is missing type")
+        return cls(
+            command_id=str(command_id),
+            type=str(command_type),
+            payload=_dict(data.get("payload")),
+            created_at=data.get("created_at"),
+            cursor=data.get("cursor"),
+        )
+
+
+@dataclass(slots=True)
+class CommandAck:
+    command_id: str
+    status: str
+    succeeded: bool | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    output: JsonDict = field(default_factory=dict)
+    error: str | None = None
+
+    def to_dict(self) -> JsonDict:
+        return asdict(self)
+
+    @classmethod
+    def from_result(
+        cls,
+        command_id: str,
+        result: CommandResult,
+        *,
+        started_at: str | None = None,
+        finished_at: str | None = None,
+    ) -> "CommandAck":
+        return cls(
+            command_id=command_id,
+            status="succeeded" if result.succeeded else "failed",
+            succeeded=result.succeeded,
+            started_at=started_at,
+            finished_at=finished_at,
+            output=result.output,
+            error=result.error,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CommandAck":
+        return cls(
+            command_id=str(data["command_id"]),
+            status=str(data["status"]),
+            succeeded=data.get("succeeded"),
+            started_at=data.get("started_at"),
+            finished_at=data.get("finished_at"),
+            output=_dict(data.get("output")),
+            error=data.get("error"),
+        )

--- a/src/tether/cli.py
+++ b/src/tether/cli.py
@@ -7,7 +7,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import typer
 from rich.console import Console
@@ -4784,6 +4784,387 @@ def connect_status(
 
 
 app.add_typer(connect_app, name="connect")
+
+
+# ─── tether agent {start,status,run-once} ───────────────────────────────────
+
+agent_app = typer.Typer(
+    help="Enroll and run the FastCrest Cloud edge agent.",
+    no_args_is_help=True,
+)
+
+
+def _agent_imports() -> tuple[Any, Any, Any]:
+    try:
+        from tether.agent import client as agent_client
+        from tether.agent import config as agent_config
+        from tether.agent import daemon as agent_daemon
+    except ImportError as exc:
+        err_console.print(
+            "[red]Tether Agent modules are not available yet.[/red] "
+            "Install the agent extra or include src/tether/agent."
+        )
+        raise typer.Exit(1) from exc
+    return agent_config, agent_client, agent_daemon
+
+
+def _agent_get(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _agent_default_config_path(agent_config: Any) -> Path:
+    for name in ("default_config_path", "get_default_config_path"):
+        fn = getattr(agent_config, name, None)
+        if callable(fn):
+            return Path(fn())
+    return Path.home() / ".tether" / "agent.json"
+
+
+def _agent_load_config(agent_config: Any, config_path: Optional[Path]) -> Any:
+    load_fn = getattr(agent_config, "load_config", None) or getattr(
+        agent_config, "load_agent_config", None
+    )
+    if not callable(load_fn):
+        err_console.print("[red]Agent config module is missing load_config().[/red]")
+        raise typer.Exit(1)
+    try:
+        if config_path is not None:
+            cfg = load_fn(config_path)
+        else:
+            cfg = load_fn()
+        if cfg is None:
+            raise FileNotFoundError(config_path or _agent_default_config_path(agent_config))
+        return cfg
+    except FileNotFoundError as exc:
+        path = config_path or _agent_default_config_path(agent_config)
+        err_console.print(f"[red]No agent config found at {path}.[/red]")
+        raise typer.Exit(1) from exc
+    except Exception as exc:  # noqa: BLE001
+        err_console.print(f"[red]Failed to load agent config:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+
+def _agent_save_config(agent_config: Any, cfg: Any, config_path: Optional[Path]) -> None:
+    save_fn = getattr(agent_config, "save_config", None) or getattr(
+        agent_config, "save_agent_config", None
+    )
+    if not callable(save_fn):
+        err_console.print("[red]Agent config module is missing save_config().[/red]")
+        raise typer.Exit(1)
+    try:
+        if config_path is not None:
+            save_fn(cfg, config_path)
+        else:
+            save_fn(cfg)
+    except Exception as exc:  # noqa: BLE001
+        err_console.print(f"[red]Failed to save agent config:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+
+def _agent_client(agent_client: Any, cfg: Any = None, cloud_url: Optional[str] = None) -> Any:
+    cls = getattr(agent_client, "AgentClient", None)
+    if cls is None:
+        err_console.print("[red]Agent client module is missing AgentClient.[/red]")
+        raise typer.Exit(1)
+
+    token = _agent_get(cfg, "device_token") if cfg is not None else None
+    resolved_cloud = cloud_url or _agent_get(cfg, "cloud_url")
+    attempts = []
+    if cfg is not None:
+        attempts.append(lambda: cls(config=cfg))
+    attempts.extend(
+        (
+            lambda: cls(cloud_url=resolved_cloud, device_token=token),
+            lambda: cls(resolved_cloud, token),
+            lambda: cls(resolved_cloud),
+        )
+    )
+    last_exc: Exception | None = None
+    for attempt in attempts:
+        try:
+            return attempt()
+        except (AttributeError, TypeError) as exc:
+            last_exc = exc
+    err_console.print(f"[red]Failed to initialize AgentClient:[/red] {last_exc}")
+    raise typer.Exit(1)
+
+
+def _agent_enroll(client: Any, enroll_token: str) -> Any:
+    enroll_fn = getattr(client, "enroll", None)
+    if not callable(enroll_fn):
+        err_console.print("[red]AgentClient is missing enroll().[/red]")
+        raise typer.Exit(1)
+    request = None
+    try:
+        from tether.agent.models import EnrollRequest
+
+        request = EnrollRequest(enroll_token=enroll_token)
+    except Exception:  # noqa: BLE001
+        request = None
+    attempts = []
+    if request is not None:
+        attempts.append(lambda: enroll_fn(request))
+    attempts.extend(
+        (
+            lambda: enroll_fn(enroll_token=enroll_token),
+            lambda: enroll_fn(enroll_token),
+        )
+    )
+    last_exc: Exception | None = None
+    for attempt in attempts:
+        try:
+            response = attempt()
+            if hasattr(response, "to_config"):
+                return response.to_config(client.cloud_url)
+            return response
+        except TypeError as exc:
+            last_exc = exc
+        except Exception as exc:  # noqa: BLE001
+            err_console.print(f"[red]Enrollment failed:[/red] {exc}")
+            raise typer.Exit(1) from exc
+    err_console.print(f"[red]Enrollment failed:[/red] {last_exc}")
+    raise typer.Exit(1)
+
+
+def _agent_config_from_enrollment(agent_config: Any, enrollment: Any, cloud_url: str) -> Any:
+    if isinstance(enrollment, dict):
+        enrollment.setdefault("cloud_url", cloud_url)
+        return enrollment
+    if _agent_get(enrollment, "cloud_url") is not None:
+        return enrollment
+    cls = getattr(agent_config, "AgentConfig", None)
+    if cls is not None:
+        try:
+            return cls(
+                device_id=_agent_get(enrollment, "device_id"),
+                device_token=_agent_get(enrollment, "device_token"),
+                cloud_url=cloud_url,
+                workspace_id=_agent_get(enrollment, "workspace_id"),
+                heartbeat_interval_seconds=_agent_get(
+                    enrollment,
+                    "heartbeat_interval_seconds",
+                    30,
+                ),
+            )
+        except TypeError:
+            pass
+    if hasattr(enrollment, "to_dict"):
+        data = enrollment.to_dict()
+        data["cloud_url"] = cloud_url
+        return data
+    return enrollment
+
+
+def _agent_run_once(agent_daemon: Any, cfg: Any, client: Any = None) -> Any:
+    for name in ("run_once", "run_agent_once", "run_cycle"):
+        fn = getattr(agent_daemon, name, None)
+        if callable(fn):
+            attempts = []
+            if client is not None:
+                attempts.extend(
+                    (
+                        lambda: fn(config=cfg, client=client),
+                        lambda: fn(cfg, client),
+                    )
+                )
+            attempts.extend((lambda: fn(cfg), lambda: fn(config=cfg)))
+            last_exc: TypeError | None = None
+            for attempt in attempts:
+                try:
+                    return attempt()
+                except TypeError as exc:
+                    last_exc = exc
+            err_console.print(f"[red]Agent run-once failed:[/red] {last_exc}")
+            raise typer.Exit(1)
+    err_console.print("[red]Agent daemon module is missing run_once().[/red]")
+    raise typer.Exit(1)
+
+
+def _agent_run_loop(agent_daemon: Any, cfg: Any, client: Any = None) -> None:
+    for name in ("run_forever", "run_loop", "run_daemon", "start_daemon"):
+        fn = getattr(agent_daemon, name, None)
+        if callable(fn):
+            attempts = []
+            if client is not None:
+                attempts.extend(
+                    (
+                        lambda: fn(config=cfg, client=client),
+                        lambda: fn(cfg, client),
+                    )
+                )
+            attempts.extend((lambda: fn(cfg), lambda: fn(config=cfg)))
+            last_exc: TypeError | None = None
+            for attempt in attempts:
+                try:
+                    attempt()
+                    return
+                except TypeError as exc:
+                    last_exc = exc
+            err_console.print(f"[red]Agent loop failed:[/red] {last_exc}")
+            raise typer.Exit(1)
+    err_console.print("[red]Agent daemon module is missing run_loop().[/red]")
+    raise typer.Exit(1)
+
+
+def _agent_status_payload(cfg: Any) -> dict[str, Any]:
+    last_command = _agent_get(cfg, "last_command") or {}
+    last_command_result = _agent_get(
+        cfg,
+        "last_command_result",
+        _agent_get(last_command, "result"),
+    )
+    if hasattr(last_command_result, "to_dict"):
+        last_command_result = last_command_result.to_dict()
+    return {
+        "device_id": _agent_get(cfg, "device_id"),
+        "cloud_url": _agent_get(cfg, "cloud_url"),
+        "workspace_id": _agent_get(cfg, "workspace_id"),
+        "heartbeat_interval_seconds": _agent_get(
+            cfg,
+            "heartbeat_interval_seconds",
+            _agent_get(cfg, "heartbeat_interval"),
+        ),
+        "last_heartbeat_at": _agent_get(
+            cfg,
+            "last_heartbeat_at",
+            _agent_get(cfg, "last_heartbeat"),
+        ),
+        "last_command_id": _agent_get(
+            cfg,
+            "last_command_id",
+            _agent_get(last_command, "id"),
+        ),
+        "last_command_result": _agent_get(
+            {"result": last_command_result},
+            "result",
+        ),
+    }
+
+
+@agent_app.command("start")
+def agent_start(
+    cloud: Optional[str] = typer.Option(
+        None,
+        "--cloud",
+        help="FastCrest Cloud URL.",
+    ),
+    enroll_token: Optional[str] = typer.Option(
+        None,
+        "--enroll-token",
+        help="One-time enrollment token from FastCrest Cloud.",
+    ),
+    config_path: Optional[Path] = typer.Option(
+        None,
+        "--config",
+        help="Path to agent config.",
+    ),
+    once: bool = typer.Option(
+        False,
+        "--once",
+        help="Run one deterministic agent cycle and exit.",
+    ),
+) -> None:
+    """Enroll this machine if needed, then run the agent."""
+    agent_config, agent_client, agent_daemon = _agent_imports()
+    cfg = None
+    try:
+        cfg = _agent_load_config(agent_config, config_path)
+    except typer.Exit:
+        if not enroll_token:
+            err_console.print(
+                "[red]Missing agent config and no --enroll-token was provided.[/red]"
+            )
+            raise typer.Exit(1)
+
+    if enroll_token:
+        if not cloud:
+            cloud = _agent_get(cfg, "cloud_url") if cfg is not None else None
+        if not cloud:
+            err_console.print("[red]--cloud is required when enrolling.[/red]")
+            raise typer.Exit(2)
+        client = _agent_client(agent_client, cloud_url=cloud)
+        cfg = _agent_config_from_enrollment(
+            agent_config,
+            _agent_enroll(client, enroll_token),
+            cloud,
+        )
+        _agent_save_config(agent_config, cfg, config_path)
+        console.print(f"Enrolled device {_agent_get(cfg, 'device_id') or '(unknown)'}.")
+
+    if cfg is None:
+        err_console.print("[red]Missing agent config.[/red]")
+        raise typer.Exit(1)
+
+    if once:
+        client = _agent_client(agent_client, cfg=cfg)
+        _agent_run_once(agent_daemon, cfg, client)
+        console.print("Agent cycle complete.")
+    else:
+        console.print("Starting Tether Agent.")
+        client = _agent_client(agent_client, cfg=cfg)
+        _agent_run_loop(agent_daemon, cfg, client)
+
+
+@agent_app.command("status")
+def agent_status(
+    config_path: Optional[Path] = typer.Option(
+        None,
+        "--config",
+        help="Path to agent config.",
+    ),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON.",
+    ),
+) -> None:
+    """Show local Tether Agent identity and latest activity."""
+    agent_config, _agent_client_module, _agent_daemon_module = _agent_imports()
+    cfg = _agent_load_config(agent_config, config_path)
+    payload = _agent_status_payload(cfg)
+    if as_json:
+        console.print(json.dumps(payload, sort_keys=True))
+        return
+
+    table = Table(title="Tether Agent")
+    table.add_column("Field", style="bold")
+    table.add_column("Value")
+    labels = {
+        "device_id": "Device ID",
+        "cloud_url": "Cloud URL",
+        "workspace_id": "Workspace ID",
+        "heartbeat_interval_seconds": "Heartbeat Interval",
+        "last_heartbeat_at": "Last Heartbeat",
+        "last_command_id": "Last Command ID",
+        "last_command_result": "Last Command Result",
+    }
+    for key, label in labels.items():
+        value = payload.get(key)
+        if key == "heartbeat_interval_seconds" and value is not None:
+            value = f"{value}s"
+        table.add_row(label, str(value) if value not in (None, "") else "-")
+    console.print(table)
+
+
+@agent_app.command("run-once")
+def agent_run_once(
+    config_path: Optional[Path] = typer.Option(
+        None,
+        "--config",
+        help="Path to agent config.",
+    ),
+) -> None:
+    """Load config and run one agent cycle."""
+    agent_config, agent_client, agent_daemon = _agent_imports()
+    cfg = _agent_load_config(agent_config, config_path)
+    client = _agent_client(agent_client, cfg=cfg)
+    _agent_run_once(agent_daemon, cfg, client)
+    console.print("Agent cycle complete.")
+
+
+app.add_typer(agent_app, name="agent")
 
 
 # ─── tether traces {query, summary} ─────────────────────────────────────────

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,0 +1,191 @@
+"""Tests for the `tether agent` CLI surface."""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from tether.cli import app
+
+
+@pytest.fixture
+def runner(monkeypatch: pytest.MonkeyPatch) -> CliRunner:
+    monkeypatch.setenv("TETHER_NO_UPGRADE_CHECK", "1")
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_agent_modules(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    state: dict[str, object] = {
+        "config": None,
+        "saved": [],
+        "client_inits": [],
+        "enroll_tokens": [],
+        "run_once": [],
+        "run_loop": [],
+    }
+
+    agent_pkg = types.ModuleType("tether.agent")
+    config_mod = types.ModuleType("tether.agent.config")
+    client_mod = types.ModuleType("tether.agent.client")
+    daemon_mod = types.ModuleType("tether.agent.daemon")
+
+    def default_config_path() -> Path:
+        return Path("/tmp/tether-agent.json")
+
+    def load_config(path: Path | None = None) -> dict[str, object]:
+        if state["config"] is None:
+            raise FileNotFoundError(path or default_config_path())
+        return state["config"]  # type: ignore[return-value]
+
+    def save_config(cfg: dict[str, object], path: Path | None = None) -> None:
+        state["config"] = cfg
+        state["saved"].append((cfg, path))  # type: ignore[union-attr]
+
+    class AgentClient:
+        def __init__(
+            self,
+            cloud_url: str,
+            device_token: str | None = None,
+        ) -> None:
+            state["client_inits"].append((cloud_url, device_token))  # type: ignore[union-attr]
+            self.cloud_url = cloud_url
+
+        def enroll(self, enroll_token: object) -> dict[str, object]:
+            token = getattr(enroll_token, "enroll_token", enroll_token)
+            state["enroll_tokens"].append(token)  # type: ignore[union-attr]
+            return {
+                "device_id": "dev_123",
+                "device_token": "tok_123",
+                "cloud_url": self.cloud_url,
+                "workspace_id": "ws_123",
+                "heartbeat_interval_seconds": 30,
+            }
+
+    def run_once(cfg: dict[str, object]) -> None:
+        state["run_once"].append(cfg)  # type: ignore[union-attr]
+
+    def run_loop(cfg: dict[str, object]) -> None:
+        state["run_loop"].append(cfg)  # type: ignore[union-attr]
+
+    config_mod.default_config_path = default_config_path
+    config_mod.load_config = load_config
+    config_mod.save_config = save_config
+    client_mod.AgentClient = AgentClient
+    daemon_mod.run_once = run_once
+    daemon_mod.run_loop = run_loop
+    agent_pkg.config = config_mod
+    agent_pkg.client = client_mod
+    agent_pkg.daemon = daemon_mod
+
+    monkeypatch.setitem(sys.modules, "tether.agent", agent_pkg)
+    monkeypatch.setitem(sys.modules, "tether.agent.config", config_mod)
+    monkeypatch.setitem(sys.modules, "tether.agent.client", client_mod)
+    monkeypatch.setitem(sys.modules, "tether.agent.daemon", daemon_mod)
+    return state
+
+
+def test_agent_status_missing_config(
+    runner: CliRunner,
+    fake_agent_modules: dict[str, object],
+) -> None:
+    result = runner.invoke(app, ["agent", "status"])
+
+    assert result.exit_code == 1
+    assert "No agent config found" in result.output
+
+
+def test_agent_status_json(
+    runner: CliRunner,
+    fake_agent_modules: dict[str, object],
+) -> None:
+    fake_agent_modules["config"] = {
+        "device_id": "dev_123",
+        "cloud_url": "https://cloud.example.test",
+        "workspace_id": "ws_123",
+        "heartbeat_interval_seconds": 30,
+        "last_heartbeat_at": "2026-06-04T12:00:00Z",
+        "last_command_id": "cmd_123",
+        "last_command_result": "succeeded",
+    }
+
+    result = runner.invoke(app, ["agent", "status", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload == {
+        "device_id": "dev_123",
+        "cloud_url": "https://cloud.example.test",
+        "workspace_id": "ws_123",
+        "heartbeat_interval_seconds": 30,
+        "last_heartbeat_at": "2026-06-04T12:00:00Z",
+        "last_command_id": "cmd_123",
+        "last_command_result": "succeeded",
+    }
+
+
+def test_agent_start_once_enrollment_path(
+    runner: CliRunner,
+    fake_agent_modules: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "agent.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "start",
+            "--cloud",
+            "https://cloud.example.test",
+            "--enroll-token",
+            "enroll_123",
+            "--config",
+            str(config_path),
+            "--once",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake_agent_modules["enroll_tokens"] == ["enroll_123"]
+    assert fake_agent_modules["saved"] == [
+        (
+            {
+                "device_id": "dev_123",
+                "device_token": "tok_123",
+                "cloud_url": "https://cloud.example.test",
+                "workspace_id": "ws_123",
+                "heartbeat_interval_seconds": 30,
+            },
+            config_path,
+        )
+    ]
+    assert fake_agent_modules["run_once"] == [fake_agent_modules["config"]]
+    assert "Enrolled device dev_123" in result.output
+    assert "Agent cycle complete" in result.output
+
+
+def test_agent_run_once_path(
+    runner: CliRunner,
+    fake_agent_modules: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    cfg = {
+        "device_id": "dev_existing",
+        "cloud_url": "https://cloud.example.test",
+        "device_token": "tok_existing",
+    }
+    fake_agent_modules["config"] = cfg
+
+    result = runner.invoke(
+        app,
+        ["agent", "run-once", "--config", str(tmp_path / "agent.json")],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake_agent_modules["run_once"] == [cfg]
+    assert "Agent cycle complete" in result.output

--- a/tests/test_agent_client.py
+++ b/tests/test_agent_client.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import pytest
+
+from tether.agent.client import AgentClient, AgentClientError
+from tether.agent.models import CommandAck, EnrollRequest, HeartbeatPayload
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def request(self, method, url, headers=None, json=None, timeout=None):
+        self.requests.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": dict(headers or {}),
+                "json": json,
+                "timeout": timeout,
+            }
+        )
+        return self.responses.pop(0)
+
+
+def test_enroll_posts_to_contract_endpoint_without_auth():
+    session = FakeSession(
+        [
+            FakeResponse(
+                payload={
+                    "device_id": "dev_1",
+                    "device_token": "tok_1",
+                    "workspace_id": "ws_1",
+                    "heartbeat_interval_seconds": 30,
+                }
+            )
+        ]
+    )
+    client = AgentClient("https://cloud.example.test/", session=session, timeout_seconds=3)
+
+    response = client.enroll(EnrollRequest(enroll_token="enroll_1", hostname="host-a"))
+
+    request = session.requests[0]
+    assert response.device_id == "dev_1"
+    assert request["method"] == "POST"
+    assert request["url"] == "https://cloud.example.test/agent/enroll"
+    assert "Authorization" not in request["headers"]
+    assert request["json"]["enroll_token"] == "enroll_1"
+    assert request["timeout"] == 3
+
+
+def test_heartbeat_uses_device_url_and_bearer_token():
+    session = FakeSession([FakeResponse(payload={"ok": True})])
+    client = AgentClient("https://cloud.example.test", device_token="tok_1", session=session)
+
+    client.heartbeat("dev/with space", HeartbeatPayload(device_id="dev/with space", workspace_id="ws_1"))
+
+    request = session.requests[0]
+    assert request["method"] == "POST"
+    assert request["url"] == "https://cloud.example.test/agent/devices/dev%2Fwith%20space/heartbeat"
+    assert request["headers"]["Authorization"] == "Bearer tok_1"
+    assert request["json"]["workspace_id"] == "ws_1"
+
+
+def test_poll_commands_adds_after_cursor_and_parses_commands():
+    session = FakeSession(
+        [
+            FakeResponse(
+                payload={
+                    "commands": [
+                        {
+                            "command_id": "cmd_1",
+                            "type": "noop",
+                            "payload": {"x": 1},
+                            "created_at": "2026-06-04T12:00:00Z",
+                        }
+                    ],
+                    "next_cursor": "cmd_1",
+                }
+            )
+        ]
+    )
+    client = AgentClient("https://cloud.example.test", device_token="tok_1", session=session)
+
+    commands = client.poll_commands("dev_1", after="cmd_0")
+
+    assert session.requests[0]["method"] == "GET"
+    assert session.requests[0]["url"] == "https://cloud.example.test/agent/devices/dev_1/commands?after=cmd_0"
+    assert commands[0].command_id == "cmd_1"
+    assert commands[0].type == "noop"
+    assert commands[0].payload == {"x": 1}
+
+
+def test_ack_command_posts_ack_payload():
+    session = FakeSession([FakeResponse(payload={"ok": True})])
+    client = AgentClient("https://cloud.example.test", device_token="tok_1", session=session)
+
+    client.ack_command("dev_1", "cmd_1", CommandAck(command_id="cmd_1", status="succeeded", succeeded=True))
+
+    request = session.requests[0]
+    assert request["method"] == "POST"
+    assert request["url"] == "https://cloud.example.test/agent/devices/dev_1/commands/cmd_1/ack"
+    assert request["headers"]["Authorization"] == "Bearer tok_1"
+    assert request["json"]["status"] == "succeeded"
+    assert request["json"]["succeeded"] is True
+
+
+def test_authenticated_calls_require_device_token():
+    client = AgentClient("https://cloud.example.test", session=FakeSession([]))
+
+    with pytest.raises(AgentClientError, match="device token"):
+        client.poll_commands("dev_1")
+
+
+def test_http_errors_raise_client_error():
+    client = AgentClient(
+        "https://cloud.example.test",
+        device_token="tok_1",
+        session=FakeSession([FakeResponse(status_code=401, payload={}, text="unauthorized")]),
+    )
+
+    with pytest.raises(AgentClientError, match="HTTP 401"):
+        client.poll_commands("dev_1")

--- a/tests/test_agent_commands.py
+++ b/tests/test_agent_commands.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+
+from tether.agent.commands import execute_command
+
+
+def test_noop_succeeds():
+    result = execute_command({"id": "cmd_1", "type": "noop"}, now=lambda: 10.0)
+
+    assert result["command_id"] == "cmd_1"
+    assert result["succeeded"] is True
+    assert result["status"] == "succeeded"
+
+
+def test_unknown_command_fails_unsupported():
+    result = execute_command({"id": "cmd_1", "type": "deploy"}, now=lambda: 10.0)
+
+    assert result["succeeded"] is False
+    assert result["error"]["reason"] == "unsupported_command"
+
+
+def test_doctor_success_parses_summary():
+    payload = {"summary": {"pass": 2, "fail": 0, "warn": 1, "skip": 0}, "checks": []}
+
+    def runner(argv, **kwargs):
+        assert argv == ["tether", "doctor", "--format", "json"]
+        assert kwargs["timeout"] == 60.0
+        return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+    result = execute_command({"id": "cmd_1", "type": "doctor"}, runner=runner, now=lambda: 10.0)
+
+    assert result["succeeded"] is True
+    assert result["output"]["summary"] == {"pass": 2, "fail": 0, "warn": 1, "skip": 0}
+
+
+def test_doctor_accepts_payload_options():
+    payload = {"summary": {"pass": 1, "fail": 0, "warn": 0, "skip": 0}, "checks": []}
+
+    def runner(argv, **kwargs):
+        assert argv == ["custom-doctor"]
+        assert kwargs["timeout"] == 2.0
+        return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+    result = execute_command(
+        {"id": "cmd_1", "type": "doctor", "payload": {"argv": ["custom-doctor"], "timeout_seconds": 2}},
+        runner=runner,
+        now=lambda: 10.0,
+    )
+
+    assert result["succeeded"] is True
+
+
+def test_doctor_nonzero_fails_with_summary():
+    payload = {"summary": {"pass": 1, "fail": 1, "warn": 0, "skip": 0}, "checks": []}
+
+    def runner(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 1, stdout=json.dumps(payload), stderr="failed")
+
+    result = execute_command({"id": "cmd_1", "type": "doctor"}, runner=runner, now=lambda: 10.0)
+
+    assert result["succeeded"] is False
+    assert result["error"]["reason"] == "doctor_exit_nonzero"
+    assert result["output"]["summary"]["fail"] == 1
+
+
+def test_doctor_malformed_json_fails():
+    def runner(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 0, stdout="{not json", stderr="")
+
+    result = execute_command({"id": "cmd_1", "type": "doctor"}, runner=runner, now=lambda: 10.0)
+
+    assert result["succeeded"] is False
+    assert result["error"]["reason"] == "malformed_json"
+
+
+def test_doctor_timeout_fails():
+    def runner(argv, **kwargs):
+        raise subprocess.TimeoutExpired(argv, timeout=kwargs["timeout"], output="partial")
+
+    result = execute_command(
+        {"id": "cmd_1", "type": "doctor", "timeout_seconds": 1},
+        runner=runner,
+        now=lambda: 10.0,
+    )
+
+    assert result["succeeded"] is False
+    assert result["error"]["reason"] == "timeout"
+    assert result["stdout"] == "partial"
+
+
+def test_doctor_process_start_failure_is_acked():
+    def runner(argv, **kwargs):
+        raise FileNotFoundError("missing tether")
+
+    result = execute_command({"id": "cmd_1", "type": "doctor"}, runner=runner, now=lambda: 10.0)
+
+    assert result["succeeded"] is False
+    assert result["status"] == "failed"
+    assert result["error"]["reason"] == "process_start_failed"
+    assert result["error"]["argv"] == ["tether", "doctor", "--format", "json"]
+
+
+def test_serve_status_no_server_is_graceful():
+    def get_json(url, timeout):
+        raise OSError("connection refused")
+
+    result = execute_command(
+        {"id": "cmd_1", "type": "serve_status"},
+        http_get_json=get_json,
+        now=lambda: 10.0,
+    )
+
+    assert result["succeeded"] is True
+    assert result["output"]["reachable"] is False
+    assert result["output"]["ready"] is False
+    assert result["output"]["url"] == "http://127.0.0.1:8000"
+
+
+def test_serve_status_ready_fake_server():
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"status": "ok", "state": "ready"}).encode())
+                return
+            if self.path == "/config":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"robot_id": "robot_1"}).encode())
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}"
+        result = execute_command(
+            {"id": "cmd_1", "type": "serve_status", "serve_url": url},
+            now=lambda: 10.0,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert result["succeeded"] is True
+    assert result["output"]["reachable"] is True
+    assert result["output"]["ready"] is True
+    assert result["output"]["health"]["body"]["state"] == "ready"
+    assert result["output"]["config"]["body"]["robot_id"] == "robot_1"

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import stat
+
+from tether.agent.config import AgentConfig, load_config, save_config
+from tether.agent.models import CommandResult
+
+
+def test_config_round_trip_with_override_path(tmp_path):
+    path = tmp_path / "nested" / "agent.json"
+    config = AgentConfig(
+        device_id="dev_123",
+        cloud_url="https://cloud.example.test",
+        workspace_id="ws_123",
+        device_token="tok_secret",
+        heartbeat_interval_seconds=45,
+        last_heartbeat_at="2026-06-04T12:00:00Z",
+        last_command_id="cmd_1",
+        last_command_result=CommandResult(succeeded=True, output={"kind": "noop"}),
+    )
+
+    saved_path = save_config(config, path)
+    loaded = load_config(path)
+
+    assert saved_path == path
+    assert loaded == config
+
+
+def test_load_config_returns_none_when_missing(tmp_path):
+    assert load_config(tmp_path / "missing.json") is None
+
+
+def test_config_permissions_are_restricted_on_posix(tmp_path):
+    if os.name != "posix":
+        return
+    path = tmp_path / "agent.json"
+
+    save_config(AgentConfig(device_token="tok_secret"), path)
+
+    file_mode = stat.S_IMODE(path.stat().st_mode)
+    dir_mode = stat.S_IMODE(path.parent.stat().st_mode)
+    assert file_mode & 0o077 == 0
+    assert dir_mode & 0o077 == 0

--- a/tests/test_agent_daemon.py
+++ b/tests/test_agent_daemon.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tether.agent.daemon import run_once
+
+
+@dataclass
+class Config:
+    device_id: str = "dev_1"
+    cloud_url: str = "https://cloud.example"
+    device_token: str = "tok"
+    heartbeat_interval_seconds: float = 30.0
+
+
+class FakeClient:
+    def __init__(self, commands=None):
+        self.commands = commands or []
+        self.heartbeats = []
+        self.acks = []
+
+    def heartbeat(self, payload):
+        self.heartbeats.append(payload)
+        return {"ok": True}
+
+    def poll_commands(self):
+        return {"commands": self.commands}
+
+    def ack_command(self, command_id, result):
+        self.acks.append((command_id, result))
+        return {"ok": True}
+
+
+def test_run_once_heartbeat_and_no_commands():
+    client = FakeClient()
+
+    result = run_once(Config(), client, now=lambda: 100.0)
+
+    assert result["commands_polled"] == 0
+    assert result["commands_executed"] == 0
+    assert len(client.heartbeats) == 1
+    assert client.heartbeats[0]["device_id"] == "dev_1"
+    assert client.heartbeats[0]["observed_at"] == 100.0
+    assert client.heartbeats[0]["cloud_url"] == "https://cloud.example"
+    assert client.acks == []
+
+
+def test_run_once_executes_noop_and_acks():
+    client = FakeClient(commands=[{"id": "cmd_1", "type": "noop"}])
+
+    result = run_once(Config(), client, now=lambda: 100.0)
+
+    assert result["commands_polled"] == 1
+    assert result["commands_executed"] == 1
+    assert len(client.acks) == 1
+    command_id, ack_result = client.acks[0]
+    assert command_id == "cmd_1"
+    assert ack_result["command_id"] == "cmd_1"
+    assert ack_result["succeeded"] is True

--- a/tests/test_agent_hardware.py
+++ b/tests/test_agent_hardware.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+
+from tether.agent.hardware import collect_hardware_profile
+
+
+def test_hardware_profile_never_raises_and_is_json_serializable():
+    profile = collect_hardware_profile()
+
+    json.dumps(profile, sort_keys=True)
+    assert isinstance(profile, dict)
+    assert set(profile) >= {
+        "hostname",
+        "platform",
+        "python",
+        "agent_version",
+        "tether_version",
+        "gpu_name",
+        "cuda",
+        "jetpack",
+        "tensorrt",
+    }
+    assert isinstance(profile["platform"], str)
+    assert isinstance(profile["python"], str)


### PR DESCRIPTION
## Summary
- Adds Tether Agent config, Cloud client, hardware profile collection, command execution, and daemon loop modules.
- Adds CLI commands under tether agent: start, status, and run-once.
- Handles doctor process-start failures as bounded command ack failures instead of crashing.
- Adds focused tests for client contract, daemon behavior, command execution, config, hardware, and CLI flows.

## Validation
- PYTHONPATH=src pytest tests/test_agent_*.py -q
- PYTHONPATH=src pytest tests/test_agent_cli.py tests/test_cli.py tests/test_cli_verb_noun.py -q
- PYTHONPATH=src ruff check src/tether/agent tests/test_agent_*.py
- PYTHONPATH=src ruff check src/tether/cli.py --select E9,F63,F7,F82
- git diff --check
- Cross-repo smoke with clean Cloud + Tether worktrees: enroll -> heartbeat -> poll doctor -> ack failure payload.