### PR TITLE
Add Tether failure producer

### DIFF
--- a/src/tether/agent/client.py
+++ b/src/tether/agent/client.py
@@ -13,6 +13,7 @@ from tether.agent.models import (
     CommandAck,
     EnrollRequest,
     EnrollResponse,
+    FailureEventPayload,
     HeartbeatPayload,
     JsonDict,
 )
@@ -30,11 +31,13 @@ class AgentClient:
         cloud_url: str,
         *,
         device_token: str | None = None,
+        fleet_device_token: str | None = None,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
         session: Any | None = None,
     ) -> None:
         self.cloud_url = cloud_url.rstrip("/")
         self.device_token = device_token
+        self.fleet_device_token = fleet_device_token
         self.timeout_seconds = timeout_seconds
         self._session = session if session is not None else self._make_httpx_session(timeout_seconds)
 
@@ -72,6 +75,28 @@ class AgentClient:
             auth=True,
         )
 
+    def create_failure(
+        self,
+        device_id: str,
+        payload: FailureEventPayload | Mapping[str, Any],
+        *,
+        device_token: str | None = None,
+    ) -> JsonDict:
+        failure_token = device_token or self.fleet_device_token
+        if not failure_token:
+            raise AgentClientError("fleet device token is required for failure uploads")
+        if hasattr(payload, "to_dict"):
+            body = payload.to_dict()
+        else:
+            body = dict(payload)
+        return self._request(
+            "POST",
+            f"/fleet/devices/{urllib.parse.quote(device_id, safe='')}/failures",
+            json_body=body,
+            auth=True,
+            auth_token=failure_token,
+        )
+
     def _request(
         self,
         method: str,
@@ -80,13 +105,15 @@ class AgentClient:
         json_body: Mapping[str, Any] | None = None,
         params: Mapping[str, Any] | None = None,
         auth: bool,
+        auth_token: str | None = None,
     ) -> Any:
         url = self._url(path, params)
         headers = {"Content-Type": "application/json"}
         if auth:
-            if not self.device_token:
+            token = auth_token or self.device_token
+            if not token:
                 raise AgentClientError("device token is required for authenticated agent calls")
