### PR TITLE
feat(agent): emit route readiness telemetry

### DIFF
--- a/src/tether/agent/client.py
+++ b/src/tether/agent/client.py
@@ -14,6 +14,7 @@ from tether.agent.models import (
     EnrollRequest,
     EnrollResponse,
     FailureEventPayload,
+    FleetHeartbeatPayload,
     HeartbeatPayload,
     JsonDict,
 )
@@ -95,6 +96,28 @@ class AgentClient:
             json_body=body,
             auth=True,
             auth_token=failure_token,
+        )
+
+    def fleet_heartbeat(
+        self,
+        device_id: str,
+        payload: FleetHeartbeatPayload | Mapping[str, Any],
+        *,
+        device_token: str | None = None,
+    ) -> JsonDict:
+        heartbeat_token = device_token or self.fleet_device_token
+        if not heartbeat_token:
+            raise AgentClientError("fleet device token is required for fleet heartbeats")
+        if hasattr(payload, "to_dict"):
+            body = payload.to_dict()
+        else:
+            body = dict(payload)
+        return self._request(
+            "POST",
+            f"/fleet/devices/{urllib.parse.quote(device_id, safe='')}/heartbeat",
+            json_body=body,
+            auth=True,
+            auth_token=heartbeat_token,
         )
 
     def _request(

--- a/src/tether/agent/commands.py
+++ b/src/tether/agent/commands.py
@@ -5,15 +5,14 @@ import subprocess
 import time
 from collections.abc import Callable, Mapping
 from typing import Any
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+
+from tether.agent.resources import DEFAULT_SERVE_URL, collect_serve_status
 
 DEFAULT_DOCTOR_TIMEOUT_SECONDS = 60.0
-DEFAULT_SERVE_URL = "http://127.0.0.1:8000"
 MAX_OUTPUT_BYTES = 16 * 1024
 
 Runner = Callable[..., subprocess.CompletedProcess[str]]
-HttpGetJson = Callable[[str, float], tuple[int, Any]]
+HttpGetJson = Callable[..., tuple[int, Any]]
 
 
 def execute_command(
@@ -165,15 +164,11 @@ def run_serve_status_command(
 ) -> dict[str, Any]:
     base_url = _serve_url(command, config)
     timeout = float(_command_options(command).get("timeout_seconds", 3.0))
-    get_json = http_get_json or _http_get_json
-
-    health = _probe_json(get_json, f"{base_url}/health", timeout)
-    config_probe = _probe_json(get_json, f"{base_url}/config", timeout)
-    reachable = health["ok"] or config_probe["ok"]
-    ready = bool(
-        health["ok"]
-        and isinstance(health.get("body"), Mapping)
-        and health["body"].get("status") == "ok"
+    output = collect_serve_status(
+        base_url,
+        api_key=_serve_api_key(command, config),
+        timeout_seconds=timeout,
+        http_get_json=http_get_json,
     )
 
     return _result(
@@ -182,13 +177,7 @@ def run_serve_status_command(
         succeeded=True,
         started_at=started_at,
         finished_at=_timestamp(now),
-        output={
-            "url": base_url,
-            "reachable": reachable,
-            "ready": ready,
-            "health": health,
-            "config": config_probe,
-        },
+        output=output,
     )
 
 
@@ -205,46 +194,6 @@ def bound_result(result: Mapping[str, Any], *, max_bytes: int = MAX_OUTPUT_BYTES
 
 def _subprocess_runner(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
     return subprocess.run(argv, **kwargs)
-
-
-def _http_get_json(url: str, timeout: float) -> tuple[int, Any]:
-    request = Request(url, headers={"Accept": "application/json"})
-    with urlopen(request, timeout=timeout) as response:
-        body = response.read(MAX_OUTPUT_BYTES + 1)
-        text = body.decode("utf-8", errors="replace")
-        return int(response.status), json.loads(text)
-
-
-def _probe_json(get_json: HttpGetJson, url: str, timeout: float) -> dict[str, Any]:
-    try:
-        status_code, body = get_json(url, timeout)
-    except HTTPError as exc:
-        raw = exc.read(MAX_OUTPUT_BYTES + 1).decode("utf-8", errors="replace")
-        try:
-            body = json.loads(raw)
-        except json.JSONDecodeError:
-            body = raw
-        return {
-            "ok": False,
-            "status_code": exc.code,
-            "body": _truncate_jsonish(body, max_bytes=MAX_OUTPUT_BYTES),
-            "error": {"reason": "http_error"},
-        }
-    except (URLError, TimeoutError, OSError) as exc:
-        return {
-            "ok": False,
-            "status_code": None,
-            "body": None,
-            "error": {"reason": "unreachable", "message": str(exc)},
-        }
-    except json.JSONDecodeError as exc:
-        return {
-            "ok": False,
-            "status_code": None,
-            "body": None,
-            "error": {"reason": "malformed_json", "message": str(exc)},
-        }
-    return {"ok": 200 <= int(status_code) < 300, "status_code": status_code, "body": body}
 
 
 def _normalize_doctor_summary(payload: Mapping[str, Any]) -> dict[str, int]:
@@ -312,6 +261,14 @@ def _serve_url(command: Mapping[str, Any], config: Any | None) -> str:
     if not value and config is not None:
         value = getattr(config, "serve_url", None) or getattr(config, "local_serve_url", None)
     return str(value or DEFAULT_SERVE_URL).rstrip("/")
+
+
+def _serve_api_key(command: Mapping[str, Any], config: Any | None) -> str | None:
+    options = _command_options(command)
+    value = options.get("local_serve_api_key") or options.get("serve_api_key")
+    if not value and config is not None:
+        value = getattr(config, "local_serve_api_key", None) or getattr(config, "serve_api_key", None)
+    return str(value) if value else None
 
 
 def _command_options(command: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/tether/agent/config.py
+++ b/src/tether/agent/config.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
 
 from tether.agent.models import CommandResult, JsonDict
 
 DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30
+DEFAULT_LOCAL_SERVE_TIMEOUT_SECONDS = 3.0
 
 
 @dataclass(slots=True)
@@ -18,9 +19,12 @@ class AgentConfig:
     device_id: str | None = None
     cloud_url: str | None = None
     workspace_id: str | None = None
-    device_token: str | None = None
+    device_token: str | None = field(default=None, repr=False)
     fleet_device_id: str | None = None
-    fleet_device_token: str | None = None
+    fleet_device_token: str | None = field(default=None, repr=False)
+    local_serve_url: str | None = None
+    local_serve_api_key: str | None = field(default=None, repr=False)
+    local_serve_timeout_seconds: float = DEFAULT_LOCAL_SERVE_TIMEOUT_SECONDS
     heartbeat_interval_seconds: int = DEFAULT_HEARTBEAT_INTERVAL_SECONDS
     last_heartbeat_at: str | None = None
     last_command_id: str | None = None
@@ -50,6 +54,11 @@ class AgentConfig:
             device_token=data.get("device_token"),
             fleet_device_id=data.get("fleet_device_id"),
             fleet_device_token=data.get("fleet_device_token"),
+            local_serve_url=data.get("local_serve_url", data.get("serve_url")),
+            local_serve_api_key=data.get("local_serve_api_key", data.get("serve_api_key")),
+            local_serve_timeout_seconds=float(
+                data.get("local_serve_timeout_seconds", DEFAULT_LOCAL_SERVE_TIMEOUT_SECONDS)
+            ),
             heartbeat_interval_seconds=int(
                 data.get("heartbeat_interval_seconds", DEFAULT_HEARTBEAT_INTERVAL_SECONDS)
             ),

--- a/src/tether/agent/daemon.py
+++ b/src/tether/agent/daemon.py
@@ -22,8 +22,10 @@ def run_once(
     now: Callable[[], float] | None = None,
 ) -> dict[str, Any]:
     timestamp = _timestamp(now)
-    heartbeat_payload = _heartbeat_payload(config, timestamp)
+    route_readiness = _collect_route_readiness(config, timestamp)
+    heartbeat_payload = _heartbeat_payload(config, timestamp, route_readiness=route_readiness)
     heartbeat_response = _client_heartbeat(client, config, heartbeat_payload)
+    fleet_heartbeat = _client_fleet_readiness_heartbeat(client, config, route_readiness, timestamp)
 
     raw_commands = _client_poll_commands(client, config)
     commands = _normalize_commands(raw_commands)
@@ -46,6 +48,7 @@ def run_once(
 
     return {
         "heartbeat": heartbeat_response,
+        "fleet_heartbeat": fleet_heartbeat,
         "commands_polled": len(commands),
         "commands_executed": len(results),
         "results": results,
@@ -85,7 +88,12 @@ def run_forever(
             signal.signal(signal.SIGINT, old_handler)
 
 
-def _heartbeat_payload(config: Any, observed_at: float) -> dict[str, Any]:
+def _heartbeat_payload(
+    config: Any,
+    observed_at: float,
+    *,
+    route_readiness: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     payload = {
         "device_id": getattr(config, "device_id", None),
         "observed_at": observed_at,
@@ -97,7 +105,32 @@ def _heartbeat_payload(config: Any, observed_at: float) -> dict[str, Any]:
         value = getattr(config, attr, None)
         if value is not None:
             payload[attr] = value
+    if isinstance(route_readiness, Mapping):
+        serve_status = route_readiness.get("serve_status")
+        if isinstance(serve_status, Mapping):
+            payload["serve_status"] = dict(serve_status)
+    doctor_summary = _doctor_summary_from_config(config)
+    if doctor_summary is not None:
+        payload["doctor_summary"] = doctor_summary
     return payload
+
+
+def _collect_route_readiness(config: Any, observed_at: float) -> dict[str, Any]:
+    try:
+        from tether.agent.resources import collect_route_readiness
+    except ImportError:
+        return {}
+    try:
+        return collect_route_readiness(config, observed_at=observed_at)
+    except Exception:  # noqa: BLE001
+        return {
+            "schema_version": 1,
+            "producer": "tether-agent",
+            "observed_at": observed_at,
+            "serve_reachable": False,
+            "serve_ready": False,
+            "errors": [{"probe": "readiness", "reason": "collector_failed"}],
+        }
 
 
 def _collect_hardware_profile() -> Any | None:
@@ -198,6 +231,53 @@ def _upload_failure_event(
     return {"status": "uploaded", "response": response}
 
 
+def _client_fleet_readiness_heartbeat(
+    client: Any,
+    config: Any,
+    route_readiness: Mapping[str, Any],
+    observed_at: float,
+) -> dict[str, Any]:
+    device_id = _config_fleet_device_id(config)
+    token = _config_fleet_device_token(config)
+    client_token = getattr(client, "fleet_device_token", None)
+    if device_id is None:
+        return {"status": "skipped", "reason": "missing_fleet_device_id"}
+    if token is None and client_token is None:
+        return {"status": "skipped", "reason": "missing_fleet_device_token"}
+
+    fleet_heartbeat = getattr(client, "fleet_heartbeat", None)
+    if not callable(fleet_heartbeat):
+        return {"status": "skipped", "reason": "client_missing_fleet_heartbeat"}
+
+    payload = _fleet_readiness_payload(config, route_readiness, observed_at)
+    try:
+        response = fleet_heartbeat(str(device_id), payload, device_token=token)
+    except TypeError:
+        try:
+            response = fleet_heartbeat(str(device_id), payload)
+        except Exception as exc:  # noqa: BLE001
+            return {"status": "failed", "reason": "fleet_heartbeat_failed", "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "failed", "reason": "fleet_heartbeat_failed", "error": str(exc)}
+    return {"status": "posted", "response": response, "payload": payload}
+
+
+def _fleet_readiness_payload(
+    config: Any,
+    route_readiness: Mapping[str, Any],
+    observed_at: float,
+) -> dict[str, Any]:
+    try:
+        from tether.agent.resources import fleet_readiness_heartbeat_payload
+    except ImportError:
+        return {"extra": {"route_readiness": dict(route_readiness)}}
+    return fleet_readiness_heartbeat_payload(
+        config,
+        route_readiness=route_readiness,
+        observed_at=observed_at,
+    )
+
+
 def _heartbeat_model(payload: Mapping[str, Any]) -> Any:
     try:
         from tether.agent.models import HeartbeatPayload
@@ -214,6 +294,24 @@ def _command_ack(command_id: Any, result: Mapping[str, Any]) -> Any:
     payload = dict(result)
     payload["command_id"] = str(command_id)
     return CommandAck.from_dict(payload)
+
+
+def _doctor_summary_from_config(config: Any) -> dict[str, int] | None:
+    result = getattr(config, "last_command_result", None)
+    if result is None:
+        return None
+    output = getattr(result, "output", None)
+    if output is None and isinstance(result, Mapping):
+        output = result.get("output")
+    if not isinstance(output, Mapping):
+        return None
+    summary = output.get("summary")
+    if not isinstance(summary, Mapping):
+        doctor = output.get("doctor")
+        summary = doctor.get("summary") if isinstance(doctor, Mapping) else None
+    if not isinstance(summary, Mapping):
+        return None
+    return {key: int(summary.get(key, 0) or 0) for key in ("pass", "fail", "warn", "skip")}
 
 
 def _config_device_id(config: Any) -> str | None:

--- a/src/tether/agent/models.py
+++ b/src/tether/agent/models.py
@@ -12,6 +12,12 @@ def _dict(value: Mapping[str, Any] | None) -> JsonDict:
     return dict(value or {})
 
 
+def _optional_float(value: Any) -> float | None:
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    return float(value)
+
+
 @dataclass(slots=True)
 class EnrollRequest:
     enroll_token: str
@@ -83,6 +89,8 @@ class HeartbeatPayload:
     agent_version: str | None = None
     tether_version: str | None = None
     hardware_profile: JsonDict = field(default_factory=dict)
+    serve_status: JsonDict = field(default_factory=dict)
+    doctor_summary: JsonDict = field(default_factory=dict)
     last_command_id: str | None = None
     last_command_result: CommandResult | JsonDict | None = None
     last_heartbeat_at: str | None = None
@@ -110,9 +118,42 @@ class HeartbeatPayload:
             agent_version=data.get("agent_version"),
             tether_version=data.get("tether_version"),
             hardware_profile=_dict(data.get("hardware_profile")),
+            serve_status=_dict(data.get("serve_status")),
+            doctor_summary=_dict(data.get("doctor_summary")),
             last_command_id=data.get("last_command_id"),
             last_command_result=parsed_result,
             last_heartbeat_at=data.get("last_heartbeat_at"),
+        )
+
+
+@dataclass(slots=True)
+class FleetHeartbeatPayload:
+    latency_p50_ms: float | None = None
+    latency_p95_ms: float | None = None
+    latency_p99_ms: float | None = None
+    mem_used_mb: float | None = None
+    gpu_util_pct: float | None = None
+    action_chunks_completed: int = 0
+    failure_count: int = 0
+    artifact_version: str | None = None
+    extra: JsonDict = field(default_factory=dict)
+
+    def to_dict(self) -> JsonDict:
+        data = asdict(self)
+        return {key: value for key, value in data.items() if value is not None}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "FleetHeartbeatPayload":
+        return cls(
+            latency_p50_ms=_optional_float(data.get("latency_p50_ms")),
+            latency_p95_ms=_optional_float(data.get("latency_p95_ms")),
+            latency_p99_ms=_optional_float(data.get("latency_p99_ms")),
+            mem_used_mb=_optional_float(data.get("mem_used_mb")),
+            gpu_util_pct=_optional_float(data.get("gpu_util_pct")),
+            action_chunks_completed=int(data.get("action_chunks_completed", 0) or 0),
+            failure_count=int(data.get("failure_count", 0) or 0),
+            artifact_version=data.get("artifact_version"),
+            extra=_dict(data.get("extra")),
         )
 
 

--- a/src/tether/agent/resources.py
+++ b/src/tether/agent/resources.py
@@ -1,0 +1,597 @@
+"""Bounded local readiness and resource collection for Agent heartbeats."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+import urllib.parse
+from collections.abc import Callable, Mapping
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+JsonDict = dict[str, Any]
+HttpGetJson = Callable[..., tuple[int, Any]]
+
+DEFAULT_SERVE_URL = "http://127.0.0.1:8000"
+DEFAULT_SERVE_TIMEOUT_SECONDS = 3.0
+MAX_OUTPUT_BYTES = 16 * 1024
+MAX_STRING_CHARS = 512
+
+_TOKEN_RE = re.compile(r"\b(?:dvc|fca|rc)_(?:live|test|dev)_[A-Za-z0-9._-]{6,}\b")
+_ABS_PATH_RE = re.compile(r"(?<!:)\/(?:[\w .-]+\/){1,}[\w .-]+")
+
+
+def collect_serve_status(
+    serve_url: str | None = None,
+    *,
+    api_key: str | None = None,
+    timeout_seconds: float = DEFAULT_SERVE_TIMEOUT_SECONDS,
+    http_get_json: HttpGetJson | None = None,
+) -> JsonDict:
+    """Probe local ``tether serve`` health/config without leaking secrets."""
+    base_url = _normalize_serve_url(serve_url)
+    get_json = http_get_json or _http_get_json
+    headers = _auth_headers(api_key)
+
+    health = _probe_json(get_json, f"{base_url}/health", timeout_seconds)
+    config_probe = _probe_json(get_json, f"{base_url}/config", timeout_seconds, headers=headers)
+    reachable = bool(health["ok"] or config_probe["ok"])
+    ready = bool(
+        health["ok"]
+        and isinstance(health.get("body"), Mapping)
+        and (
+            health["body"].get("status") == "ok"
+            or health["body"].get("state") in {"ready", "ok", "healthy"}
+        )
+    )
+
+    return _bounded_mapping(
+        {
+            "url": _safe_url(base_url),
+            "reachable": reachable,
+            "ready": ready,
+            "health": health,
+            "config": config_probe,
+        },
+        max_bytes=MAX_OUTPUT_BYTES,
+    )
+
+
+def collect_route_readiness(
+    config: Any | None = None,
+    *,
+    observed_at: float | None = None,
+    http_get_json: HttpGetJson | None = None,
+) -> JsonDict:
+    """Collect route-readiness evidence for Fleet telemetry."""
+    timestamp = time.time() if observed_at is None else float(observed_at)
+    serve_url = _config_value(config, "local_serve_url", "serve_url") or DEFAULT_SERVE_URL
+    api_key = _config_value(config, "local_serve_api_key", "serve_api_key")
+    timeout = _optional_float(
+        _config_value(config, "local_serve_timeout_seconds", "serve_timeout_seconds")
+    ) or DEFAULT_SERVE_TIMEOUT_SECONDS
+
+    serve_status = collect_serve_status(
+        str(serve_url),
+        api_key=str(api_key) if api_key else None,
+        timeout_seconds=timeout,
+        http_get_json=http_get_json,
+    )
+    health_body = _body_mapping(serve_status.get("health"))
+    config_body = _body_mapping(serve_status.get("config"))
+    artifact_identity = _artifact_identity(config, health_body, config_body)
+    runtime = _runtime_identity(config, health_body, config_body)
+    resource_pressure = collect_resource_pressure()
+
+    readiness: JsonDict = {
+        "schema_version": 1,
+        "producer": "tether-agent",
+        "observed_at": timestamp,
+        "serve_url_kind": _serve_url_kind(str(serve_url)),
+        "serve_reachable": bool(serve_status.get("reachable")),
+        "serve_ready": bool(serve_status.get("ready")),
+        "serve_status": _serve_status_summary(serve_status),
+        "resource_pressure": resource_pressure,
+        "errors": _serve_errors(serve_status),
+    }
+    if artifact_identity:
+        readiness["artifact_identity"] = artifact_identity
+    if runtime:
+        readiness["runtime"] = runtime
+    return _bounded_mapping(readiness, max_bytes=MAX_OUTPUT_BYTES)
+
+
+def fleet_readiness_heartbeat_payload(
+    config: Any | None,
+    *,
+    route_readiness: Mapping[str, Any] | None = None,
+    observed_at: float | None = None,
+    http_get_json: HttpGetJson | None = None,
+) -> JsonDict:
+    readiness = dict(
+        route_readiness
+        or collect_route_readiness(config, observed_at=observed_at, http_get_json=http_get_json)
+    )
+    resource_pressure = readiness.get("resource_pressure")
+    if not isinstance(resource_pressure, Mapping):
+        resource_pressure = {}
+    artifact_identity = readiness.get("artifact_identity")
+    if not isinstance(artifact_identity, Mapping):
+        artifact_identity = {}
+
+    payload: JsonDict = {
+        "action_chunks_completed": int(
+            _config_value(config, "action_chunks_completed", "fleet_action_chunks_completed") or 0
+        ),
+        "failure_count": int(_config_value(config, "failure_count", "fleet_failure_count") or 0),
+        "extra": {"route_readiness": readiness},
+    }
+    for key in ("latency_p50_ms", "latency_p95_ms", "latency_p99_ms"):
+        value = _optional_float(_config_value(config, key))
+        if value is not None:
+            payload[key] = value
+    mem_used = _first_number(resource_pressure, "mem_used_mb", "memory_used_mb")
+    gpu_util = _first_number(resource_pressure, "gpu_util_pct", "gpu_utilization_pct")
+    artifact_version = _first_string(
+        artifact_identity,
+        "artifact_version",
+        "artifact_id",
+        "registry_artifact_id",
+        "id",
+    ) or _config_value(config, "artifact_version", "current_artifact_version")
+    if mem_used is not None:
+        payload["mem_used_mb"] = mem_used
+    if gpu_util is not None:
+        payload["gpu_util_pct"] = gpu_util
+    if artifact_version:
+        payload["artifact_version"] = str(artifact_version)
+    return _bounded_mapping(payload, max_bytes=MAX_OUTPUT_BYTES)
+
+
+def collect_resource_pressure() -> JsonDict:
+    pressure: JsonDict = {}
+    _add_memory_pressure(pressure)
+    _add_gpu_pressure(pressure)
+    _add_thermal_pressure(pressure)
+    pressure["pressure"] = _has_pressure(pressure)
+    return _bounded_mapping(pressure, max_bytes=MAX_OUTPUT_BYTES)
+
+
+def _http_get_json(url: str, timeout: float, headers: Mapping[str, str] | None = None) -> tuple[int, Any]:
+    request = Request(url, headers={"Accept": "application/json", **dict(headers or {})})
+    with urlopen(request, timeout=timeout) as response:
+        body = response.read(MAX_OUTPUT_BYTES + 1)
+        text = body.decode("utf-8", errors="replace")
+        return int(response.status), json.loads(text)
+
+
+def _probe_json(
+    get_json: HttpGetJson,
+    url: str,
+    timeout: float,
+    *,
+    headers: Mapping[str, str] | None = None,
+) -> JsonDict:
+    try:
+        status_code, body = _call_get_json(get_json, url, timeout, headers)
+    except HTTPError as exc:
+        raw = exc.read(MAX_OUTPUT_BYTES + 1).decode("utf-8", errors="replace")
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            body = raw
+        return {
+            "ok": False,
+            "status_code": exc.code,
+            "body": _sanitize_value(body),
+            "error": {"reason": "http_error"},
+        }
+    except (URLError, TimeoutError, OSError) as exc:
+        return {
+            "ok": False,
+            "status_code": None,
+            "body": None,
+            "error": {"reason": "unreachable", "message": _sanitize_text(str(exc))},
+        }
+    except json.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "status_code": None,
+            "body": None,
+            "error": {"reason": "malformed_json", "message": _sanitize_text(str(exc))},
+        }
+    return {
+        "ok": 200 <= int(status_code) < 300,
+        "status_code": int(status_code),
+        "body": _sanitize_value(body),
+    }
+
+
+def _call_get_json(
+    get_json: HttpGetJson,
+    url: str,
+    timeout: float,
+    headers: Mapping[str, str] | None,
+) -> tuple[int, Any]:
+    try:
+        return get_json(url, timeout, dict(headers or {}))
+    except TypeError:
+        return get_json(url, timeout)
+
+
+def _normalize_serve_url(value: str | None) -> str:
+    return str(value or DEFAULT_SERVE_URL).rstrip("/")
+
+
+def _auth_headers(api_key: str | None) -> dict[str, str]:
+    if not api_key:
+        return {}
+    return {"Authorization": f"Bearer {api_key}", "X-Tether-Key": api_key}
+
+
+def _body_mapping(probe: Any) -> Mapping[str, Any]:
+    if isinstance(probe, Mapping) and isinstance(probe.get("body"), Mapping):
+        return probe["body"]
+    return {}
+
+
+def _serve_status_summary(serve_status: Mapping[str, Any]) -> JsonDict:
+    health = serve_status.get("health") if isinstance(serve_status.get("health"), Mapping) else {}
+    config = serve_status.get("config") if isinstance(serve_status.get("config"), Mapping) else {}
+    health_body = _body_mapping(health)
+    config_body = _body_mapping(config)
+    summary: JsonDict = {
+        "reachable": bool(serve_status.get("reachable")),
+        "ready": bool(serve_status.get("ready")),
+        "health_status_code": health.get("status_code") if isinstance(health, Mapping) else None,
+        "config_status_code": config.get("status_code") if isinstance(config, Mapping) else None,
+    }
+    for key in ("status", "state", "model_loaded", "inference_mode", "robot_id"):
+        if key in health_body:
+            summary[key] = health_body[key]
+    for key in ("robot_id", "runtime", "runtime_name", "artifact_version"):
+        if key in config_body:
+            summary.setdefault(key, config_body[key])
+    return {key: value for key, value in _sanitize_value(summary).items() if value is not None}
+
+
+def _serve_errors(serve_status: Mapping[str, Any]) -> list[JsonDict]:
+    errors: list[JsonDict] = []
+    for name in ("health", "config"):
+        probe = serve_status.get(name)
+        if not isinstance(probe, Mapping) or probe.get("ok"):
+            continue
+        error = probe.get("error")
+        errors.append(
+            {
+                "probe": name,
+                "status_code": probe.get("status_code"),
+                "reason": error.get("reason") if isinstance(error, Mapping) else None,
+            }
+        )
+    return [error for error in errors if error.get("reason") or error.get("status_code") is not None]
+
+
+def _artifact_identity(
+    config: Any | None,
+    health_body: Mapping[str, Any],
+    config_body: Mapping[str, Any],
+) -> JsonDict:
+    identity: JsonDict = {}
+    aliases = {
+        "artifact_id": ("artifact_id", "registry_artifact_id"),
+        "artifact_version": ("artifact_version", "current_artifact_version", "model_version"),
+        "optimized_artifact_digest": ("optimized_artifact_digest", "artifact_digest", "digest"),
+        "runtime": ("runtime", "runtime_name", "inference_mode"),
+        "target_hardware_class": ("target_hardware_class", "target_sku", "target"),
+    }
+    for out_key, keys in aliases.items():
+        value = _first_source_value(config, health_body, config_body, keys)
+        if value:
+            identity[out_key] = str(value)
+    return _bounded_mapping(identity, max_bytes=MAX_OUTPUT_BYTES)
+
+
+def _runtime_identity(
+    config: Any | None,
+    health_body: Mapping[str, Any],
+    config_body: Mapping[str, Any],
+) -> JsonDict:
+    runtime: JsonDict = {}
+    name = _first_source_value(
+        config,
+        health_body,
+        config_body,
+        ("runtime", "runtime_name", "inference_mode"),
+    )
+    if name:
+        runtime["name"] = str(name)
+    for key in ("robot_id", "model_loaded", "vlm_loaded"):
+        value = _first_source_value(config, health_body, config_body, (key,))
+        if value is not None:
+            runtime[key] = value
+    return _bounded_mapping(runtime, max_bytes=MAX_OUTPUT_BYTES)
+
+
+def _first_source_value(
+    config: Any | None,
+    health_body: Mapping[str, Any],
+    config_body: Mapping[str, Any],
+    keys: tuple[str, ...],
+) -> Any:
+    for key in keys:
+        value = _config_value(config, key)
+        if value not in (None, ""):
+            return value
+    for source in (config_body, health_body):
+        value = _first_value(source, keys)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _first_value(source: Mapping[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        if key in source:
+            return source[key]
+    return None
+
+
+def _config_value(config: Any | None, *names: str) -> Any:
+    if config is None:
+        return None
+    for name in names:
+        value = getattr(config, name, None)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _add_memory_pressure(out: JsonDict) -> None:
+    meminfo = _read_proc_meminfo()
+    total_kb = meminfo.get("MemTotal")
+    available_kb = meminfo.get("MemAvailable")
+    if total_kb and available_kb is not None:
+        total_mb = total_kb / 1024.0
+        available_mb = available_kb / 1024.0
+        used_mb = max(0.0, total_mb - available_mb)
+        out["mem_used_mb"] = round(used_mb, 3)
+        out["mem_total_mb"] = round(total_mb, 3)
+        out["memory_pressure_pct"] = round((used_mb / total_mb) * 100.0, 3)
+
+
+def _read_proc_meminfo() -> dict[str, float]:
+    path = "/proc/meminfo"
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return {}
+    values: dict[str, float] = {}
+    for line in lines:
+        if ":" not in line:
+            continue
+        key, raw = line.split(":", 1)
+        parts = raw.strip().split()
+        if parts:
+            try:
+                values[key] = float(parts[0])
+            except ValueError:
+                continue
+    return values
+
+
+def _add_gpu_pressure(out: JsonDict) -> None:
+    output = _run(
+        [
+            "nvidia-smi",
+            "--query-gpu=utilization.gpu,memory.used,memory.total,temperature.gpu",
+            "--format=csv,noheader,nounits",
+        ]
+    )
+    if not output:
+        return
+    first = output.splitlines()[0]
+    parts = [part.strip() for part in first.split(",")]
+    if len(parts) >= 1:
+        out["gpu_util_pct"] = _optional_float(parts[0])
+    if len(parts) >= 3:
+        used = _optional_float(parts[1])
+        total = _optional_float(parts[2])
+        if used is not None:
+            out["gpu_mem_used_mb"] = used
+        if total:
+            out["gpu_mem_total_mb"] = total
+            if used is not None:
+                out["gpu_memory_pressure_pct"] = round((used / total) * 100.0, 3)
+    if len(parts) >= 4:
+        out["gpu_temperature_c"] = _optional_float(parts[3])
+
+
+def _add_thermal_pressure(out: JsonDict) -> None:
+    thermal_root = "/sys/class/thermal"
+    try:
+        entries = os.listdir(thermal_root)
+    except OSError:
+        return
+    max_temp_c: float | None = None
+    for entry in entries[:32]:
+        temp_path = os.path.join(thermal_root, entry, "temp")
+        try:
+            with open(temp_path, "r", encoding="utf-8") as fh:
+                raw = fh.read().strip()
+        except OSError:
+            continue
+        value = _optional_float(raw)
+        if value is None:
+            continue
+        temp_c = value / 1000.0 if value > 1000 else value
+        max_temp_c = temp_c if max_temp_c is None else max(max_temp_c, temp_c)
+    if max_temp_c is not None:
+        out["max_thermal_c"] = round(max_temp_c, 3)
+        out["thermal_throttled"] = max_temp_c >= 85.0
+
+
+def _has_pressure(data: Mapping[str, Any]) -> bool:
+    for key in ("memory_pressure_pct", "gpu_memory_pressure_pct"):
+        value = _optional_float(data.get(key))
+        if value is not None and value >= 90.0:
+            return True
+    gpu_util = _optional_float(data.get("gpu_util_pct"))
+    if gpu_util is not None and gpu_util >= 98.0:
+        return True
+    for key in ("gpu_temperature_c", "max_thermal_c"):
+        value = _optional_float(data.get(key))
+        if value is not None and value >= 85.0:
+            return True
+    return bool(data.get("thermal_throttled"))
+
+
+def _run(command: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2.0,
+        )
+    except Exception:
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
+def _serve_url_kind(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value)
+    host = (parsed.hostname or "").lower()
+    if host in {"127.0.0.1", "localhost", "::1"}:
+        return "loopback"
+    if host.startswith(("10.", "192.168.")) or (
+        host.startswith("172.") and _host_second_octet_in_private_range(host)
+    ):
+        return "private"
+    return "remote" if host else "unknown"
+
+
+def _host_second_octet_in_private_range(host: str) -> bool:
+    try:
+        second = int(host.split(".")[1])
+    except (IndexError, ValueError):
+        return False
+    return 16 <= second <= 31
+
+
+def _safe_url(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value)
+    netloc = parsed.hostname or ""
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    return urllib.parse.urlunsplit((parsed.scheme, netloc, parsed.path.rstrip("/"), "", ""))
+
+
+def _bounded_mapping(value: Mapping[str, Any], *, max_bytes: int) -> JsonDict:
+    sanitized = _sanitize_value(dict(value))
+    if not isinstance(sanitized, Mapping):
+        return {}
+    data = dict(sanitized)
+    encoded = json.dumps(data, sort_keys=True, default=str).encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return data
+    return {
+        "truncated": True,
+        "schema_version": data.get("schema_version", 1),
+        "producer": data.get("producer", "tether-agent"),
+    }
+
+
+def _sanitize_value(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _sanitize_text(value)
+    if isinstance(value, Mapping):
+        return {
+            str(key): _sanitize_value(inner)
+            for key, inner in value.items()
+            if _safe_key(str(key), inner)
+        }
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_value(inner) for inner in value[:32]]
+    return _sanitize_text(str(value))
+
+
+def _safe_key(key: str, value: Any) -> bool:
+    lowered = key.lower()
+    blocked = (
+        "token",
+        "secret",
+        "password",
+        "api_key",
+        "apikey",
+        "authorization",
+        "credential",
+        "signed_url",
+        "stdout",
+        "stderr",
+        "traceback",
+        "env",
+        "path",
+        "uri",
+    )
+    if any(part in lowered for part in blocked):
+        return False
+    return not (isinstance(value, str) and _looks_like_unsafe_path(value))
+
+
+def _sanitize_text(text: str) -> str:
+    if _looks_like_url(text):
+        cleaned = _safe_url(text)
+    else:
+        cleaned = _ABS_PATH_RE.sub("[redacted-path]", text)
+    cleaned = _TOKEN_RE.sub("[redacted-token]", cleaned)
+    if len(cleaned) > MAX_STRING_CHARS:
+        return cleaned[:MAX_STRING_CHARS] + "...[truncated]"
+    return cleaned
+
+
+def _looks_like_url(value: str) -> bool:
+    parsed = urllib.parse.urlsplit(value)
+    return bool(parsed.scheme and parsed.netloc)
+
+
+def _looks_like_unsafe_path(value: str) -> bool:
+    if _looks_like_url(value):
+        return False
+    return bool(_ABS_PATH_RE.search(value))
+
+
+def _first_number(source: Mapping[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        value = _optional_float(source.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _first_string(source: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = source.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/test_agent_client.py
+++ b/tests/test_agent_client.py
@@ -143,6 +143,34 @@ def test_create_failure_posts_to_fleet_failure_endpoint_with_fleet_token():
     assert "device_id" not in request["json"]
 
 
+def test_fleet_heartbeat_posts_to_fleet_endpoint_with_fleet_device_token():
+    session = FakeSession([FakeResponse(payload={"ok": True})])
+    client = AgentClient(
+        "https://cloud.example.test",
+        device_token="fca_dev_control",
+        fleet_device_token="dvc_test_heartbeat",
+        session=session,
+    )
+
+    client.fleet_heartbeat(
+        "dev/fleet",
+        {
+            "latency_p99_ms": 42.0,
+            "mem_used_mb": 1024.0,
+            "artifact_version": "art_1",
+            "extra": {"route_readiness": {"serve_ready": True}},
+        },
+    )
+
+    request = session.requests[0]
+    assert request["method"] == "POST"
+    assert request["url"] == "https://cloud.example.test/fleet/devices/dev%2Ffleet/heartbeat"
+    assert request["headers"]["Authorization"] == "Bearer dvc_test_heartbeat"
+    assert request["json"]["latency_p99_ms"] == 42.0
+    assert request["json"]["artifact_version"] == "art_1"
+    assert request["json"]["extra"]["route_readiness"]["serve_ready"] is True
+
+
 def test_authenticated_calls_require_device_token():
     client = AgentClient("https://cloud.example.test", session=FakeSession([]))
 
@@ -159,6 +187,17 @@ def test_failure_upload_requires_fleet_device_token():
 
     with pytest.raises(AgentClientError, match="fleet device token"):
         client.create_failure("dev_1", {"event_type": "diagnostic_failure"})
+
+
+def test_fleet_heartbeat_requires_fleet_device_token():
+    client = AgentClient(
+        "https://cloud.example.test",
+        device_token="fca_dev_control",
+        session=FakeSession([]),
+    )
+
+    with pytest.raises(AgentClientError, match="fleet device token"):
+        client.fleet_heartbeat("dev_1", {"extra": {"route_readiness": {}}})
 
 
 def test_http_errors_raise_client_error():

--- a/tests/test_agent_commands.py
+++ b/tests/test_agent_commands.py
@@ -159,3 +159,36 @@ def test_serve_status_ready_fake_server():
     assert result["output"]["ready"] is True
     assert result["output"]["health"]["body"]["state"] == "ready"
     assert result["output"]["config"]["body"]["robot_id"] == "robot_1"
+
+
+def test_serve_status_uses_local_api_key_and_sanitizes_response():
+    calls = []
+
+    def get_json(url, timeout, headers=None):
+        calls.append((url, dict(headers or {})))
+        if url.endswith("/health"):
+            return 200, {"status": "ok", "state": "ready", "export_dir": "/tmp/secret/model"}
+        assert headers["Authorization"] == "Bearer serve_secret"
+        return 200, {
+            "robot_id": "robot_1",
+            "api_key": "serve_secret",
+            "signed_url": "https://example.test/blob?token=secret",
+        }
+
+    result = execute_command(
+        {
+            "id": "cmd_1",
+            "type": "serve_status",
+            "serve_url": "http://127.0.0.1:9999",
+            "local_serve_api_key": "serve_secret",
+        },
+        http_get_json=get_json,
+        now=lambda: 10.0,
+    )
+    rendered = json.dumps(result, sort_keys=True)
+
+    assert result["output"]["ready"] is True
+    assert calls[1][1]["Authorization"] == "Bearer serve_secret"
+    assert "serve_secret" not in rendered
+    assert "signed_url" not in rendered
+    assert "/tmp/secret/model" not in rendered

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -16,6 +16,9 @@ def test_config_round_trip_with_override_path(tmp_path):
         device_token="tok_secret",
         fleet_device_id="dev_fleet_123",
         fleet_device_token="dvc_test_secret",
+        local_serve_url="http://127.0.0.1:8181",
+        local_serve_api_key="serve_secret",
+        local_serve_timeout_seconds=2.5,
         heartbeat_interval_seconds=45,
         last_heartbeat_at="2026-06-04T12:00:00Z",
         last_command_id="cmd_1",
@@ -27,6 +30,20 @@ def test_config_round_trip_with_override_path(tmp_path):
 
     assert saved_path == path
     assert loaded == config
+
+
+def test_config_repr_omits_token_like_values():
+    config = AgentConfig(
+        device_token="tok_secret",
+        fleet_device_token="dvc_test_secret",
+        local_serve_api_key="serve_secret",
+    )
+
+    rendered = repr(config)
+
+    assert "tok_secret" not in rendered
+    assert "dvc_test_secret" not in rendered
+    assert "serve_secret" not in rendered
 
 
 def test_load_config_returns_none_when_missing(tmp_path):

--- a/tests/test_agent_daemon.py
+++ b/tests/test_agent_daemon.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
 
 from tether.agent.daemon import run_once
 
@@ -12,16 +15,20 @@ class Config:
     device_token: str = "tok"
     fleet_device_id: str = "dev_fleet_1"
     fleet_device_token: str = "dvc_test_1"
+    local_serve_url: str = "http://127.0.0.1:1"
+    local_serve_api_key: str | None = None
     heartbeat_interval_seconds: float = 30.0
 
 
 class FakeClient:
-    def __init__(self, commands=None, fail_create_failure=False):
+    def __init__(self, commands=None, fail_create_failure=False, fail_fleet_heartbeat=False):
         self.commands = commands or []
         self.heartbeats = []
+        self.fleet_heartbeats = []
         self.acks = []
         self.failures = []
         self.fail_create_failure = fail_create_failure
+        self.fail_fleet_heartbeat = fail_fleet_heartbeat
 
     def heartbeat(self, payload):
         self.heartbeats.append(payload)
@@ -41,6 +48,13 @@ class FakeClient:
         self.failures.append((device_id, body, device_token))
         return {"failure": {"id": "fail_1"}}
 
+    def fleet_heartbeat(self, device_id, payload, device_token=None):
+        if self.fail_fleet_heartbeat:
+            raise RuntimeError("fleet unavailable")
+        body = payload.to_dict() if hasattr(payload, "to_dict") else dict(payload)
+        self.fleet_heartbeats.append((device_id, body, device_token))
+        return {"telemetry": {"id": "tel_1"}}
+
 
 def test_run_once_heartbeat_and_no_commands():
     client = FakeClient()
@@ -54,6 +68,83 @@ def test_run_once_heartbeat_and_no_commands():
     assert client.heartbeats[0]["observed_at"] == 100.0
     assert client.heartbeats[0]["cloud_url"] == "https://cloud.example"
     assert client.acks == []
+    assert len(client.fleet_heartbeats) == 1
+
+
+def test_run_once_posts_agent_and_fleet_readiness_from_fake_ready_serve():
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(
+                    json.dumps(
+                        {
+                            "status": "ok",
+                            "state": "ready",
+                            "inference_mode": "onnx",
+                            "robot_id": "robot_1",
+                            "export_dir": "/tmp/secret/model",
+                        }
+                    ).encode()
+                )
+                return
+            if self.path == "/config":
+                assert self.headers["Authorization"] == "Bearer serve_secret"
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(
+                    json.dumps(
+                        {
+                            "robot_id": "robot_1",
+                            "artifact_version": "art_1",
+                            "optimized_artifact_digest": "sha256:abc",
+                            "target_sku": "orin",
+                            "signed_url": "https://example.test/model?token=secret",
+                            "device_token": "dvc_test_should_not_leak",
+                        }
+                    ).encode()
+                )
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        config = Config(
+            local_serve_url=f"http://127.0.0.1:{server.server_port}",
+            local_serve_api_key="serve_secret",
+        )
+        client = FakeClient()
+
+        result = run_once(config, client, now=lambda: 100.0)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert len(client.heartbeats) == 1
+    assert client.heartbeats[0]["serve_status"]["ready"] is True
+    assert len(client.fleet_heartbeats) == 1
+    device_id, payload, token = client.fleet_heartbeats[0]
+    readiness = payload["extra"]["route_readiness"]
+    rendered = json.dumps(payload, sort_keys=True)
+    assert result["fleet_heartbeat"]["status"] == "posted"
+    assert device_id == "dev_fleet_1"
+    assert token == "dvc_test_1"
+    assert payload["artifact_version"] == "art_1"
+    assert readiness["serve_ready"] is True
+    assert readiness["runtime"]["name"] == "onnx"
+    assert readiness["artifact_identity"]["optimized_artifact_digest"] == "sha256:abc"
+    assert "signed_url" not in rendered
+    assert "dvc_test_should_not_leak" not in rendered
+    assert "/tmp/secret/model" not in rendered
 
 
 def test_run_once_executes_noop_and_acks():
@@ -112,3 +203,14 @@ def test_run_once_failure_upload_error_does_not_block_ack():
 
     assert len(client.acks) == 1
     assert result["results"][0]["failure_upload"]["status"] == "failed"
+
+
+def test_run_once_fleet_readiness_error_does_not_block_command_ack():
+    client = FakeClient(commands=[{"id": "cmd_1", "type": "noop"}], fail_fleet_heartbeat=True)
+
+    result = run_once(Config(), client, now=lambda: 100.0)
+
+    assert len(client.acks) == 1
+    assert result["fleet_heartbeat"]["status"] == "failed"
+    assert result["fleet_heartbeat"]["reason"] == "fleet_heartbeat_failed"
+    assert result["commands_executed"] == 1

--- a/tests/test_agent_hardware.py
+++ b/tests/test_agent_hardware.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from tether.agent.hardware import collect_hardware_profile
+from tether.agent.resources import collect_resource_pressure, collect_route_readiness
 
 
 def test_hardware_profile_never_raises_and_is_json_serializable():
@@ -23,3 +24,43 @@ def test_hardware_profile_never_raises_and_is_json_serializable():
     }
     assert isinstance(profile["platform"], str)
     assert isinstance(profile["python"], str)
+
+
+def test_resource_pressure_never_raises_and_is_json_serializable():
+    pressure = collect_resource_pressure()
+
+    json.dumps(pressure, sort_keys=True)
+    assert isinstance(pressure, dict)
+    assert "pressure" in pressure
+
+
+def test_route_readiness_sanitizes_tokens_signed_urls_and_paths():
+    def get_json(url, timeout, headers=None):
+        if url.endswith("/health"):
+            return 200, {
+                "status": "ok",
+                "state": "ready",
+                "inference_mode": "onnx",
+                "export_dir": "/tmp/secret/model",
+            }
+        return 200, {
+            "artifact_version": "art_1",
+            "optimized_artifact_digest": "sha256:abc",
+            "target_sku": "orin",
+            "signed_url": "https://example.test/model?token=secret",
+            "device_token": "dvc_test_should_not_leak",
+        }
+
+    readiness = collect_route_readiness(
+        None,
+        observed_at=100.0,
+        http_get_json=get_json,
+    )
+    rendered = json.dumps(readiness, sort_keys=True)
+
+    assert readiness["serve_ready"] is True
+    assert readiness["artifact_identity"]["artifact_version"] == "art_1"
+    assert readiness["runtime"]["name"] == "onnx"
+    assert "/tmp/secret/model" not in rendered
+    assert "signed_url" not in rendered
+    assert "dvc_test_should_not_leak" not in rendered

--- a/tests/test_vlm_prefix.py
+++ b/tests/test_vlm_prefix.py
@@ -11,20 +11,14 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 import torch
-import torch.nn as nn
 
 from tether.exporters.vlm_prefix_exporter import (
-    DEFAULT_IMAGE_SIZE,
-    DEFAULT_PREFIX_SEQ_LEN,
     DEFAULT_VLM_KV_DIM,
-    VisionEncoderForONNX,
-    export_vlm_prefix,
 )
 from tether.runtime.vlm_components import (
     HIDDEN_SIZE,
@@ -605,10 +599,12 @@ class TestOrchestratorGracefulDegradation:
                 return mock_vision_session
             raise FileNotFoundError(f"Not found: {path}")
 
-        with patch.dict("sys.modules", {}):
-            import onnxruntime
-            with patch.object(onnxruntime, "InferenceSession", side_effect=mock_session_init):
-                from tether.runtime.vlm_orchestrator import VLMPrefixOrchestrator
+        fake_ort = MagicMock()
+        fake_ort.InferenceSession.side_effect = mock_session_init
+        with patch.dict("sys.modules", {"onnxruntime": fake_ort}):
+            with patch.object(
+                VLMPrefixOrchestrator, "_load_tokenizer_and_processor"
+            ):
                 orch = VLMPrefixOrchestrator(tmp_path, config)
 
                 assert orch.is_loaded
@@ -623,10 +619,10 @@ class TestOrchestratorGracefulDegradation:
         (tmp_path / "tether_config.json").write_text(json.dumps(config))
         # No ONNX files created
 
-        from tether.runtime.vlm_orchestrator import VLMPrefixOrchestrator
-        orch = VLMPrefixOrchestrator(tmp_path, config)
+        with patch.object(VLMPrefixOrchestrator, "_load_tokenizer_and_processor"):
+            orch = VLMPrefixOrchestrator(tmp_path, config)
 
-        assert not orch.is_loaded
+            assert not orch.is_loaded
 
 
 # ---------------------------------------------------------------------------
@@ -685,11 +681,10 @@ class TestOrchestratorFullPipeline:
             "input_ids": np.ones((1, 32), dtype=np.int64),
         }
 
-        import onnxruntime
-        with patch.object(onnxruntime, "InferenceSession", side_effect=mock_ort_init):
-            with patch.object(
-                VLMPrefixOrchestrator, "_load_tokenizer_and_processor"
-            ):
+        fake_ort = MagicMock()
+        fake_ort.InferenceSession.side_effect = mock_ort_init
+        with patch.dict("sys.modules", {"onnxruntime": fake_ort}):
+            with patch.object(VLMPrefixOrchestrator, "_load_tokenizer_and_processor"):
                 orch = VLMPrefixOrchestrator(tmp_path, config)
                 orch._tokenizer = mock_tokenizer
 


### PR DESCRIPTION
## Summary
- add bounded Tether route-readiness collection from local serve health/config, resource pressure, runtime identity, and artifact identity
- add Fleet heartbeat emission via existing dvc_* credentials with extra.route_readiness
- keep Fleet readiness post best-effort so command ack/failure upload continue
- sanitize token-like fields, signed URLs, env-ish keys, auth headers, and unsafe local paths

## Validation
- PYTHONPATH=src pytest tests/test_agent_client.py tests/test_agent_daemon.py tests/test_agent_commands.py tests/test_agent_config.py tests/test_agent_hardware.py -q -> 34 passed
- PYTHONPATH=src ruff check src/tether/agent tests/test_agent_client.py tests/test_agent_daemon.py tests/test_agent_commands.py tests/test_agent_config.py tests/test_agent_hardware.py -> passed
- git diff --check -> passed
- cross-repo smoke: Tether readiness payload consumed by Cloud router returned edge with no token leak

## Scope held
- no hot-path fallback
- no billing/quota writes
- no Fleet/Registry/Rollout mutation
- no raw camera/action payloads