### PR TITLE
Publish Improve worker outputs and add Modal wrapper

### DIFF
--- a/scripts/real_improve_worker_modal.py
+++ b/scripts/real_improve_worker_modal.py
@@ -1,0 +1,120 @@
+"""Run the FastCrest Improve worker contract on Modal.
+
+This is the credentialed smoke wrapper for the Cloud Improve worker path. It
+does not talk to the Cloud database and it does not write Registry/Fleet state.
+Cloud builds ``fastcrest.improve.worker_input.v1``; this script runs the
+Tether-owned worker in Modal and returns a ``fastcrest.improve.worker_result.v1``
+envelope that Cloud can ingest through the existing Improve APIs.
+
+Usage:
+    modal run scripts/real_improve_worker_modal.py \\
+        --worker-input worker_input.json \\
+        --output-uri s3://<bucket>/improve/<job_id>/ \\
+        --gpu A10G
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import modal
+
+app = modal.App("fastcrest-real-improve-worker")
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REMOTE_REPO = "/workspace/tether"
+
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("git")
+    .pip_install(
+        "boto3>=1.34",
+        "pydantic>=2.0",
+        "pyyaml>=6.0",
+        "rich>=13.0",
+        "typer>=0.9.0",
+    )
+    .add_local_dir(
+        _REPO_ROOT,
+        _REMOTE_REPO,
+        copy=True,
+        ignore=[
+            ".git",
+            ".mypy_cache",
+            ".pytest_cache",
+            ".ruff_cache",
+            ".venv",
+            "build",
+            "dist",
+            "**/__pycache__",
+            "*.pyc",
+        ],
+    )
+    .run_commands(f"cd {_REMOTE_REPO} && pip install -e .")
+)
+
+
+@app.function(image=image, timeout=3600, scaledown_window=60)
+def run_worker_remote(
+    worker_input: dict[str, Any],
+    *,
+    output_uri: str,
+    result_pretty: bool = False,
+) -> dict[str, Any]:
+    import os
+    import time
+    from pathlib import Path
+
+    from tether.finetune.improve_worker import run_improve_worker
+
+    job_id = str(worker_input.get("job_id") or "unknown_job")
+    run_dir = Path("/tmp/fastcrest_improve_worker") / job_id
+    started = time.time()
+    result = run_improve_worker(
+        worker_input,
+        output_dir=run_dir,
+        output_uri=output_uri,
+        now=started,
+    )
+    result.setdefault("metadata", {})
+    result["metadata"] = {
+        **dict(result.get("metadata") or {}),
+        "modal_app": "fastcrest-real-improve-worker",
+        "modal_smoke": True,
+        "modal_gpu_requested": os.environ.get("MODAL_GPU", "unknown"),
+        "elapsed_s": time.time() - started,
+    }
+    if result_pretty:
+        print(json.dumps(result, indent=2, sort_keys=True), flush=True)
+    else:
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")), flush=True)
+    return result
+
+
+@app.local_entrypoint()
+def main(
+    worker_input: str,
+    output_uri: str,
+    gpu: str = "A10G",
+    timeout_seconds: int = 3600,
+    result_output: str = "",
+    pretty: bool = False,
+) -> None:
+    if not output_uri:
+        raise SystemExit("--output-uri is required")
+    payload = json.loads(Path(worker_input).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit("--worker-input must be a JSON object")
+
+    runner = run_worker_remote.with_options(gpu=gpu, timeout=timeout_seconds)
+    result = runner.remote(payload, output_uri=output_uri, result_pretty=pretty)
+    encoded = json.dumps(
+        result,
+        indent=2 if pretty else None,
+        sort_keys=True,
+        separators=None if pretty else (",", ":"),
+    )
+    if result_output:
+        Path(result_output).write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)

--- a/src/tether/finetune/improve_worker.py
+++ b/src/tether/finetune/improve_worker.py
@@ -17,11 +17,14 @@ import argparse
 import hashlib
 import json
 import math
+import os
+import shutil
 import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
+from urllib.parse import urlparse
 
 
 WORKER_INPUT_CONTRACT_VERSION = "fastcrest.improve.worker_input.v1"
@@ -90,6 +93,7 @@ def run_improve_worker(
     worker_input: Mapping[str, Any],
     *,
     output_dir: str | Path | None = None,
+    output_uri: str | None = None,
     now: float | None = None,
 ) -> dict[str, Any]:
     """Run the deterministic local Improve worker.