-            headers["Authorization"] = f"Bearer {self.device_token}"
+            headers["Authorization"] = f"Bearer {token}"
 
         if self._session is not None:
             response = self._session.request(
@@ -149,6 +176,12 @@ def make_default_client(
     cloud_url: str,
     *,
     device_token: str | None = None,
+    fleet_device_token: str | None = None,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> AgentClient:
-    return AgentClient(cloud_url, device_token=device_token, timeout_seconds=timeout_seconds)
+    return AgentClient(
+        cloud_url,
+        device_token=device_token,
+        fleet_device_token=fleet_device_token,
+        timeout_seconds=timeout_seconds,
+    )

--- a/src/tether/agent/config.py
+++ b/src/tether/agent/config.py
@@ -19,6 +19,8 @@ class AgentConfig:
     cloud_url: str | None = None
     workspace_id: str | None = None
     device_token: str | None = None
+    fleet_device_id: str | None = None
+    fleet_device_token: str | None = None
     heartbeat_interval_seconds: int = DEFAULT_HEARTBEAT_INTERVAL_SECONDS
     last_heartbeat_at: str | None = None
     last_command_id: str | None = None
@@ -46,6 +48,8 @@ class AgentConfig:
             cloud_url=data.get("cloud_url"),
             workspace_id=data.get("workspace_id"),
             device_token=data.get("device_token"),
+            fleet_device_id=data.get("fleet_device_id"),
+            fleet_device_token=data.get("fleet_device_token"),
             heartbeat_interval_seconds=int(
                 data.get("heartbeat_interval_seconds", DEFAULT_HEARTBEAT_INTERVAL_SECONDS)
             ),

--- a/src/tether/agent/daemon.py
+++ b/src/tether/agent/daemon.py
@@ -38,6 +38,10 @@ def run_once(
                 result = dict(result)
                 result["command_id"] = command_id
         _ack_command(client, config, command, result)
+        failure_upload = _upload_failure_event(client, config, command, result)
+        if failure_upload is not None:
+            result = dict(result)
+            result["failure_upload"] = failure_upload
         results.append(result)
 
     return {
@@ -155,6 +159,45 @@ def _client_poll_commands(client: Any, config: Any) -> Any:
     return _call_flexible(client.poll_commands)
 
 
+def _upload_failure_event(
+    client: Any,
+    config: Any,
+    command: Mapping[str, Any],
+    result: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    try:
+        from tether.agent.failures import build_failure_from_command_result
+    except ImportError:
+        return None
+
+    payload = build_failure_from_command_result(command, result, config=config)
+    if payload is None:
+        return None
+
+    device_id = _config_fleet_device_id(config)
+    token = _config_fleet_device_token(config)
+    client_token = getattr(client, "fleet_device_token", None)
+    if device_id is None:
+        return {"status": "skipped", "reason": "missing_fleet_device_id"}
+    if token is None and client_token is None:
+        return {"status": "skipped", "reason": "missing_fleet_device_token"}
+
+    create_failure = getattr(client, "create_failure", None)
+    if not callable(create_failure):
+        return {"status": "skipped", "reason": "client_missing_create_failure"}
+
+    try:
+        response = create_failure(str(device_id), payload, device_token=token)
+    except TypeError:
+        try:
+            response = create_failure(str(device_id), payload)
+        except Exception as exc:  # noqa: BLE001
+            return {"status": "failed", "reason": "failure_upload_failed", "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "failed", "reason": "failure_upload_failed", "error": str(exc)}
+    return {"status": "uploaded", "response": response}
+
+
 def _heartbeat_model(payload: Mapping[str, Any]) -> Any:
     try:
         from tether.agent.models import HeartbeatPayload
@@ -176,6 +219,29 @@ def _command_ack(command_id: Any, result: Mapping[str, Any]) -> Any:
 def _config_device_id(config: Any) -> str | None:
     value = getattr(config, "device_id", None)
     return str(value) if value is not None else None
+
+
+def _config_fleet_device_id(config: Any) -> str | None:
+    value = getattr(config, "fleet_device_id", None)
+    if value is not None:
+        return str(value)
+    if _looks_like_fleet_device_token(getattr(config, "device_token", None)):
+        return _config_device_id(config)
+    return None
+
+
+def _config_fleet_device_token(config: Any) -> str | None:
+    value = getattr(config, "fleet_device_token", None)
+    if value is not None:
+        return str(value)
+    device_token = getattr(config, "device_token", None)
+    if _looks_like_fleet_device_token(device_token):
+        return str(device_token)
+    return None
+
+
+def _looks_like_fleet_device_token(value: Any) -> bool:
+    return isinstance(value, str) and value.startswith(("dvc_live_", "dvc_test_"))
 
 
 def _call_flexible(method: Callable[..., Any], payload: Any | None = None) -> Any:

--- a/src/tether/agent/failures.py
+++ b/src/tether/agent/failures.py
@@ -1,0 +1,285 @@
+"""Failure-event producer helpers for Tether Agent."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from tether.agent.models import FailureEventPayload
+
+METADATA_SOFT_MAX_BYTES = 8 * 1024
+DIAGNOSTIC_SOFT_MAX_BYTES = 16 * 1024
+MAX_STRING_CHARS = 512
+
+_TOKEN_RE = re.compile(r"\b(?:dvc|fca|rc)_(?:live|test|dev)_[A-Za-z0-9._-]{6,}\b")
+_ABS_PATH_RE = re.compile(r"(?<!:)\/(?:[\w .-]+\/){1,}[\w .-]+")
+
+
+def build_failure_from_command_result(
+    command: Mapping[str, Any],
+    result: Mapping[str, Any],
+    *,
+    config: Any | None = None,
+) -> FailureEventPayload | None:
+    command_type = _command_type(command, result)
+    if command_type == "serve_status":
+        payload = _serve_status_failure(command, result, config=config)
+        if payload is not None:
+            return payload
+
+    if result.get("succeeded") is True:
+        return None
+
+    reason = _error_reason(result)
+    event_type = "unsupported_command" if reason == "unsupported_command" else "diagnostic_failure"
+    severity = "warning" if event_type == "unsupported_command" else "critical"
+    return FailureEventPayload(
+        event_type=event_type,
+        severity=severity,
+        started_at=_optional_float(result.get("started_at")),
+        ended_at=_optional_float(result.get("finished_at")),
+        do_not_train=True,
+        metadata=_bounded_json(
+            _base_metadata(command, result, config=config),
+            max_bytes=METADATA_SOFT_MAX_BYTES,
+        ),
+        diagnostic=_bounded_json(
+            {
+                "schema_version": 1,
+                "producer": "tether-agent",
+                "trigger": event_type,
+                "error_code": _sanitize_value(reason or event_type),
+                "summary": _summary_for(command_type, reason),
+                "command": _command_diagnostic(command, result),
+                "doctor": _doctor_diagnostic(result),
+                "redaction": _redaction_summary(),
+            },
+            max_bytes=DIAGNOSTIC_SOFT_MAX_BYTES,
+        ),
+    )
+
+
+def _serve_status_failure(
+    command: Mapping[str, Any],
+    result: Mapping[str, Any],
+    *,
+    config: Any | None = None,
+) -> FailureEventPayload | None:
+    output = result.get("output")
+    if not isinstance(output, Mapping):
+        return None if result.get("succeeded") is True else _fallback_failed_serve(command, result, config=config)
+
+    reachable = bool(output.get("reachable"))
+    ready = bool(output.get("ready"))
+    if reachable and ready:
+        return None
+
+    error_code = "serve_unreachable" if not reachable else "serve_not_ready"
+    return FailureEventPayload(
+        event_type="serve_unavailable",
+        severity="critical" if not reachable else "warning",
+        started_at=_optional_float(result.get("started_at")),
+        ended_at=_optional_float(result.get("finished_at")),
+        do_not_train=True,
+        metadata=_bounded_json(
+            _base_metadata(command, result, config=config),
+            max_bytes=METADATA_SOFT_MAX_BYTES,
+        ),
+        diagnostic=_bounded_json(
+            {
+                "schema_version": 1,
+                "producer": "tether-agent",
+                "trigger": "serve_unavailable",
+                "error_code": error_code,
+                "summary": "local serve endpoint is unreachable"
+                if not reachable
+                else "local serve endpoint is reachable but not ready",
+                "serve": _serve_diagnostic(output),
+                "command": _command_diagnostic(command, result),
+                "redaction": _redaction_summary(),
+            },
+            max_bytes=DIAGNOSTIC_SOFT_MAX_BYTES,
+        ),
+    )
+
+
+def _fallback_failed_serve(
+    command: Mapping[str, Any],
+    result: Mapping[str, Any],
+    *,
+    config: Any | None = None,
+) -> FailureEventPayload:
+    return FailureEventPayload(
+        event_type="serve_unavailable",
+        severity="critical",
+        started_at=_optional_float(result.get("started_at")),
+        ended_at=_optional_float(result.get("finished_at")),
+        do_not_train=True,
+        metadata=_bounded_json(_base_metadata(command, result, config=config), max_bytes=METADATA_SOFT_MAX_BYTES),
+        diagnostic=_bounded_json(
+            {
+                "schema_version": 1,
+                "producer": "tether-agent",
+                "trigger": "serve_unavailable",
+                "error_code": _sanitize_value(_error_reason(result) or "serve_failed"),
+                "summary": "serve status command failed",
+                "command": _command_diagnostic(command, result),
+                "redaction": _redaction_summary(),
+            },
+            max_bytes=DIAGNOSTIC_SOFT_MAX_BYTES,
+        ),
+    )
+
+
+def _base_metadata(command: Mapping[str, Any], result: Mapping[str, Any], *, config: Any | None) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "command_id": _command_id(command, result),
+        "command_type": _command_type(command, result),
+        "status": result.get("status"),
+    }
+    for attr in ("agent_version", "tether_version"):
+        value = getattr(config, attr, None) if config is not None else None
+        if value:
+            data[attr] = str(value)
+    return {key: _sanitize_value(value) for key, value in data.items() if value is not None}
+
+
+def _command_diagnostic(command: Mapping[str, Any], result: Mapping[str, Any]) -> dict[str, Any]:
+    diagnostic: dict[str, Any] = {
+        "id": _command_id(command, result),
+        "type": _command_type(command, result),
+    }
+    reason = _error_reason(result)
+    if reason:
+        diagnostic["reason"] = reason
+    exit_code = result.get("exit_code")
+    if exit_code is not None:
+        diagnostic["exit_code"] = exit_code
+    return {key: _sanitize_value(value) for key, value in diagnostic.items() if value is not None}
+
+
+def _doctor_diagnostic(result: Mapping[str, Any]) -> dict[str, Any] | None:
+    output = result.get("output")
+    if not isinstance(output, Mapping):
+        return None
+    summary = output.get("summary")
+    if not isinstance(summary, Mapping):
+        doctor = output.get("doctor")
+        summary = doctor.get("summary") if isinstance(doctor, Mapping) else None
+    if not isinstance(summary, Mapping):
+        return None
+    return {"summary": {key: int(summary.get(key, 0) or 0) for key in ("pass", "fail", "warn", "skip")}}
+
+
+def _serve_diagnostic(output: Mapping[str, Any]) -> dict[str, Any]:
+    health = output.get("health") if isinstance(output.get("health"), Mapping) else {}
+    config = output.get("config") if isinstance(output.get("config"), Mapping) else {}
+    return {
+        "reachable": bool(output.get("reachable")),
+        "ready": bool(output.get("ready")),
+        "health_status_code": health.get("status_code") if isinstance(health, Mapping) else None,
+        "config_status_code": config.get("status_code") if isinstance(config, Mapping) else None,
+        "health_error": _probe_error_reason(health),
+        "config_error": _probe_error_reason(config),
+    }
+
+
+def _probe_error_reason(value: Any) -> str | None:
+    if not isinstance(value, Mapping):
+        return None
+    error = value.get("error")
+    if isinstance(error, Mapping):
+        reason = error.get("reason")
+        return str(reason) if reason is not None else None
+    return None
+
+
+def _error_reason(result: Mapping[str, Any]) -> str | None:
+    error = result.get("error")
+    if isinstance(error, Mapping):
+        reason = error.get("reason") or error.get("error_code")
+        return str(reason) if reason is not None else None
+    if error:
+        return str(error)
+    return None
+
+
+def _summary_for(command_type: str, reason: str | None) -> str:
+    if command_type == "doctor":
+        return "doctor command failed"
+    if reason == "unsupported_command":
+        return "unsupported agent command failed"
+    return "agent command failed"
+
+
+def _redaction_summary() -> dict[str, str]:
+    return {
+        "stdout": "omitted",
+        "stderr": "omitted",
+        "traceback": "omitted",
+        "images": "none",
+        "instructions": "none",
+        "actions": "none",
+    }
+
+
+def _bounded_json(value: Mapping[str, Any], *, max_bytes: int) -> dict[str, Any]:
+    sanitized = _sanitize_value(value)
+    if not isinstance(sanitized, Mapping):
+        return {}
+    data = dict(sanitized)
+    encoded = json.dumps(data, sort_keys=True, default=str).encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return data
+    return {
+        "truncated": True,
+        "schema_version": data.get("schema_version", 1),
+        "producer": data.get("producer", "tether-agent"),
+        "trigger": data.get("trigger") or data.get("command_type") or "failure",
+        "error_code": data.get("error_code") or "payload_truncated",
+        "redaction": _redaction_summary(),
+    }
+
+
+def _sanitize_value(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _sanitize_text(value)
+    if isinstance(value, Mapping):
+        return {str(key): _sanitize_value(inner) for key, inner in value.items() if _safe_key(str(key))}
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_value(inner) for inner in value[:32]]
+    return _sanitize_text(str(value))
+
+
+def _safe_key(key: str) -> bool:
+    lowered = key.lower()
+    blocked = ("token", "secret", "password", "api_key", "authorization", "stdout", "stderr", "traceback")
+    return not any(part in lowered for part in blocked)
+
+
+def _sanitize_text(text: str) -> str:
+    cleaned = _TOKEN_RE.sub("[redacted-token]", text)
+    cleaned = _ABS_PATH_RE.sub("[redacted-path]", cleaned)
+    if len(cleaned) > MAX_STRING_CHARS:
+        return cleaned[:MAX_STRING_CHARS] + "...[truncated]"
+    return cleaned
+
+
+def _command_type(command: Mapping[str, Any], result: Mapping[str, Any]) -> str:
+    value = result.get("command_type") or command.get("type") or command.get("command_type") or command.get("name")
+    return str(value or "")
+
+
+def _command_id(command: Mapping[str, Any], result: Mapping[str, Any]) -> str | None:
+    value = result.get("command_id") or command.get("command_id") or command.get("id")
+    return str(value) if value is not None else None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)

--- a/src/tether/agent/models.py
+++ b/src/tether/agent/models.py
@@ -40,6 +40,8 @@ class EnrollResponse:
     device_token: str
     workspace_id: str
     heartbeat_interval_seconds: int = 30
+    fleet_device_id: str | None = None
+    fleet_device_token: str | None = None
 
     def to_dict(self) -> JsonDict:
         return asdict(self)
@@ -51,6 +53,8 @@ class EnrollResponse:
             device_token=str(data["device_token"]),
             workspace_id=str(data["workspace_id"]),
             heartbeat_interval_seconds=int(data.get("heartbeat_interval_seconds", 30)),
+            fleet_device_id=data.get("fleet_device_id"),
+            fleet_device_token=data.get("fleet_device_token"),
         )
 
 
@@ -182,4 +186,43 @@ class CommandAck:
             finished_at=data.get("finished_at"),
             output=_dict(data.get("output")),
             error=data.get("error"),
+        )
+
+
+@dataclass(slots=True)
+class FailureEventPayload:
+    event_type: str
+    severity: str = "warning"
+    started_at: float | None = None
+    ended_at: float | None = None
+    artifact_id: str | None = None
+    assignment_id: str | None = None
+    rollout_id: str | None = None
+    rollout_stage_id: str | None = None
+    rollout_device_step_id: str | None = None
+    operator_note: str | None = None
+    do_not_train: bool = True
+    metadata: JsonDict = field(default_factory=dict)
+    diagnostic: JsonDict = field(default_factory=dict)
+
+    def to_dict(self) -> JsonDict:
+        data = asdict(self)
+        return {key: value for key, value in data.items() if value is not None}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "FailureEventPayload":
+        return cls(
+            event_type=str(data["event_type"]),
+            severity=str(data.get("severity", "warning")),
+            started_at=data.get("started_at"),
+            ended_at=data.get("ended_at"),
+            artifact_id=data.get("artifact_id"),
+            assignment_id=data.get("assignment_id"),
+            rollout_id=data.get("rollout_id"),
+            rollout_stage_id=data.get("rollout_stage_id"),
+            rollout_device_step_id=data.get("rollout_device_step_id"),
+            operator_note=data.get("operator_note"),
+            do_not_train=bool(data.get("do_not_train", True)),
+            metadata=_dict(data.get("metadata")),
+            diagnostic=_dict(data.get("diagnostic")),
         )

--- a/src/tether/cli.py
+++ b/src/tether/cli.py
@@ -4870,12 +4870,14 @@ def _agent_client(agent_client: Any, cfg: Any = None, cloud_url: Optional[str] =
         raise typer.Exit(1)
 
     token = _agent_get(cfg, "device_token") if cfg is not None else None
+    fleet_token = _agent_get(cfg, "fleet_device_token") if cfg is not None else None
     resolved_cloud = cloud_url or _agent_get(cfg, "cloud_url")
     attempts = []
     if cfg is not None:
         attempts.append(lambda: cls(config=cfg))
     attempts.extend(
         (
+            lambda: cls(cloud_url=resolved_cloud, device_token=token, fleet_device_token=fleet_token),
             lambda: cls(cloud_url=resolved_cloud, device_token=token),
             lambda: cls(resolved_cloud, token),
             lambda: cls(resolved_cloud),
@@ -4940,6 +4942,8 @@ def _agent_config_from_enrollment(agent_config: Any, enrollment: Any, cloud_url:
             return cls(
                 device_id=_agent_get(enrollment, "device_id"),
                 device_token=_agent_get(enrollment, "device_token"),
+                fleet_device_id=_agent_get(enrollment, "fleet_device_id"),
+                fleet_device_token=_agent_get(enrollment, "fleet_device_token"),
                 cloud_url=cloud_url,
                 workspace_id=_agent_get(enrollment, "workspace_id"),
                 heartbeat_interval_seconds=_agent_get(
@@ -5021,6 +5025,7 @@ def _agent_status_payload(cfg: Any) -> dict[str, Any]:
         "device_id": _agent_get(cfg, "device_id"),
         "cloud_url": _agent_get(cfg, "cloud_url"),
         "workspace_id": _agent_get(cfg, "workspace_id"),
+        "fleet_device_id": _agent_get(cfg, "fleet_device_id"),
         "heartbeat_interval_seconds": _agent_get(
             cfg,
             "heartbeat_interval_seconds",
@@ -5135,6 +5140,7 @@ def agent_status(
         "device_id": "Device ID",
         "cloud_url": "Cloud URL",
         "workspace_id": "Workspace ID",
+        "fleet_device_id": "Fleet Device ID",
         "heartbeat_interval_seconds": "Heartbeat Interval",
         "last_heartbeat_at": "Last Heartbeat",
         "last_command_id": "Last Command ID",

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -61,6 +61,8 @@ def fake_agent_modules(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
             return {
                 "device_id": "dev_123",
                 "device_token": "tok_123",
+                "fleet_device_id": "dev_fleet_123",
+                "fleet_device_token": "dvc_test_123",
                 "cloud_url": self.cloud_url,
                 "workspace_id": "ws_123",
                 "heartbeat_interval_seconds": 30,
@@ -107,6 +109,7 @@ def test_agent_status_json(
         "device_id": "dev_123",
         "cloud_url": "https://cloud.example.test",
         "workspace_id": "ws_123",
+        "fleet_device_id": "dev_fleet_123",
         "heartbeat_interval_seconds": 30,
         "last_heartbeat_at": "2026-06-04T12:00:00Z",
         "last_command_id": "cmd_123",
@@ -121,6 +124,7 @@ def test_agent_status_json(
         "device_id": "dev_123",
         "cloud_url": "https://cloud.example.test",
         "workspace_id": "ws_123",
+        "fleet_device_id": "dev_fleet_123",
         "heartbeat_interval_seconds": 30,
         "last_heartbeat_at": "2026-06-04T12:00:00Z",
         "last_command_id": "cmd_123",
@@ -157,6 +161,8 @@ def test_agent_start_once_enrollment_path(
             {
                 "device_id": "dev_123",
                 "device_token": "tok_123",
+                "fleet_device_id": "dev_fleet_123",
+                "fleet_device_token": "dvc_test_123",
                 "cloud_url": "https://cloud.example.test",
                 "workspace_id": "ws_123",
                 "heartbeat_interval_seconds": 30,

--- a/tests/test_agent_client.py
+++ b/tests/test_agent_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tether.agent.client import AgentClient, AgentClientError
-from tether.agent.models import CommandAck, EnrollRequest, HeartbeatPayload
+from tether.agent.models import CommandAck, EnrollRequest, FailureEventPayload, HeartbeatPayload
 
 
 class FakeResponse:
@@ -116,11 +116,49 @@ def test_ack_command_posts_ack_payload():
     assert request["json"]["succeeded"] is True
 
 
+def test_create_failure_posts_to_fleet_failure_endpoint_with_fleet_token():
+    session = FakeSession([FakeResponse(payload={"failure": {"id": "fail_1"}})])
+    client = AgentClient(
+        "https://cloud.example.test",
+        device_token="fca_dev_control",
+        fleet_device_token="dvc_test_failure",
+        session=session,
+    )
+
+    client.create_failure(
+        "dev/fleet",
+        FailureEventPayload(
+            event_type="diagnostic_failure",
+            diagnostic={"schema_version": 1, "producer": "tether-agent"},
+        ),
+    )
+
+    request = session.requests[0]
+    assert request["method"] == "POST"
+    assert request["url"] == "https://cloud.example.test/fleet/devices/dev%2Ffleet/failures"
+    assert request["headers"]["Authorization"] == "Bearer dvc_test_failure"
+    assert request["json"]["event_type"] == "diagnostic_failure"
+    assert request["json"]["do_not_train"] is True
+    assert "workspace_id" not in request["json"]
+    assert "device_id" not in request["json"]
+
+
 def test_authenticated_calls_require_device_token():
     client = AgentClient("https://cloud.example.test", session=FakeSession([]))
 
     with pytest.raises(AgentClientError, match="device token"):
         client.poll_commands("dev_1")
+
+
+def test_failure_upload_requires_fleet_device_token():
+    client = AgentClient(
+        "https://cloud.example.test",
+        device_token="fca_dev_control",
+        session=FakeSession([]),
+    )
+
+    with pytest.raises(AgentClientError, match="fleet device token"):
+        client.create_failure("dev_1", {"event_type": "diagnostic_failure"})
 
 
 def test_http_errors_raise_client_error():

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -14,6 +14,8 @@ def test_config_round_trip_with_override_path(tmp_path):
         cloud_url="https://cloud.example.test",
         workspace_id="ws_123",
         device_token="tok_secret",
+        fleet_device_id="dev_fleet_123",
+        fleet_device_token="dvc_test_secret",
         heartbeat_interval_seconds=45,
         last_heartbeat_at="2026-06-04T12:00:00Z",
         last_command_id="cmd_1",

--- a/tests/test_agent_daemon.py
+++ b/tests/test_agent_daemon.py
@@ -10,14 +10,18 @@ class Config:
     device_id: str = "dev_1"
     cloud_url: str = "https://cloud.example"
     device_token: str = "tok"
+    fleet_device_id: str = "dev_fleet_1"
+    fleet_device_token: str = "dvc_test_1"
     heartbeat_interval_seconds: float = 30.0
 
 
 class FakeClient:
-    def __init__(self, commands=None):
+    def __init__(self, commands=None, fail_create_failure=False):
         self.commands = commands or []
         self.heartbeats = []
         self.acks = []
+        self.failures = []
+        self.fail_create_failure = fail_create_failure
 
     def heartbeat(self, payload):
         self.heartbeats.append(payload)
@@ -29,6 +33,13 @@ class FakeClient:
     def ack_command(self, command_id, result):
         self.acks.append((command_id, result))
         return {"ok": True}
+
+    def create_failure(self, device_id, payload, device_token=None):
+        if self.fail_create_failure:
+            raise RuntimeError("cloud unavailable")
+        body = payload.to_dict() if hasattr(payload, "to_dict") else dict(payload)
+        self.failures.append((device_id, body, device_token))
+        return {"failure": {"id": "fail_1"}}
 
 
 def test_run_once_heartbeat_and_no_commands():
@@ -57,3 +68,47 @@ def test_run_once_executes_noop_and_acks():
     assert command_id == "cmd_1"
     assert ack_result["command_id"] == "cmd_1"
     assert ack_result["succeeded"] is True
+    assert client.failures == []
+
+
+def test_run_once_uploads_failure_after_failed_command_ack():
+    client = FakeClient(commands=[{"id": "cmd_1", "type": "doctor"}])
+
+    def runner(command):
+        return {
+            "command_id": "cmd_1",
+            "command_type": "doctor",
+            "succeeded": False,
+            "status": "failed",
+            "error": {"reason": "doctor_exit_nonzero"},
+            "output": {"summary": {"pass": 0, "fail": 1, "warn": 0, "skip": 0}},
+        }
+
+    result = run_once(Config(), client, command_runner=runner, now=lambda: 100.0)
+
+    assert len(client.acks) == 1
+    assert len(client.failures) == 1
+    device_id, body, token = client.failures[0]
+    assert device_id == "dev_fleet_1"
+    assert token == "dvc_test_1"
+    assert body["event_type"] == "diagnostic_failure"
+    assert body["do_not_train"] is True
+    assert result["results"][0]["failure_upload"]["status"] == "uploaded"
+
+
+def test_run_once_failure_upload_error_does_not_block_ack():
+    client = FakeClient(commands=[{"id": "cmd_1", "type": "doctor"}], fail_create_failure=True)
+
+    def runner(command):
+        return {
+            "command_id": "cmd_1",
+            "command_type": "doctor",
+            "succeeded": False,
+            "status": "failed",
+            "error": {"reason": "doctor_exit_nonzero"},
+        }
+
+    result = run_once(Config(), client, command_runner=runner, now=lambda: 100.0)
+
+    assert len(client.acks) == 1
+    assert result["results"][0]["failure_upload"]["status"] == "failed"

--- a/tests/test_agent_failures.py
+++ b/tests/test_agent_failures.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from tether.agent.failures import build_failure_from_command_result
+
+
+class Config:
+    agent_version = "0.1.0"
+    tether_version = "0.12.0"
+
+
+def test_failed_doctor_result_builds_bounded_failure_payload():
+    command = {"id": "cmd_1", "type": "doctor"}
+    result = {
+        "command_id": "cmd_1",
+        "command_type": "doctor",
+        "succeeded": False,
+        "status": "failed",
+        "started_at": 10.0,
+        "finished_at": 12.0,
+        "stdout": "raw stdout with dvc_test_SECRETSECRET should not ship",
+        "stderr": "/Users/example/private/path should not ship",
+        "output": {"summary": {"pass": 2, "fail": 1, "warn": 0, "skip": 0}},
+        "error": {"reason": "doctor_exit_nonzero", "message": "failed at /Users/example/private/path"},
+    }
+
+    payload = build_failure_from_command_result(command, result, config=Config())
+
+    assert payload is not None
+    body = payload.to_dict()
+    assert body["event_type"] == "diagnostic_failure"
+    assert body["severity"] == "critical"
+    assert body["do_not_train"] is True
+    assert body["started_at"] == 10.0
+    assert body["ended_at"] == 12.0
+    assert "workspace_id" not in body
+    assert "device_id" not in body
+    assert "retention_days" not in body
+    assert body["metadata"] == {
+        "command_id": "cmd_1",
+        "command_type": "doctor",
+        "status": "failed",
+        "agent_version": "0.1.0",
+        "tether_version": "0.12.0",
+    }
+    assert body["diagnostic"]["error_code"] == "doctor_exit_nonzero"
+    assert body["diagnostic"]["doctor"]["summary"]["fail"] == 1
+    assert "stdout" not in str(body)
+    assert "stderr" not in str(body)
+    assert "SECRETSECRET" not in str(body)
+    assert "/Users/example" not in str(body)
+
+
+def test_successful_noop_does_not_emit_failure():
+    payload = build_failure_from_command_result(
+        {"id": "cmd_1", "type": "noop"},
+        {"command_id": "cmd_1", "command_type": "noop", "succeeded": True, "status": "succeeded"},
+    )
+
+    assert payload is None
+
+
+def test_unready_serve_status_emits_serve_unavailable():
+    payload = build_failure_from_command_result(
+        {"id": "cmd_2", "type": "serve_status"},
+        {
+            "command_id": "cmd_2",
+            "command_type": "serve_status",
+            "succeeded": True,
+            "status": "succeeded",
+            "output": {
+                "reachable": True,
+                "ready": False,
+                "health": {"ok": True, "status_code": 200},
+                "config": {"ok": False, "status_code": 503, "error": {"reason": "not_ready"}},
+                "url": "http://127.0.0.1:8000",
+            },
+        },
+    )
+
+    assert payload is not None
+    body = payload.to_dict()
+    assert body["event_type"] == "serve_unavailable"
+    assert body["severity"] == "warning"
+    assert body["diagnostic"]["error_code"] == "serve_not_ready"
+    assert "127.0.0.1" not in str(body)
+
+
+def test_oversized_diagnostic_is_truncated():
+    payload = build_failure_from_command_result(
+        {"id": "cmd_3", "type": "doctor"},
+        {
+            "command_id": "cmd_3",
+            "command_type": "doctor",
+            "succeeded": False,
+            "status": "failed",
+            "error": {"reason": "x" * 100_000},
+        },
+    )
+
+    assert payload is not None
+    body = payload.to_dict()
+    encoded = str(body["diagnostic"]).encode("utf-8")
+    assert len(encoded) < 16 * 1024


### PR DESCRIPTION
## Summary
- add bounded failure-event payloads and sanitization for Tether Agent command results
- post failures to Cloud Fleet failure ingest with explicit Fleet device credentials
- persist Fleet identity from Agent enrollment and keep failure upload best-effort after command ack

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -p no:cacheprovider tests/test_agent*.py -q
- PYTHONPATH=src ruff check src/tether/agent tests/test_agent_failures.py tests/test_agent_client.py tests/test_agent_config.py tests/test_agent_daemon.py tests/test_agent_cli.py
- git diff --check