### PR TITLE
Add cloud burst dry-run contract

### DIFF
--- a/src/tether/runtime/cloud_burst_contract.py
+++ b/src/tether/runtime/cloud_burst_contract.py
@@ -1,0 +1,256 @@
+"""Contract helpers for Tether -> FastCrest Cloud burst validation.
+
+The helpers in this module build and validate the dry-run handoff payload used
+before online Cloud GPU burst is enabled. They do not proxy `/act`, execute a
+remote model, or send raw local files.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Callable, Mapping
+from urllib import request as urllib_request
+from urllib.parse import urlparse
+
+
+BURST_SCHEMA_VERSION = "cloud_burst_validation.v0"
+DEFAULT_TIMEOUT_S = 2.0
+
+_SENSITIVE_KEY_PARTS = {
+    "authorization",
+    "api_key",
+    "bearer",
+    "credential",
+    "device_token",
+    "password",
+    "plaintext",
+    "secret",
+    "signed_url",
+    "token",
+}
+_RAW_KEY_PARTS = {
+    "action_data",
+    "action_trace",
+    "camera",
+    "frame",
+    "image",
+    "joint_positions",
+    "local_path",
+    "raw_action",
+    "raw_observation",
+    "video",
+}
+_SIGNED_URL_QUERY_PARTS = {
+    "awsaccesskeyid",
+    "expires",
+    "signature",
+    "token",
+    "x-amz-credential",
+    "x-amz-security-token",
+    "x-amz-signature",
+}
+_LOCAL_PATH_RE = re.compile(r"^(?:/Users/|/home/|/var/|/tmp/|/private/|/Volumes/|file://|~/|[A-Za-z]:\\)")
+
+
+class CloudBurstContractError(ValueError):
+    """Raised when a burst request/response violates the v0 contract."""
+
+
+Transport = Callable[[str, dict[str, Any], dict[str, str], float], Mapping[str, Any]]
+
+
+def build_burst_validation_request(
+    *,
+    request_id: str,
+    route_decision_id: str,
+    device_id: str,
+    payload_hash: str,
+    payload_manifest: Mapping[str, Any],
+    workload_type: str = "vla_action",
+    privacy_mode: str = "standard",
+    cloud_allowed: bool = True,
+    artifact_identity: Mapping[str, Any] | None = None,
+    latency_budget_ms: float | None = None,
+    max_cost_usd: float | None = None,
+    cloud_backend: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the bounded payload sent to Cloud's burst validator."""
+
+    if not _required(request_id):
+        raise CloudBurstContractError("missing request_id")
+    if not _required(route_decision_id):
+        raise CloudBurstContractError("missing route_decision_id")
+    if not _required(device_id):
+        raise CloudBurstContractError("missing device_id")
+    if not _required(payload_hash):
+        raise CloudBurstContractError("missing payload_hash")
+    if _normalize_privacy(privacy_mode) == "edge_only":
+        raise CloudBurstContractError("privacy_edge_only")
+    if not bool(cloud_allowed):
+        raise CloudBurstContractError("cloud_disallowed")
+
+    manifest = dict(payload_manifest)
+    sanitized_manifest = redact_for_burst(manifest)
+    if sanitized_manifest != manifest:
+        raise CloudBurstContractError("payload_manifest_unsafe")
+
+    body: dict[str, Any] = {
+        "schema_version": BURST_SCHEMA_VERSION,
+        "request_id": request_id,
+        "route_decision_id": route_decision_id,
+        "device_id": device_id,
+        "workload_type": workload_type,
+        "privacy_mode": privacy_mode,
+        "cloud_allowed": True,
+        "payload_hash": payload_hash,
+        "payload_manifest": sanitized_manifest,
+        "request_hash": _hash_payload(
+            {
+                "request_id": request_id,
+                "route_decision_id": route_decision_id,
+                "device_id": device_id,
+                "payload_hash": payload_hash,
+                "payload_manifest": sanitized_manifest,
+            }
+        ),
+    }
+    if artifact_identity:
+        body["artifact_identity"] = redact_for_burst(dict(artifact_identity))
+    if latency_budget_ms is not None:
+        body["latency_budget_ms"] = float(latency_budget_ms)
+    if max_cost_usd is not None:
+        body["max_cost_usd"] = float(max_cost_usd)
+    if cloud_backend is not None:
+        safe_backend = redact_for_burst(dict(cloud_backend))
+        if safe_backend != dict(cloud_backend):
+            raise CloudBurstContractError("cloud_backend_unsafe")
+        body["cloud_backend"] = safe_backend
+    return body
+
+
+def post_burst_validation(
+    cloud_url: str,
+    request_body: Mapping[str, Any],
+    *,
+    api_key: str,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    transport: Transport | None = None,
+) -> dict[str, Any]:
+    """Post a dry-run burst validation request to Cloud or an injected fake."""
+
+    if not _required(cloud_url):
+        raise CloudBurstContractError("missing_cloud_url")
+    if not _required(api_key):
+        raise CloudBurstContractError("missing_api_key")
+    url = cloud_url.rstrip("/") + "/routing/burst/validate"
+    headers = {"Content-Type": "application/json", "X-API-Key": api_key}
+    payload = dict(request_body)
+    response = transport(url, payload, headers, timeout_s) if transport else _stdlib_post(url, payload, headers, timeout_s)
+    return validate_burst_validation_response(response)
+
+
+def validate_burst_validation_response(response: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate Cloud's dry-run validation response."""
+
+    body = dict(response)
+    if body.get("schema_version") != BURST_SCHEMA_VERSION:
+        raise CloudBurstContractError("burst_response_schema_mismatch")
+    status = body.get("status")
+    if status not in {"allow", "review", "block"}:
+        raise CloudBurstContractError("burst_response_status_invalid")
+    if body.get("backend_called") is not False:
+        raise CloudBurstContractError("burst_validation_must_not_call_backend")
+    if not isinstance(body.get("reasons"), list):
+        raise CloudBurstContractError("burst_response_reasons_invalid")
+    return body
+
+
+def burst_trace_from_validation(request_body: Mapping[str, Any], response_body: Mapping[str, Any]) -> dict[str, Any]:
+    """Return local trace/readiness-friendly metadata for a validation attempt."""
+
+    response = validate_burst_validation_response(response_body)
+    reasons = response.get("reasons") or []
+    return {
+        "schema_version": "tether_cloud_burst_trace.v0",
+        "request_id": request_body.get("request_id"),
+        "route_decision_id": request_body.get("route_decision_id"),
+        "device_id": request_body.get("device_id"),
+        "request_hash": request_body.get("request_hash") or response.get("request_hash"),
+        "status": response.get("status"),
+        "backend_called": False,
+        "reason_codes": [str(reason.get("code")) for reason in reasons if isinstance(reason, Mapping)],
+    }
+
+
+def redact_for_burst(value: Any) -> Any:
+    """Recursively remove secrets, local paths, signed URLs, and raw media/action blobs."""
+
+    if isinstance(value, Mapping):
+        out: dict[str, Any] = {}
+        for key, item in value.items():
+            key_s = str(key)
+            lowered = key_s.lower()
+            if _blocked_key(lowered):
+                continue
+            out[key_s] = redact_for_burst(item)
+        return out
+    if isinstance(value, list):
+        return [redact_for_burst(item) for item in value]
+    if isinstance(value, tuple):
+        return [redact_for_burst(item) for item in value]
+    if isinstance(value, str):
+        return _redact_string(value)
+    return value
+
+
+def _stdlib_post(url: str, payload: Mapping[str, Any], headers: Mapping[str, str], timeout_s: float) -> Mapping[str, Any]:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    req = urllib_request.Request(url, data=encoded, headers=dict(headers), method="POST")
+    with urllib_request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 - caller controls Cloud URL.
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _hash_payload(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _blocked_key(lowered_key: str) -> bool:
+    return any(part in lowered_key for part in _SENSITIVE_KEY_PARTS | _RAW_KEY_PARTS)
+
+
+def _redact_string(value: str) -> str:
+    raw = value.strip()
+    if not raw:
+        return value
+    if _LOCAL_PATH_RE.match(raw):
+        return "[redacted_path]"
+    parsed = urlparse(raw)
+    if parsed.scheme in {"http", "https"} and parsed.query:
+        query = parsed.query.lower()
+        if any(part in query for part in _SIGNED_URL_QUERY_PARTS):
+            return "[redacted_url]"
+    return value
+
+
+def _normalize_privacy(value: str | None) -> str:
+    raw = (value or "").strip().lower().replace("-", "_")
+    if raw in {"edge", "edge_only", "local_only", "private", "privacy_edge_only"}:
+        return "edge_only"
+    return raw or "standard"
+
+
+def _required(value: Any) -> bool:
+    return bool(str(value or "").strip())
+
+
+__all__ = [
+    "BURST_SCHEMA_VERSION",
+    "CloudBurstContractError",
+    "build_burst_validation_request",
+    "burst_trace_from_validation",
+    "post_burst_validation",
+    "redact_for_burst",
+    "validate_burst_validation_response",
+]

--- a/src/tether/runtime/cloud_fallback.py
+++ b/src/tether/runtime/cloud_fallback.py
@@ -1,0 +1,78 @@
+"""Dry-run Cloud burst handoff helpers for Tether runtime.
+
+This is not live `/act` proxying. It builds the bounded request, calls Cloud's
+validation endpoint, and returns local trace metadata so operators can prove the
+handoff contract before enabling online Cloud GPU burst.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .cloud_burst_contract import (
+    Transport,
+    build_burst_validation_request,
+    burst_trace_from_validation,
+    post_burst_validation,
+)
+
+
+@dataclass(frozen=True)
+class CloudBurstDryRunResult:
+    request: dict[str, Any]
+    response: dict[str, Any]
+    trace: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "request": self.request,
+            "response": self.response,
+            "trace": self.trace,
+        }
+
+
+def dry_run_cloud_burst(
+    *,
+    cloud_url: str,
+    api_key: str,
+    request_id: str,
+    route_decision_id: str,
+    device_id: str,
+    payload_hash: str,
+    payload_manifest: Mapping[str, Any],
+    workload_type: str = "vla_action",
+    privacy_mode: str = "standard",
+    cloud_allowed: bool = True,
+    artifact_identity: Mapping[str, Any] | None = None,
+    latency_budget_ms: float | None = None,
+    max_cost_usd: float | None = None,
+    cloud_backend: Mapping[str, Any] | None = None,
+    timeout_s: float = 2.0,
+    transport: Transport | None = None,
+) -> CloudBurstDryRunResult:
+    request = build_burst_validation_request(
+        request_id=request_id,
+        route_decision_id=route_decision_id,
+        device_id=device_id,
+        workload_type=workload_type,
+        privacy_mode=privacy_mode,
+        cloud_allowed=cloud_allowed,
+        max_cost_usd=max_cost_usd,
+        payload_hash=payload_hash,
+        payload_manifest=payload_manifest,
+        artifact_identity=artifact_identity,
+        latency_budget_ms=latency_budget_ms,
+        cloud_backend=cloud_backend,
+    )
+    response = post_burst_validation(
+        cloud_url,
+        request,
+        api_key=api_key,
+        timeout_s=timeout_s,
+        transport=transport,
+    )
+    trace = burst_trace_from_validation(request, response)
+    return CloudBurstDryRunResult(request=request, response=response, trace=trace)
+
+
+__all__ = ["CloudBurstDryRunResult", "dry_run_cloud_burst"]

--- a/tests/fixtures/cloud_burst/allow_request.json
+++ b/tests/fixtures/cloud_burst/allow_request.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "cloud_burst_validation.v0",
+  "request_id": "brq_fixture_allow",
+  "route_decision_id": "rtd_fixture_cloud",
+  "device_id": "dev_fixture",
+  "workload_type": "warehouse_packing_qa",
+  "privacy_mode": "standard",
+  "cloud_allowed": true,
+  "max_cost_usd": 0.01,
+  "payload_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "payload_manifest": {
+    "parts": [
+      {
+        "kind": "tensor",
+        "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "bytes": 2048
+      }
+    ]
+  },
+  "cloud_backend": {
+    "available": true,
+    "backend_id": "fake-cloud",
+    "estimated_latency_ms": 90.0,
+    "estimated_cost_usd": 0.002
+  }
+}

--- a/tests/fixtures/cloud_burst/allow_response.json
+++ b/tests/fixtures/cloud_burst/allow_response.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "cloud_burst_validation.v0",
+  "status": "allow",
+  "request_id": "brq_fixture_allow",
+  "route_decision_id": "rtd_fixture_cloud",
+  "device_id": "dev_fixture",
+  "request_hash": "fixture-request-hash",
+  "backend_called": false,
+  "reasons": [
+    {
+      "code": "cloud_burst_allowed",
+      "severity": "info",
+      "message": "Cloud burst validation passed for dry-run handoff."
+    }
+  ]
+}

--- a/tests/fixtures/cloud_burst/block_edge_only_request.json
+++ b/tests/fixtures/cloud_burst/block_edge_only_request.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "cloud_burst_validation.v0",
+  "request_id": "brq_fixture_block",
+  "route_decision_id": "rtd_fixture_cloud",
+  "device_id": "dev_fixture",
+  "workload_type": "factory_visual_inspection",
+  "privacy_mode": "edge_only",
+  "cloud_allowed": true,
+  "max_cost_usd": 0.01,
+  "payload_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "payload_manifest": {
+    "parts": [
+      {
+        "kind": "tensor",
+        "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "bytes": 2048
+      }
+    ]
+  },
+  "cloud_backend": {
+    "available": true,
+    "backend_id": "fake-cloud",
+    "estimated_latency_ms": 90.0,
+    "estimated_cost_usd": 0.002
+  }
+}

--- a/tests/fixtures/cloud_burst/review_missing_receipt_request.json
+++ b/tests/fixtures/cloud_burst/review_missing_receipt_request.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "cloud_burst_validation.v0",
+  "request_id": "brq_fixture_review",
+  "route_decision_id": "rtd_missing_fixture",
+  "device_id": "dev_fixture",
+  "workload_type": "warehouse_barcode_recognition",
+  "privacy_mode": "standard",
+  "cloud_allowed": true,
+  "max_cost_usd": 0.01,
+  "payload_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "payload_manifest": {
+    "parts": [
+      {
+        "kind": "tensor",
+        "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "bytes": 2048
+      }
+    ]
+  },
+  "cloud_backend": {
+    "available": true,
+    "backend_id": "fake-cloud",
+    "estimated_latency_ms": 90.0,
+    "estimated_cost_usd": 0.002
+  }
+}

--- a/tests/test_cloud_burst_contract.py
+++ b/tests/test_cloud_burst_contract.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tether.runtime.cloud_burst_contract import (
+    BURST_SCHEMA_VERSION,
+    CloudBurstContractError,
+    build_burst_validation_request,
+    burst_trace_from_validation,
+    post_burst_validation,
+    validate_burst_validation_response,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "cloud_burst"
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _request(**overrides):
+    body = build_burst_validation_request(
+        request_id="brq_1",
+        route_decision_id="rtd_1",
+        device_id="dev_1",
+        workload_type="factory_visual_inspection",
+        privacy_mode="standard",
+        cloud_allowed=True,
+        max_cost_usd=0.01,
+        payload_hash="sha256:" + "a" * 64,
+        payload_manifest={"parts": [{"kind": "tensor", "sha256": "b" * 64, "bytes": 2048}]},
+        cloud_backend={"available": True, "backend_id": "fake-cloud", "estimated_cost_usd": 0.002},
+    )
+    body.update(overrides)
+    return body
+
+
+def _response(**overrides):
+    body = {
+        "schema_version": BURST_SCHEMA_VERSION,
+        "status": "allow",
+        "request_id": "brq_1",
+        "route_decision_id": "rtd_1",
+        "device_id": "dev_1",
+        "request_hash": "abc",
+        "backend_called": False,
+        "reasons": [{"code": "cloud_burst_allowed", "severity": "info", "message": "ok"}],
+    }
+    body.update(overrides)
+    return body
+
+
+def test_build_burst_validation_request_is_bounded_and_deterministic() -> None:
+    request = _request()
+
+    assert request["schema_version"] == BURST_SCHEMA_VERSION
+    assert request["route_decision_id"] == "rtd_1"
+    assert request["payload_manifest"]["parts"][0]["kind"] == "tensor"
+    assert request["request_hash"]
+    assert "api_key" not in str(request)
+
+
+def test_shared_cloud_burst_fixtures_cover_allow_review_and_block_shapes() -> None:
+    allow_request = _fixture("allow_request.json")
+    allow_response = validate_burst_validation_response(_fixture("allow_response.json"))
+    review_request = _fixture("review_missing_receipt_request.json")
+    block_request = _fixture("block_edge_only_request.json")
+
+    assert allow_request["schema_version"] == BURST_SCHEMA_VERSION
+    assert allow_response["status"] == "allow"
+    assert review_request["route_decision_id"] == "rtd_missing_fixture"
+    assert block_request["privacy_mode"] == "edge_only"
+
+
+@pytest.mark.parametrize(
+    ("privacy_mode", "cloud_allowed", "error"),
+    [
+        ("edge_only", True, "privacy_edge_only"),
+        ("standard", False, "cloud_disallowed"),
+    ],
+)
+def test_build_burst_validation_request_blocks_before_dispatch(privacy_mode, cloud_allowed, error) -> None:
+    with pytest.raises(CloudBurstContractError, match=error):
+        build_burst_validation_request(
+            request_id="brq_1",
+            route_decision_id="rtd_1",
+            device_id="dev_1",
+            privacy_mode=privacy_mode,
+            cloud_allowed=cloud_allowed,
+            payload_hash="sha256:" + "a" * 64,
+            payload_manifest={"parts": []},
+        )
+
+
+def test_build_burst_validation_request_rejects_unsafe_manifest() -> None:
+    with pytest.raises(CloudBurstContractError, match="payload_manifest_unsafe"):
+        build_burst_validation_request(
+            request_id="brq_1",
+            route_decision_id="rtd_1",
+            device_id="dev_1",
+            payload_hash="sha256:" + "a" * 64,
+            payload_manifest={
+                "local_path": "/Users/romirjain/private/frame.png",
+                "signed_url": "https://example.invalid/blob?X-Amz-Signature=secret",
+                "token": "secret",
+            },
+        )
+
+
+def test_post_burst_validation_uses_fake_transport_without_backend_execution() -> None:
+    calls = []
+
+    def fake_transport(url, payload, headers, timeout_s):
+        calls.append((url, payload, headers, timeout_s))
+        return _response(request_hash=payload["request_hash"])
+
+    response = post_burst_validation(
+        "https://cloud.example",
+        _request(),
+        api_key="rc_test_123",
+        timeout_s=1.5,
+        transport=fake_transport,
+    )
+
+    assert calls[0][0] == "https://cloud.example/routing/burst/validate"
+    assert calls[0][2]["X-API-Key"] == "rc_test_123"
+    assert response["status"] == "allow"
+    assert response["backend_called"] is False
+
+
+def test_validate_burst_response_rejects_backend_called() -> None:
+    with pytest.raises(CloudBurstContractError, match="burst_validation_must_not_call_backend"):
+        validate_burst_validation_response(_response(backend_called=True))
+
+
+def test_burst_trace_from_validation_records_reason_codes() -> None:
+    trace = burst_trace_from_validation(_request(), _response(status="review"))
+
+    assert trace == {
+        "schema_version": "tether_cloud_burst_trace.v0",
+        "request_id": "brq_1",
+        "route_decision_id": "rtd_1",
+        "device_id": "dev_1",
+        "request_hash": _request()["request_hash"],
+        "status": "review",
+        "backend_called": False,
+        "reason_codes": ["cloud_burst_allowed"],
+    }

--- a/tests/test_cloud_fallback.py
+++ b/tests/test_cloud_fallback.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from tether.runtime.cloud_burst_contract import BURST_SCHEMA_VERSION, CloudBurstContractError
+from tether.runtime.cloud_fallback import dry_run_cloud_burst
+
+
+def _response(status: str = "allow", request_hash: str = "abc") -> dict:
+    return {
+        "schema_version": BURST_SCHEMA_VERSION,
+        "status": status,
+        "request_id": "brq_dry",
+        "route_decision_id": "rtd_dry",
+        "device_id": "dev_dry",
+        "request_hash": request_hash,
+        "backend_called": False,
+        "reasons": [{"code": "cloud_burst_allowed", "severity": "info", "message": "ok"}],
+    }
+
+
+def test_dry_run_cloud_burst_calls_validation_endpoint_and_records_trace() -> None:
+    calls = []
+
+    def fake_transport(url, payload, headers, timeout_s):
+        calls.append((url, payload, headers, timeout_s))
+        return _response(request_hash=payload["request_hash"])
+
+    result = dry_run_cloud_burst(
+        cloud_url="https://cloud.example",
+        api_key="rc_test_123",
+        request_id="brq_dry",
+        route_decision_id="rtd_dry",
+        device_id="dev_dry",
+        workload_type="warehouse_packing_qa",
+        payload_hash="sha256:" + "a" * 64,
+        payload_manifest={"parts": [{"kind": "tensor", "sha256": "b" * 64}]},
+        cloud_backend={"available": True, "backend_id": "fake-cloud", "estimated_cost_usd": 0.002},
+        transport=fake_transport,
+    )
+
+    assert calls[0][0] == "https://cloud.example/routing/burst/validate"
+    assert calls[0][1]["workload_type"] == "warehouse_packing_qa"
+    assert calls[0][2]["X-API-Key"] == "rc_test_123"
+    assert result.response["status"] == "allow"
+    assert result.trace["status"] == "allow"
+    assert result.trace["backend_called"] is False
+    assert result.trace["reason_codes"] == ["cloud_burst_allowed"]
+
+
+def test_dry_run_cloud_burst_blocks_edge_only_before_transport() -> None:
+    called = False
+
+    def fake_transport(url, payload, headers, timeout_s):
+        nonlocal called
+        called = True
+        return _response(request_hash=payload["request_hash"])
+
+    with pytest.raises(CloudBurstContractError, match="privacy_edge_only"):
+        dry_run_cloud_burst(
+            cloud_url="https://cloud.example",
+            api_key="rc_test_123",
+            request_id="brq_dry",
+            route_decision_id="rtd_dry",
+            device_id="dev_dry",
+            privacy_mode="edge_only",
+            payload_hash="sha256:" + "a" * 64,
+            payload_manifest={"parts": [{"kind": "tensor", "sha256": "b" * 64}]},
+            transport=fake_transport,
+        )
+
+    assert called is False


### PR DESCRIPTION
## Summary
- add stdlib-only cloud burst request/response contract helpers
- add dry_run_cloud_burst() with injectable fake transport and trace-compatible metadata
- add shared cloud-burst fixtures and tests for bounded manifests, local privacy/cloud_allowed blocks, fake Cloud validation calls, and backend_called=false responses

## Validation
- PYTHONPATH=src pytest tests/test_cloud_burst_contract.py -q
- PYTHONPATH=src pytest tests/test_cloud_burst_contract.py tests/test_cloud_fallback.py tests/test_split.py -q
- PYTHONPATH=src pytest tests/test_cloud_burst_contract.py tests/test_cloud_fallback.py tests/test_split.py tests/test_agent_client.py tests/test_agent_hardware.py tests/test_agent_daemon.py tests/test_record_chain.py -q
- PYTHONPATH=src ruff check src/tether/runtime/cloud_burst_contract.py src/tether/runtime/cloud_fallback.py tests/test_cloud_burst_contract.py tests/test_cloud_fallback.py
- python -m compileall -q src/tether/runtime/cloud_burst_contract.py src/tether/runtime/cloud_fallback.py tests/test_cloud_burst_contract.py tests/test_cloud_fallback.py
- git diff --check
- shared fixture SHA-256s match the Cloud PR fixture set

## Scope guard
This is a dry-run contract only. It does not wire into live /act dispatch, does not reuse the existing raw split fallback path, does not send raw images/actions/traces/local paths/tokens, and does not claim live Cloud GPU execution.