@@ -112,12 +116,13 @@ def run_improve_worker(
                 f"dry-run worker failed by request: {failure_mode}",
                 failure_mode=failure_mode,
             )
+        publish_uri = output_uri or _optional_output_uri(runner_config)
         materialized = materialize_selected_evidence(
             payload,
             output_dir=output_dir,
             now=time.time() if now is None else now,
         )
-        return _success_result(payload, materialized)
+        return _success_result(payload, materialized, output_uri=publish_uri)
     except ImproveWorkerError as exc:
         return _failure_result(context, exc.code, str(exc))
     except (OSError, TypeError, ValueError) as exc:
@@ -259,6 +264,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run the Tether Improve dry-run worker.")
     parser.add_argument("--worker-input", required=True, help="Worker input JSON file, or '-' for stdin.")
     parser.add_argument("--output-dir", help="Directory for local dry-run artifacts.")
+    parser.add_argument("--output-uri", help="Publish worker artifacts to this file:// or s3:// prefix.")
     parser.add_argument("--result-output", "--output", dest="result_output", help="Write result JSON here.")
     parser.add_argument("--pretty", action="store_true", help="Pretty-print result JSON.")
     args = parser.parse_args(argv)
@@ -268,7 +274,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     except (OSError, json.JSONDecodeError) as exc:
         result = _failure_result({}, "invalid_worker_input", f"could not read worker input: {exc}")
     else:
-        result = run_improve_worker(payload, output_dir=args.output_dir)
+        result = run_improve_worker(payload, output_dir=args.output_dir, output_uri=args.output_uri)
 
     encoded = json.dumps(
         result,
@@ -286,6 +292,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 def _success_result(
     payload: Mapping[str, Any],
     materialized: MaterializedEvidence,
+    *,
+    output_uri: str | None,
 ) -> dict[str, Any]:
     artifact_path = materialized.output_dir / "candidate_artifact.json"
     metrics = _metrics(payload)
@@ -355,6 +363,30 @@ def _success_result(
             "modal_gpu_follow_up_command": modal_command,
         },
     }
+    if output_uri:
+        published = _publish_worker_outputs(
+            output_uri,
+            {
+                "candidate_artifact.json": artifact_path,
+                "selected_evidence_manifest.json": materialized.manifest_path,
+                "training_log.jsonl": log_path,
+                "VERIFICATION.md": verification_path,
+            },
+        )
+        result["artifact_uri"] = published["candidate_artifact.json"]
+        result["outputs"] = {
+            **result["outputs"],
+            "manifest_uri": published["selected_evidence_manifest.json"],
+            "training_log_uri": published["training_log.jsonl"],
+            "verification_md_uri": published["VERIFICATION.md"],
+            "final_checkpoint_uri": published["candidate_artifact.json"],
+        }
+        result["metadata"] = {
+            **result["metadata"],
+            "output_uri": _normalize_output_uri(output_uri),
+            "output_published": True,
+            "published_files": published,
+        }
     result["worker_result_hash"] = _hash_payload(result)
     return result
 
@@ -681,6 +713,86 @@ def _write_verification_md(
     )
 
 
