### PR TITLE
[codex] Add Tether Agent service installer

### DIFF
--- a/src/tether/agent/service.py
+++ b/src/tether/agent/service.py
@@ -1,0 +1,150 @@
+"""Service file generation for long-running Tether Agent daemons."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import shlex
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SERVICE_NAME = "tether-agent"
+LAUNCHD_LABEL = "com.fastcrest.tether-agent"
+
+
+@dataclass(slots=True)
+class ServicePlan:
+    kind: str
+    path: Path
+    content: str
+
+
+def detect_service_kind(platform: str | None = None) -> str:
+    value = platform or sys.platform
+    if value == "darwin":
+        return "launchd"
+    if value.startswith("linux"):
+        return "systemd"
+    raise ValueError(f"unsupported service platform: {value}")
+
+
+def resolve_tether_bin(explicit: str | os.PathLike[str] | None = None) -> str:
+    if explicit:
+        return str(explicit)
+    return shutil.which("tether") or str(Path(sys.argv[0]).resolve())
+
+
+def service_path(kind: str, *, home: str | os.PathLike[str] | None = None) -> Path:
+    base = Path(home) if home is not None else Path.home()
+    if kind == "systemd":
+        return base / ".config" / "systemd" / "user" / f"{SERVICE_NAME}.service"
+    if kind == "launchd":
+        return base / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+    raise ValueError(f"unsupported service kind: {kind}")
+
+
+def render_systemd_user_service(
+    *,
+    tether_bin: str | os.PathLike[str],
+    config_path: str | os.PathLike[str],
+) -> str:
+    argv = " ".join(
+        shlex.quote(str(part))
+        for part in (
+            tether_bin,
+            "agent",
+            "start",
+            "--config",
+            config_path,
+        )
+    )
+    return "\n".join(
+        [
+            "[Unit]",
+            "Description=Tether Agent",
+            "After=network-online.target",
+            "Wants=network-online.target",
+            "",
+            "[Service]",
+            "Type=simple",
+            f"ExecStart={argv}",
+            "Restart=always",
+            "RestartSec=5",
+            "Environment=TETHER_NO_UPGRADE_CHECK=1",
+            "",
+            "[Install]",
+            "WantedBy=default.target",
+            "",
+        ]
+    )
+
+
+def render_launchd_plist(
+    *,
+    tether_bin: str | os.PathLike[str],
+    config_path: str | os.PathLike[str],
+    home: str | os.PathLike[str] | None = None,
+) -> str:
+    base = Path(home) if home is not None else Path.home()
+    payload = {
+        "Label": LAUNCHD_LABEL,
+        "ProgramArguments": [
+            str(tether_bin),
+            "agent",
+            "start",
+            "--config",
+            str(config_path),
+        ],
+        "RunAtLoad": True,
+        "KeepAlive": True,
+        "EnvironmentVariables": {"TETHER_NO_UPGRADE_CHECK": "1"},
+        "StandardOutPath": str(base / "Library" / "Logs" / "tether-agent.log"),
+        "StandardErrorPath": str(base / "Library" / "Logs" / "tether-agent.err.log"),
+    }
+    return plistlib.dumps(payload, sort_keys=True).decode("utf-8")
+
+
+def build_service_plan(
+    *,
+    kind: str = "auto",
+    config_path: str | os.PathLike[str],
+    tether_bin: str | os.PathLike[str] | None = None,
+    home: str | os.PathLike[str] | None = None,
+) -> ServicePlan:
+    resolved_kind = detect_service_kind() if kind == "auto" else kind
+    resolved_tether = resolve_tether_bin(tether_bin)
+    target = service_path(resolved_kind, home=home)
+    if resolved_kind == "systemd":
+        content = render_systemd_user_service(
+            tether_bin=resolved_tether,
+            config_path=config_path,
+        )
+    elif resolved_kind == "launchd":
+        content = render_launchd_plist(
+            tether_bin=resolved_tether,
+            config_path=config_path,
+            home=home,
+        )
+    else:
+        raise ValueError(f"unsupported service kind: {resolved_kind}")
+    return ServicePlan(kind=resolved_kind, path=target, content=content)
+
+
+def write_service(plan: ServicePlan) -> Path:
+    plan.path.parent.mkdir(parents=True, exist_ok=True)
+    plan.path.write_text(plan.content, encoding="utf-8")
+    return plan.path
+
+
+def remove_service(
+    *,
+    kind: str = "auto",
+    home: str | os.PathLike[str] | None = None,
+) -> Path:
+    resolved_kind = detect_service_kind() if kind == "auto" else kind
+    target = service_path(resolved_kind, home=home)
+    if target.exists():
+        target.unlink()
+    return target

--- a/src/tether/cli.py
+++ b/src/tether/cli.py
@@ -5164,6 +5164,99 @@ def agent_run_once(
     console.print("Agent cycle complete.")
 
 
+@agent_app.command("install-service")
+def agent_install_service(
+    config_path: Optional[Path] = typer.Option(
+        None,
+        "--config",
+        help="Path to agent config.",
+    ),
+    kind: str = typer.Option(
+        "auto",
+        "--kind",
+        help="Service kind: auto, systemd, or launchd.",
+    ),
+    tether_bin: Optional[str] = typer.Option(
+        None,
+        "--tether-bin",
+        help="Tether executable path for the generated service.",
+    ),
+    home: Optional[Path] = typer.Option(
+        None,
+        "--home",
+        help="Override home directory for service file placement.",
+    ),
+    apply_changes: bool = typer.Option(
+        False,
+        "--apply",
+        help="Write the service file. Default prints a dry-run preview.",
+    ),
+) -> None:
+    """Generate or write an autostart service for the Tether Agent."""
+    from tether.agent import config as agent_config
+    from tether.agent import service as agent_service
+
+    resolved_config = config_path or agent_config.default_config_path()
+    try:
+        plan = agent_service.build_service_plan(
+            kind=kind,
+            config_path=resolved_config,
+            tether_bin=tether_bin,
+            home=home,
+        )
+    except ValueError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(2) from exc
+
+    if apply_changes:
+        path = agent_service.write_service(plan)
+        console.print(f"Wrote {plan.kind} service to {path}.")
+        return
+
+    console.print(f"# {plan.kind} service: {plan.path}")
+    console.print(plan.content.rstrip())
+    console.print("# Dry run only. Re-run with --apply to write this file.")
+
+
+@agent_app.command("uninstall-service")
+def agent_uninstall_service(
+    kind: str = typer.Option(
+        "auto",
+        "--kind",
+        help="Service kind: auto, systemd, or launchd.",
+    ),
+    home: Optional[Path] = typer.Option(
+        None,
+        "--home",
+        help="Override home directory for service file placement.",
+    ),
+    apply_changes: bool = typer.Option(
+        False,
+        "--apply",
+        help="Delete the service file. Default prints a dry-run path.",
+    ),
+) -> None:
+    """Remove the Tether Agent autostart service file."""
+    from tether.agent import service as agent_service
+
+    try:
+        target = agent_service.service_path(
+            agent_service.detect_service_kind() if kind == "auto" else kind,
+            home=home,
+        )
+    except ValueError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(2) from exc
+
+    if apply_changes:
+        removed = agent_service.remove_service(kind=kind, home=home)
+        console.print(f"Removed service file path {removed}.")
+        return
+
+    console.print(f"# {kind} service path: {target}")
+    console.print("# Dry run only. Re-run with --apply to delete this file.")
+
+
 app.add_typer(agent_app, name="agent")
 
 

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -189,3 +189,72 @@ def test_agent_run_once_path(
     assert result.exit_code == 0, result.output
     assert fake_agent_modules["run_once"] == [cfg]
     assert "Agent cycle complete" in result.output
+
+
+def test_agent_install_service_dry_run(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "install-service",
+            "--kind",
+            "systemd",
+            "--config",
+            str(tmp_path / "agent.json"),
+            "--tether-bin",
+            "/opt/tether/bin/tether",
+            "--home",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "ExecStart=/opt/tether/bin/tether agent start --config" in result.output
+    assert "Dry run only" in result.output
+    assert not (tmp_path / ".config" / "systemd" / "user" / "tether-agent.service").exists()
+
+
+def test_agent_install_and_uninstall_service_apply(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    install = runner.invoke(
+        app,
+        [
+            "agent",
+            "install-service",
+            "--kind",
+            "systemd",
+            "--config",
+            str(tmp_path / "agent.json"),
+            "--tether-bin",
+            "/opt/tether/bin/tether",
+            "--home",
+            str(tmp_path),
+            "--apply",
+        ],
+    )
+    service_path = tmp_path / ".config" / "systemd" / "user" / "tether-agent.service"
+
+    assert install.exit_code == 0, install.output
+    assert service_path.exists()
+    assert "Wrote systemd service" in install.output
+
+    uninstall = runner.invoke(
+        app,
+        [
+            "agent",
+            "uninstall-service",
+            "--kind",
+            "systemd",
+            "--home",
+            str(tmp_path),
+            "--apply",
+        ],
+    )
+
+    assert uninstall.exit_code == 0, uninstall.output
+    assert not service_path.exists()

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import plistlib
+
+from tether.agent.service import (
+    build_service_plan,
+    remove_service,
+    render_launchd_plist,
+    render_systemd_user_service,
+    service_path,
+    write_service,
+)
+
+
+def test_render_systemd_user_service():
+    content = render_systemd_user_service(
+        tether_bin="/opt/tether/bin/tether",
+        config_path="/home/edge/.tether/agent.json",
+    )
+
+    assert "Description=Tether Agent" in content
+    assert "ExecStart=/opt/tether/bin/tether agent start --config /home/edge/.tether/agent.json" in content
+    assert "Restart=always" in content
+    assert "WantedBy=default.target" in content
+
+
+def test_render_launchd_plist():
+    content = render_launchd_plist(
+        tether_bin="/opt/tether/bin/tether",
+        config_path="/Users/edge/.tether/agent.json",
+        home="/Users/edge",
+    )
+    payload = plistlib.loads(content.encode("utf-8"))
+
+    assert payload["Label"] == "com.fastcrest.tether-agent"
+    assert payload["ProgramArguments"] == [
+        "/opt/tether/bin/tether",
+        "agent",
+        "start",
+        "--config",
+        "/Users/edge/.tether/agent.json",
+    ]
+    assert payload["RunAtLoad"] is True
+    assert payload["KeepAlive"] is True
+    assert payload["StandardOutPath"] == "/Users/edge/Library/Logs/tether-agent.log"
+
+
+def test_build_and_write_systemd_service_to_temp_home(tmp_path):
+    plan = build_service_plan(
+        kind="systemd",
+        config_path=tmp_path / "agent.json",
+        tether_bin="/opt/tether/bin/tether",
+        home=tmp_path,
+    )
+
+    assert plan.path == tmp_path / ".config" / "systemd" / "user" / "tether-agent.service"
+    written = write_service(plan)
+    assert written == plan.path
+    assert written.read_text() == plan.content
+
+
+def test_remove_service_only_deletes_target_path(tmp_path):
+    target = service_path("launchd", home=tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text("payload")
+    neighbor = target.with_name("other.plist")
+    neighbor.write_text("keep")
+
+    removed = remove_service(kind="launchd", home=tmp_path)
+
+    assert removed == target
+    assert not target.exists()
+    assert neighbor.read_text() == "keep"


### PR DESCRIPTION
## Summary
- add systemd user service and launchd plist rendering for Tether Agent autostart
- add `tether agent install-service` and `uninstall-service`
- keep both commands dry-run by default; `--apply` writes or removes the service file

## Validation
- PYTHONPATH=src pytest tests/test_agent_*.py -q
- PYTHONPATH=src ruff check src/tether/agent tests/test_agent_*.py
- PYTHONPATH=src ruff check src/tether/cli.py --select E9,F63,F7,F82
- git diff --check