+def _publish_worker_outputs(output_uri: str, files: Mapping[str, Path]) -> dict[str, str]:
+    normalized = _normalize_output_uri(output_uri)
+    parsed = urlparse(normalized)
+    if parsed.scheme == "file":
+        return _publish_file_outputs(parsed, files)
+    if parsed.scheme == "s3":
+        return _publish_s3_outputs(parsed, files)
+    raise ImproveWorkerError(
+        "output_publish_failed",
+        f"unsupported output_uri scheme: {parsed.scheme or '<local>'}",
+    )
+
+
+def _publish_file_outputs(parsed, files: Mapping[str, Path]) -> dict[str, str]:  # type: ignore[no-untyped-def]
+    if not parsed.path:
+        raise ImproveWorkerError("output_publish_failed", "file output_uri must include a path")
+    output_dir = Path(parsed.path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    published: dict[str, str] = {}
+    for name, source in files.items():
+        source_path = Path(source)
+        if not source_path.exists() or not source_path.is_file():
+            raise ImproveWorkerError(
+                "output_publish_failed",
+                f"worker output missing before publish: {source_path}",
+            )
+        destination = output_dir / name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source_path.resolve() != destination.resolve():
+            shutil.copy2(source_path, destination)
+        published[name] = destination.resolve().as_uri()
+    return published
+
+
+def _publish_s3_outputs(parsed, files: Mapping[str, Path]) -> dict[str, str]:  # type: ignore[no-untyped-def]
+    if not parsed.netloc:
+        raise ImproveWorkerError("output_publish_failed", "s3 output_uri must include a bucket")
+    try:
+        import boto3  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise ImproveWorkerError("output_publish_failed", "s3 output_uri requires boto3") from exc
+
+    endpoint_url = (
+        os.environ.get("AWS_ENDPOINT_URL")
+        or os.environ.get("S3_ENDPOINT_URL")
+        or os.environ.get("R2_ENDPOINT_URL")
+    )
+    client_kwargs = {"endpoint_url": endpoint_url} if endpoint_url else {}
+    client = boto3.client("s3", **client_kwargs)
+    bucket = parsed.netloc
+    prefix = parsed.path.strip("/")
+    published: dict[str, str] = {}
+    for name, source in files.items():
+        source_path = Path(source)
+        if not source_path.exists() or not source_path.is_file():
+            raise ImproveWorkerError(
+                "output_publish_failed",
+                f"worker output missing before publish: {source_path}",
+            )
+        key = f"{prefix}/{name}" if prefix else name
+        client.upload_file(str(source_path), bucket, key)
+        published[name] = f"s3://{bucket}/{key}"
+    return published
+
+
+def _normalize_output_uri(output_uri: str) -> str:
+    value = str(output_uri or "").strip().rstrip("/")
+    if not value:
+        raise ImproveWorkerError("output_publish_failed", "output_uri is required")
+    parsed = urlparse(value)
+    if parsed.scheme:
+        if parsed.scheme not in {"file", "s3"}:
+            raise ImproveWorkerError(
+                "output_publish_failed",
+                f"unsupported output_uri scheme: {parsed.scheme}",
+            )
+        return value
+    return Path(value).resolve().as_uri()
+
+
 def _resolve_output_dir(payload: Mapping[str, Any], output_dir: str | Path | None) -> Path:
     if output_dir is None:
         return Path.cwd() / "tether_improve_worker" / str(payload.get("job_id") or "unknown_job")
@@ -689,7 +801,16 @@ def _resolve_output_dir(payload: Mapping[str, Any], output_dir: str | Path | Non
 
 def _modal_follow_up_command(payload: Mapping[str, Any]) -> str:
     job_id = str(payload.get("job_id") or "<job_id>")
-    return MODAL_GPU_FOLLOW_UP_COMMAND.replace("<job_id>", job_id)
+    output_uri = _optional_output_uri(_object(payload.get("runner_config")))
+    command = MODAL_GPU_FOLLOW_UP_COMMAND
+    if output_uri:
+        command = command.replace("s3://<bucket>/improve/<job_id>/", output_uri.rstrip("/"))
+    return command.replace("<job_id>", job_id)
+
+
+def _optional_output_uri(runner_config: Mapping[str, Any]) -> str | None:
+    value = str(runner_config.get("output_uri") or "").strip()
+    return value or None
 
 
 def _requested_failure_mode(

--- a/tests/test_improve_worker.py
+++ b/tests/test_improve_worker.py
@@ -135,6 +135,57 @@ def test_valid_worker_input_materializes_selected_evidence_and_result(tmp_path: 
     ]
 
 
+def test_output_uri_publishes_artifacts_and_rewrites_result_uris(tmp_path: Path) -> None:
+    output_uri = (tmp_path / "published" / "imp_job_1").resolve().as_uri()
+
+    result = run_improve_worker(
+        _worker_input(runner_config={"output_uri": output_uri}),
+        output_dir=tmp_path / "runs",
+        output_uri=output_uri,
+        now=1.0,
+    )
+
+    published_dir = tmp_path / "published" / "imp_job_1"
+    assert result["ok"] is True
+    assert result["artifact_uri"] == (published_dir / "candidate_artifact.json").resolve().as_uri()
+    assert result["outputs"]["manifest_uri"] == (
+        published_dir / "selected_evidence_manifest.json"
+    ).resolve().as_uri()
+    assert result["outputs"]["training_log_uri"] == (
+        published_dir / "training_log.jsonl"
+    ).resolve().as_uri()
+    assert result["outputs"]["verification_md_uri"] == (
+        published_dir / "VERIFICATION.md"
+    ).resolve().as_uri()
+    assert (published_dir / "candidate_artifact.json").exists()
+    assert (published_dir / "selected_evidence_manifest.json").exists()
+    assert (published_dir / "training_log.jsonl").exists()
+    assert (published_dir / "VERIFICATION.md").exists()
+    assert result["metadata"]["output_uri"] == output_uri
+    assert result["metadata"]["output_published"] is True
+    assert result["metadata"]["published_files"]["candidate_artifact.json"] == result["artifact_uri"]
+    assert output_uri in result["metadata"]["modal_gpu_follow_up_command"]
+
+
+def test_runner_config_output_uri_publishes_without_separate_argument(tmp_path: Path) -> None:
+    output_uri = (tmp_path / "published-from-config").resolve().as_uri()
+
+    result = run_improve_worker(
+        _worker_input(runner_config={"output_uri": output_uri}),
+        output_dir=tmp_path / "runs",
+        now=1.0,
+    )
+
+    published_dir = tmp_path / "published-from-config"
+    assert result["ok"] is True
+    assert result["artifact_uri"] == (published_dir / "candidate_artifact.json").resolve().as_uri()
+    assert result["outputs"]["manifest_uri"] == (
+        published_dir / "selected_evidence_manifest.json"
+    ).resolve().as_uri()
+    assert result["metadata"]["output_uri"] == output_uri
+    assert output_uri in result["metadata"]["modal_gpu_follow_up_command"]
+
+
 def test_selected_id_enforcement_rejects_unselected_evidence(tmp_path: Path) -> None:
     payload = _worker_input(failure_evidence=[_failure("fail_1"), _failure("fail_2")])
 
@@ -199,6 +250,7 @@ def test_malformed_input_returns_failure_envelope_not_traceback() -> None:
 def test_module_cli_writes_worker_result(tmp_path: Path) -> None:
     input_path = tmp_path / "worker_input.json"
     output_path = tmp_path / "worker_result.json"
+    published_dir = tmp_path / "published"
     input_path.write_text(json.dumps(_worker_input()), encoding="utf-8")
 
     completed = _run_module_cli(
@@ -207,6 +259,8 @@ def test_module_cli_writes_worker_result(tmp_path: Path) -> None:
         str(input_path),
         "--output-dir",
         str(tmp_path / "runs"),
+        "--output-uri",
+        published_dir.resolve().as_uri(),
         "--result-output",
         str(output_path),
     )
@@ -214,7 +268,10 @@ def test_module_cli_writes_worker_result(tmp_path: Path) -> None:
     assert completed.returncode == 0, completed.stderr
     result = json.loads(output_path.read_text(encoding="utf-8"))
     assert result["ok"] is True
-    assert result["outputs"]["manifest_uri"].startswith("file://")
+    assert result["artifact_uri"] == (published_dir / "candidate_artifact.json").resolve().as_uri()
+    assert result["outputs"]["manifest_uri"] == (
+        published_dir / "selected_evidence_manifest.json"
+    ).resolve().as_uri()
     assert MODAL_GPU_FOLLOW_UP_COMMAND.split(" --worker-input")[0] in (
         result["metadata"]["modal_gpu_follow_up_command"]
     )
@@ -231,6 +288,20 @@ def test_module_cli_malformed_input_prints_failure_without_traceback(tmp_path: P
     result = json.loads(completed.stdout)
     assert result["ok"] is False
     assert result["error_code"] == "invalid_worker_input"
+
+
+def test_modal_follow_up_script_exists_and_uses_worker_contract() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "real_improve_worker_modal.py"
+    source = script.read_text(encoding="utf-8")
+
+    assert script.exists()
+    assert "fastcrest.improve.worker_input.v1" in source
+    assert "fastcrest.improve.worker_result.v1" in source
+    assert "run_improve_worker" in source
+    assert "output_uri" in source
+    assert "with_options(gpu=gpu" in source
+    assert "modal run scripts/real_improve_worker_modal.py" in MODAL_GPU_FOLLOW_UP_COMMAND
 
 
 def _run_module_cli(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
Adds output_uri publishing for the Improve worker to file:// and s3:// prefixes, rewrites result URIs to published artifacts, carries output publication metadata, and adds a Modal wrapper for credentialed smoke runs through the existing worker contract. Validation: PYTHONPATH=src pytest tests/test_improve_worker.py -q; python -m py_compile scripts/real_improve_worker_modal.py; runtime import check for scripts/real_improve_worker_modal.py; git diff --check.