### PR TITLE
release: PyPI distribution name → fastcrest-tether (bare 'tether' is blocked on PyPI)

### DIFF
--- a/.github/workflows/doctor-smoke.yml
+++ b/.github/workflows/doctor-smoke.yml
@@ -83,7 +83,7 @@ jobs:
           # exercises the LD_LIBRARY_PATH patch path without pulling tensorrt
           # (which has no Mac wheel and is huge on Linux). Doctor should still
           # exit 0 with TRT libs ⚠ NOT installed warnings.
-          /tmp/tether-doctor-venv/bin/python -m pip install "$(ls dist/tether-*.whl)[onnx]"
+          /tmp/tether-doctor-venv/bin/python -m pip install "$(ls dist/fastcrest_tether-*.whl)[onnx]"
 
       - name: Verify tether --version matches pyproject.toml
         shell: bash

--- a/GOALS.yaml
+++ b/GOALS.yaml
@@ -213,7 +213,7 @@ goals:
 
   - id: fresh-install-verified
     status: done
-    description: "`pip install 'tether[serve,gpu] @ git+https://...'` succeeds on a fresh python:3.12-slim container and `tether --help` runs. Catches dep resolution breakage, broken editable installs, missing files in the wheel. Regression-check every release."
+    description: "`pip install 'fastcrest-tether[serve,gpu] @ git+https://...'` succeeds on a fresh python:3.12-slim container and `tether --help` runs. Catches dep resolution breakage, broken editable installs, missing files in the wheel. Regression-check every release."
     check: "test -f tests/test_fresh_install.py && .venv/bin/python -m pytest tests/test_fresh_install.py -q 2>/dev/null"
     weight: 8
 
@@ -416,8 +416,8 @@ goals:
     weight: 10
 
   - id: serve-one-line-install
-    description: "pip install tether && tether serve <hf-id> works on a Jetson with no Docker, no Triton YAML, no NVIDIA Container Toolkit. The DX win that beats Triton even though Triton wins on raw features. Most customers will tolerate a 1.5x latency hit for a 60s install vs a 4-hour Triton-on-Jetson setup."
-    check: "test -f docs/quickstart_jetson.md && grep -q 'pip install tether' README.md 2>/dev/null"
+    description: "pip install fastcrest-tether && tether serve <hf-id> works on a Jetson with no Docker, no Triton YAML, no NVIDIA Container Toolkit. The DX win that beats Triton even though Triton wins on raw features. Most customers will tolerate a 1.5x latency hit for a 60s install vs a 4-hour Triton-on-Jetson setup."
+    check: "test -f docs/quickstart_jetson.md && grep -q 'pip install fastcrest-tether' README.md 2>/dev/null"
     weight: 7
 
   # ── DEFERRED LONG-TERM SERVE (Phase 4-5; do NOT build now) ────────

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 > by [FastCrest](https://fastcrest.com) — deployment infrastructure for vision-language-action models.
 
-[![PyPI](https://img.shields.io/pypi/v/tether.svg)](https://pypi.org/project/tether/)
-[![Python](https://img.shields.io/pypi/pyversions/tether.svg)](https://pypi.org/project/tether/)
-[![License](https://img.shields.io/pypi/l/tether.svg)](https://github.com/FastCrest/tether/blob/main/LICENSE)
-[![Downloads](https://img.shields.io/pypi/dm/tether.svg)](https://pypi.org/project/tether/)
+[![PyPI](https://img.shields.io/pypi/v/fastcrest-tether.svg)](https://pypi.org/project/fastcrest-tether/)
+[![Python](https://img.shields.io/pypi/pyversions/fastcrest-tether.svg)](https://pypi.org/project/fastcrest-tether/)
+[![License](https://img.shields.io/pypi/l/fastcrest-tether.svg)](https://github.com/FastCrest/tether/blob/main/LICENSE)
+[![Downloads](https://img.shields.io/pypi/dm/fastcrest-tether.svg)](https://pypi.org/project/fastcrest-tether/)
 
 ![Tether — pip install + tether doctor + tether --help on Modal A10G with TRT EP active](assets/tether-tweet.gif)
 
@@ -28,16 +28,16 @@ The bootstrap installer detects your platform (Mac / Jetson Orin / NVIDIA GPU / 
 **Manual install** if you know what you want:
 
 ```bash
-pip install tether                            # core
-pip install 'tether[serve,gpu,monolithic]'    # GPU production path
-pip install 'tether[serve,onnx]'              # Mac / CPU runtime
+pip install fastcrest-tether                            # core
+pip install 'fastcrest-tether[serve,gpu,monolithic]'    # GPU production path
+pip install 'fastcrest-tether[serve,onnx]'              # Mac / CPU runtime
 ```
 
 Requires Python ≥ 3.10.
 
 ### What's new in v0.11.2 (2026-05-29)
 
-- **`tether connect` works on a clean install** — `requests` is now a core dependency, so `tether connect status` no longer raises `ModuleNotFoundError` on `pip install tether` without extras (it had been an undeclared import that only resolved transitively).
+- **`tether connect` works on a clean install** — `requests` is now a core dependency, so `tether connect status` no longer raises `ModuleNotFoundError` on `pip install fastcrest-tether` without extras (it had been an undeclared import that only resolved transitively).
 - **`--fast-kernels` cleared the formal N=100/task L3 LIBERO parity gate** — on Pi0.5 LIBERO-10 tasks 0-2 (600 episodes), Triton fast kernels scored 91.3% (274/300) vs native ORT 85.3% (256/300) — 6.0pp *ahead* of native, so kill-trigger 3 stays clear and the opt-in Triton runtime stays on.
 - **Hardened monolithic serve/bench path, with external-data ONNX** — dedicated ORT provider-options + tokenizer-loading modules are extracted from the request hot path; ONNX models with external weight data (`.onnx` + `.onnx_data`, required once a graph exceeds the 2 GB protobuf limit) now load in both serve and the weight-fusion export pass.
 - **Cleaner streams** — integration-command errors route to stderr, so `--json` consumers and shell pipelines get a clean stdout.
@@ -65,8 +65,8 @@ Breaking: module renames — `tether.exporters.{pi0,smolvla,gr00t}_exporter` →
 We ship patches frequently — make sure you're on the latest:
 
 ```bash
-pip install --upgrade tether              # pip
-uv add --refresh tether                   # uv (the --refresh flag is required;
+pip install --upgrade fastcrest-tether              # pip
+uv add --refresh fastcrest-tether                   # uv (the --refresh flag is required;
                                               # uv caches the package index aggressively
                                               # and won't see new releases without it)
 ```
@@ -83,7 +83,7 @@ only needed for caches built by v0.5.3 or earlier.
 
 ## Performance
 
-`tether[serve,gpu]` uses ONNX Runtime's TensorRT execution provider out of the box. Measured on Modal A10G (Ampere, sm_8.6) on 2026-04-29 against SmolVLA monolithic (5 warmup + 20 measured forward passes, batch=1):
+`fastcrest-tether[serve,gpu]` uses ONNX Runtime's TensorRT execution provider out of the box. Measured on Modal A10G (Ampere, sm_8.6) on 2026-04-29 against SmolVLA monolithic (5 warmup + 20 measured forward passes, batch=1):
 
 | Provider | Mean latency | p95 |
 |---|---|---|
@@ -125,7 +125,7 @@ Full reproducer + 9-iteration debug log: [`reflex_context/03_experiments/2026-04
 Adds ~2 GB to `[serve,gpu]` install (the `tensorrt` package + bundled libs). If you don't want it:
 
 ```bash
-pip install 'tether[serve,gpu-min]'   # ORT-CUDA only, ~5x slower on transformers
+pip install 'fastcrest-tether[serve,gpu-min]'   # ORT-CUDA only, ~5x slower on transformers
 ```
 
 Or disable the `LD_LIBRARY_PATH` patch (e.g. if it conflicts with another env-aware tool):
@@ -275,7 +275,7 @@ Hidden legacy commands (`export`, `bench`, `replay`, etc.) stay callable as alia
 ### Install notes
 
 - `[monolithic]` extra is required for the cos=+1.000000 verified export path (pins transformers==5.3.0)
-- CPU-only: `pip install 'tether[serve,onnx,monolithic]'`
+- CPU-only: `pip install 'fastcrest-tether[serve,onnx,monolithic]'`
 - GPU install needs the FULL cuDNN 9 system library (not just the pip wheel). Easiest path: NVIDIA's container `docker run --gpus all -it nvcr.io/nvidia/tensorrt:24.10-py3`, then `apt-get install -y clang` (for lerobot→evdev), then the pip install
 - `tether serve` errors loudly if cuDNN can't load — no silent CPU fallback
 - First `tether go` downloads weights (~1-14 GB depending on model) — cached on subsequent runs

--- a/contrib/ros2/README.md
+++ b/contrib/ros2/README.md
@@ -1,7 +1,7 @@
 # ROS2 Robot Adapter Starter Kits
 
 **Fork-and-customize** adapters for running Reflex VLA on real robots via ROS2.
-These are NOT part of the core `pip install tether` — they live in `contrib/`
+These are NOT part of the core `pip install fastcrest-tether` — they live in `contrib/`
 and you're expected to adapt them to your specific robot setup.
 
 ## Available Adapters

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -58,7 +58,7 @@ tether go --model pi05-libero --dry-run
 | `--api-key` | _(none)_ | If set, `/act` requires `X-Tether-Key` header (or `Authorization: Bearer`) |
 | `--dry-run` | `false` | Probe + resolve + print plan; do not pull or serve |
 
-Full flag list: `tether go --help`. Note: models that ship as raw PyTorch require the `[monolithic]` extra (`pip install 'tether[monolithic]'`) for the inline export step.
+Full flag list: `tether go --help`. Note: models that ship as raw PyTorch require the `[monolithic]` extra (`pip install 'fastcrest-tether[monolithic]'`) for the inline export step.
 
 ---
 

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -62,7 +62,7 @@ Bounded `failure_mode` enum, surfaced in the CLI + telemetry:
 | `egl-black-frames` | Force `MUJOCO_GL=osmesa` in your env. |
 | `dep-version-conflict` | Pin `robosuite==1.4.1`, `bddl==1.0.1`, `mujoco==3.3.2`. Use `--runtime modal` for known-good pins. |
 | `osmesa-compile-hang` | Increase `--preflight-timeout` (cold containers take 60-180s for first-scene compile). |
-| `import-error` | `pip install 'tether[eval-local]'` for local; `--runtime modal` for the bundled image. |
+| `import-error` | `pip install 'fastcrest-tether[eval-local]'` for local; `--runtime modal` for the bundled image. |
 
 The 5th failure (per-episode OOM) is per-call probabilistic; backoff + a legible error in the runner covers it.
 
@@ -145,7 +145,7 @@ Above-`$50` estimate triggers an extra **"are you sure?"** warning so the custom
 Phase 1: **Linux x86_64 only**. Requires the `[eval-local]` extra:
 
 ```bash
-pip install 'tether[eval-local]'
+pip install 'fastcrest-tether[eval-local]'
 ```
 
 `--runtime local` **never silently falls back to Modal**. If the local env is broken, `tether eval` fails loud with a remediation pointer. This avoids surprise Modal bills + masks real env-config issues.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,6 @@
 # Getting started with Tether
 
-A 30-minute walkthrough of the typical first hour after `pip install tether[serve,gpu]`.
+A 30-minute walkthrough of the typical first hour after `pip install fastcrest-tether[serve,gpu]`.
 
 This guide assumes a Linux box with an NVIDIA GPU. CPU-only deployments work with `[serve]` instead of `[serve,gpu]` — every example below applies, just replace `--device cuda` with `--device cpu`.
 
@@ -10,10 +10,10 @@ This guide assumes a Linux box with an NVIDIA GPU. CPU-only deployments work wit
 
 ```bash
 # GPU box (requires CUDA 12 + cuDNN 9 — easiest via nvcr.io/nvidia/tensorrt container):
-pip install 'tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
+pip install 'fastcrest-tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
 
 # CPU-only box:
-pip install 'tether[serve,onnx] @ git+https://github.com/FastCrest/tether'
+pip install 'fastcrest-tether[serve,onnx] @ git+https://github.com/FastCrest/tether'
 ```
 
 Or for development from source:
@@ -205,7 +205,7 @@ tether export lerobot/smolvla_base --target orin-nano --output ./sv
 scp -r ./sv jetson:~/sv
 
 # On the Jetson (Jetpack 6.x with TensorRT preinstalled):
-pip install 'tether[serve] @ git+https://github.com/FastCrest/tether'
+pip install 'fastcrest-tether[serve] @ git+https://github.com/FastCrest/tether'
 tether serve ./sv --port 8000 --device cuda
 ```
 
@@ -236,7 +236,7 @@ ORT 1.20+ requires CUDA 12.x + cuDNN 9.x. The pip-installed `nvidia-cudnn-cu12` 
 ```bash
 docker run --gpus all -it --rm nvcr.io/nvidia/tensorrt:24.10-py3
 # inside the container:
-pip install 'tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
+pip install 'fastcrest-tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
 tether serve ...
 ```
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -5,7 +5,7 @@ Tether exposes a [Model Context Protocol](https://spec.modelcontextprotocol.io/)
 ## Install
 
 ```bash
-pip install tether[mcp]
+pip install fastcrest-tether[mcp]
 ```
 
 Pulls [`fastmcp`](https://github.com/jlowin/fastmcp) >= 3.0 alongside the core dependencies.
@@ -89,7 +89,7 @@ Shadow actions, A/B policy routing, and dataset validation run via explicit tool
 
 **"fastmcp not installed"**
 ```bash
-pip install tether[mcp]
+pip install fastcrest-tether[mcp]
 ```
 
 **Claude Desktop doesn't list Tether as a tool**

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```bash
-pip install 'tether[tracing]'
+pip install 'fastcrest-tether[tracing]'
 ```
 
 Without the `[tracing]` extra, tracing no-ops silently; the server emits nothing and costs nothing. Your serve behavior is unchanged.
@@ -102,8 +102,8 @@ File a GitHub issue if either is blocking an integration.
 
 ## Troubleshooting
 
-**"Tracing skipped — pip install tether[tracing] to enable"**
-The `[tracing]` extra isn't installed. Run `pip install 'tether[tracing]'` and restart serve.
+**"Tracing skipped — pip install fastcrest-tether[tracing] to enable"**
+The `[tracing]` extra isn't installed. Run `pip install 'fastcrest-tether[tracing]'` and restart serve.
 
 **Spans appear in Phoenix but not in Datadog**
 Your Datadog Agent probably has `receivers.otlp` disabled. Enable OTLP gRPC on :4317 in `datadog.yaml`, or point `--otel-endpoint` at an OTel Collector that forwards to Datadog.

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -8,8 +8,8 @@ produces actions; the transport delivers them to the robot client.
 
 | Transport | Flag | When to use | Install |
 |---|---|---|---|
-| **HTTP** (default) | `--transport http` | Standard REST API. Works with any HTTP client (curl, Python requests, browser). Best for prototyping + debugging. | `pip install tether[serve]` |
-| **ZMQ** | `--transport zmq` | Low-latency binary wire. 20× lower bandwidth for multi-camera setups. 10× smaller robot-side install. Best for production robot deployments where every millisecond matters. | Server: `pip install tether[serve]`. Robot: `pip install pyzmq msgpack numpy opencv-python-headless` (~25 MB) |
+| **HTTP** (default) | `--transport http` | Standard REST API. Works with any HTTP client (curl, Python requests, browser). Best for prototyping + debugging. | `pip install fastcrest-tether[serve]` |
+| **ZMQ** | `--transport zmq` | Low-latency binary wire. 20× lower bandwidth for multi-camera setups. 10× smaller robot-side install. Best for production robot deployments where every millisecond matters. | Server: `pip install fastcrest-tether[serve]`. Robot: `pip install pyzmq msgpack numpy opencv-python-headless` (~25 MB) |
 | **ROS2** | (v1.0) | Native ROS2 action server. Reserved for v1.0. | — |
 
 ## Quick Start

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -183,7 +183,7 @@ ERROR: Ignored the following versions that require a different python version: 0
 
 **Fix:** On Jetson, install `[serve]` only — **not** `[monolithic]`:
 ```bash
-pip install 'tether[serve]'
+pip install 'fastcrest-tether[serve]'
 ```
 
 The monolithic ONNX export (`tether export --monolithic`) requires lerobot and must run on a **Python 3.12+ host** (desktop, cloud GPU, or Docker). Export there, then copy the ONNX to the Jetson and serve it:

--- a/examples/01-chat-quickstart.md
+++ b/examples/01-chat-quickstart.md
@@ -7,7 +7,7 @@
 ## Install
 
 ```bash
-pip install tether
+pip install fastcrest-tether
 ```
 
 (~40 seconds; pulls torch + transformers + onnx as deps. Yes, it's chunky — the chat agent itself is ~50 KB, but it shares the install with the rest of Tether.)
@@ -55,9 +55,9 @@ Here's what the doctor found:
   ✓ tether 0.3.5
   ⚠ torch + CUDA — torch 2.11.0, CUDA unavailable (you're on Apple Silicon)
   ⚠ ONNX Runtime — not installed
-    Action: pip install 'tether[serve,onnx]'
+    Action: pip install 'fastcrest-tether[serve,onnx]'
   ⚠ fastapi + uvicorn — not installed
-    Action: pip install 'tether[serve,onnx]'
+    Action: pip install 'fastcrest-tether[serve,onnx]'
 ```
 
 ### "What models can I deploy?"

--- a/examples/01_circle_tap_so100/README.md
+++ b/examples/01_circle_tap_so100/README.md
@@ -18,7 +18,7 @@ by 0o8o0 (MIT) per ADR `reflex_context/01_decisions/2026-05-06-vendor-auto-soarm
 
 ```bash
 # Install Tether with the so100 + bench-game extras
-pip install 'tether[so100]'           # adds scservo_sdk for the Pi-side driver
+pip install 'fastcrest-tether[so100]'           # adds scservo_sdk for the Pi-side driver
 pip install lerobot==0.5.1                # for the from-scratch ACT training step
 ```
 

--- a/examples/02-deploy-smolvla-jetson.md
+++ b/examples/02-deploy-smolvla-jetson.md
@@ -34,7 +34,7 @@ pip install onnxruntime-gpu \
   --index-url https://pypi.jetson-ai-lab.io/jp6/cu126
 
 # 3. Install tether with [serve] only (NOT [gpu], NOT [monolithic])
-pip install 'tether[serve]'
+pip install 'fastcrest-tether[serve]'
 ```
 
 > **Why not `[monolithic]`?** The monolithic export extra depends on `lerobot==0.5.1`, which requires **Python ≥ 3.12**. JetPack 6 ships Python 3.10. Export your model on a desktop/cloud machine with Python 3.12+, then copy the ONNX to the Jetson and serve it.
@@ -49,7 +49,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 ### What each piece provides:
 - `numpy<2` — ABI compatibility with Jetson AI Lab pre-built wheels
 - `torch` / `onnxruntime-gpu` (from Jetson AI Lab) — GPU-accelerated inference, compiled for `aarch64` + JetPack CUDA
-- `tether[serve]` — FastAPI + uvicorn HTTP inference server + embodiment validation
+- `fastcrest-tether[serve]` — FastAPI + uvicorn HTTP inference server + embodiment validation
 
 This pulls ~2 GB of dependencies. Takes 5-10 minutes on the Jetson.
 
@@ -61,7 +61,7 @@ Since monolithic export requires Python 3.12+ (for `lerobot`), the typical Jetso
 
 ```bash
 # On your desktop / cloud GPU (Python 3.12+)
-pip install 'tether[serve,monolithic]'
+pip install 'fastcrest-tether[serve,monolithic]'
 tether export --model smolvla-base --out ./smolvla-export/
 ```
 

--- a/examples/03-distill-pi05.md
+++ b/examples/03-distill-pi05.md
@@ -13,7 +13,7 @@ SnapFlow ([arxiv 2604.05656](https://arxiv.org/abs/2604.05656)) is the canonical
 ## Install
 
 ```bash
-pip install 'tether[monolithic]'
+pip install 'fastcrest-tether[monolithic]'
 ```
 
 ## The command

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ Each example is a self-contained walkthrough you can paste into a terminal. Star
 All examples assume you've installed at least the base package:
 
 ```bash
-pip install tether
+pip install fastcrest-tether
 ```
 
 Some examples need the GPU or monolithic export extras — each example flags what it needs at the top.

--- a/examples/so_arm100_smolvla.py
+++ b/examples/so_arm100_smolvla.py
@@ -19,8 +19,8 @@ Hardware requirements:
     - USB-to-serial bridge on /dev/ttyUSB0 (Linux) or /dev/tty.usbserial-* (Mac)
 
 Python requirements:
-    pip install 'tether[serve,gpu,monolithic,lerobot]'   # GPU host
-    pip install 'tether[serve,onnx,lerobot,so100]'       # Mac / Pi at the arm
+    pip install 'fastcrest-tether[serve,gpu,monolithic,lerobot]'   # GPU host
+    pip install 'fastcrest-tether[serve,onnx,lerobot,so100]'       # Mac / Pi at the arm
 
 Calibration:
     If you already have a LeRobot calibration file (recorded via

--- a/infra/license-worker/README.md
+++ b/infra/license-worker/README.md
@@ -90,7 +90,7 @@ python -m tether.admin.issue_license \
 
 ```bash
 # On the customer's machine
-pip install --upgrade tether
+pip install --upgrade fastcrest-tether
 tether pro activate REFLEX-XXXX-XXXX-XXXX
 # ✓ License fetched, signature verified, written to ~/.reflex/pro.license
 # ✓ Hardware bound

--- a/infra/telemetry-worker/worker.js
+++ b/infra/telemetry-worker/worker.js
@@ -1,7 +1,7 @@
 /**
  * Reflex telemetry endpoint — Cloudflare Worker.
  *
- * Receives heartbeat POSTs from `pip install tether` deployments
+ * Receives heartbeat POSTs from `pip install fastcrest-tether` deployments
  * running with a valid Pro license OR free-tier telemetry enabled.
  * Validates the payload shape, writes one row per heartbeat to D1,
  * and returns 204 No Content.

--- a/install.sh
+++ b/install.sh
@@ -119,7 +119,7 @@ if [ "$IS_OLD_NANO" -eq 1 ]; then
   echo
   info "Recommended paths:"
   echo "  ${BOLD}1. Run on a Mac${RESET} (CPU path, works for chat + dev)"
-  echo "       pip install 'tether[serve,onnx]'"
+  echo "       pip install 'fastcrest-tether[serve,onnx]'"
   echo "  ${BOLD}2. Run on Jetson Orin${RESET} (Orin Nano / NX / AGX) — full GPU support"
   echo "  ${BOLD}3. Run in the cloud${RESET} (Modal, Lambda, RunPod with NVIDIA T4+)"
   echo
@@ -222,7 +222,7 @@ if ! "$PYTHON" -m pip --version >/dev/null 2>&1; then
 fi
 
 # -- Jetson: pre-install GPU deps from Jetson AI Lab --------------------------
-# This MUST happen BEFORE `pip install tether[serve]` so that:
+# This MUST happen BEFORE `pip install fastcrest-tether[serve]` so that:
 #   1. numpy<2 is locked in place before torch's transitive dep pulls 2.x
 #   2. torch comes from the Jetson AI Lab aarch64 wheel (not PyPI x86_64)
 #   3. onnxruntime-gpu comes from Jetson AI Lab (not the unresolvable PyPI one)
@@ -282,7 +282,7 @@ if [ "$IS_JETSON" -eq 1 ] || [ "$FORCE_JETSON" -eq 1 ]; then
 fi
 
 # -- Run pip install ----------------------------------------------------------
-PIP_TARGET="tether[$EXTRAS]"
+PIP_TARGET="fastcrest-tether[$EXTRAS]"
 info "Installing: $PIP_TARGET"
 echo
 "$PYTHON" -m pip install --upgrade "$PIP_TARGET"

--- a/launch/ANNOUNCEMENT.md
+++ b/launch/ANNOUNCEMENT.md
@@ -14,7 +14,7 @@ Apache 2.0, works today on x86 CUDA + desktop GPUs, Jetson support
 coming in v0.3.
 
 ```bash
-pip install 'tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
+pip install 'fastcrest-tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
 tether export --monolithic lerobot/smolvla_base --output ./smol
 tether serve ./smol
 # POST http://localhost:8000/act → 50-step action chunks

--- a/launch/lerobot_3146_draft.md
+++ b/launch/lerobot_3146_draft.md
@@ -47,7 +47,7 @@ Exporter uses onnx-diagnostic's `torch_export_patches(patch_transformers=True)` 
 
 ```bash
 # HTTP serve
-pip install 'tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
+pip install 'fastcrest-tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
 tether export lerobot/smolvla_base --target desktop --output ./smol
 tether serve ./smol --port 8000
 

--- a/launch/reddit_robotics_draft.md
+++ b/launch/reddit_robotics_draft.md
@@ -25,7 +25,7 @@ Getting pi0 / pi0.5 to cos=1.0 at num_steps=10 needed three interacting patches 
 Three commands from zero to serving:
 
 ```bash
-pip install 'tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
+pip install 'fastcrest-tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
 tether export lerobot/pi0_base --output ./p0
 tether serve ./p0 --port 8000
 ```

--- a/launch/show_hn_draft.md
+++ b/launch/show_hn_draft.md
@@ -24,7 +24,7 @@ I built Tether because the path from "we have a trained Vision-Language-Action m
 Getting pi0 / pi0.5 to cos=1.0 at num_steps=10 required three interacting patches (under `torch.export` + `transformers==5.3.0` + DynamicCache): (1) F.pad + logical AND for the block-causal mask instead of `torch.cat` (cat loses the suffix dim under FakeTensor); (2) freeze `DynamicLayer.update` during the unrolled Euler loop so the cache doesn't grow across iterations; (3) use `past_kv.get_seq_length()` instead of the pad-mask shape for mask assembly. GR00T's simpler DiT graph (no DynamicCache, no PaliGemma masking) traces cleanly with plain `torch.onnx.export(opset=19)` — no patches needed.
 
 ```bash
-pip install 'tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
+pip install 'fastcrest-tether[serve,gpu] @ git+https://github.com/FastCrest/tether'
 tether export lerobot/smolvla_base --output ./smol
 tether serve ./smol --port 8000
 # POST /act returns 50-step action chunks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "tether"
+name = "fastcrest-tether"
 version = "0.12.0"
 description = "FastCrest Tether — edge-to-cloud robotics + edge AI deploy CLI. Optimize, deploy, verify any VLA across Jetson, RTX, Apple Silicon, AMD. Standalone or wired to FastCrest Cloud."
 readme = "README.md"
@@ -50,12 +50,12 @@ dependencies = [
     # TetherClient (Phase 0.5 customer-sdk) — sync + async HTTP client.
     # Lightweight (~2MB); shared with [serve] which already needs FastAPI's
     # starlette/anyio stack. Adding here so `from tether import TetherClient`
-    # works on a bare `pip install tether`.
+    # works on a bare `pip install fastcrest-tether`.
     "httpx>=0.24.0",
     # Ed25519 license signature verification for Pro tier (`tether pro
     # activate <code>` and the daily heartbeat path). Small (~5MB) + already
     # transitively pulled by huggingface_hub on most installs. Required at
-    # base level so `tether pro` commands work on bare `pip install tether`.
+    # base level so `tether pro` commands work on bare `pip install fastcrest-tether`.
     "cryptography>=42.0",
     # HTTP client for the `tether connect` integration framework (#188):
     # integrations/registry.py + integrations/connector.py call requests.get()
@@ -108,7 +108,7 @@ gpu-min = [
     "nvidia-cudnn-cu12>=9.5,<10.0",
     "nvidia-cublas-cu12>=12.6,<13.0",
 ]
-# HTTP serve stack. Includes onnxruntime (CPU) so `pip install tether[serve]`
+# HTTP serve stack. Includes onnxruntime (CPU) so `pip install fastcrest-tether[serve]`
 # gives you a working server out of the box. For GPU, use `[serve,gpu]` to pull in
 # onnxruntime-gpu + CUDA libs.
 serve = [
@@ -121,14 +121,14 @@ serve = [
     "prometheus-client>=0.19.0",
     # ZMQ transport (Lift #2). `tether serve --transport zmq` uses these.
     # Tiny deps (~2 MB total). Added to [serve] rather than a separate extra
-    # so `pip install tether[serve]` gives you BOTH transports.
+    # so `pip install fastcrest-tether[serve]` gives you BOTH transports.
     "pyzmq>=25.0",
     "msgpack>=1.0",
     "opencv-python-headless>=4.8",  # JPEG-on-wire serialization for ZMQ transport
 ]
 safety = ["yourdfpy"]
 # Offline EU evidence-pack generator. No runtime deps today; kept as an extra
-# so pilots can install with `pip install tether[serve,comply]`.
+# so pilots can install with `pip install fastcrest-tether[serve,comply]`.
 comply = []
 # Native parity verification — installs lerobot + its deps so
 # `scripts/local_full_diff.py` can cross-check our export path against the
@@ -153,7 +153,7 @@ native = [
 # lerobot 0.5.x requires Python >=3.12. On Jetson (Python 3.10) the
 # monolithic export can't run locally — export on a cloud/desktop host
 # (Python 3.12+) and `tether serve` the resulting ONNX on the Jetson
-# with `pip install 'tether[serve]'` only.
+# with `pip install 'fastcrest-tether[serve]'` only.
 monolithic = [
     "lerobot==0.5.1; python_version >= '3.12'",
     "transformers==5.3.0",
@@ -195,7 +195,7 @@ tracing = [
 # (`tether.embodiments.so_arm100`) can talk to the Feetech bus + import
 # LeRobot calibration JSONs. Use this on the host wired to the arm:
 #
-#   pip install 'tether[lerobot]'
+#   pip install 'fastcrest-tether[lerobot]'
 #   tether serve bundle/ --embodiment so_arm100 --port /dev/ttyUSB0
 #
 # lerobot 0.5.x requires Python >=3.12 (we skip on 3.10/3.11 to avoid pip's
@@ -210,7 +210,7 @@ lerobot = [
 # Raspberry Pi / host wired to the arm. Separate from [lerobot] because the
 # legacy auto_soarm path (used by the bench wizard) only needs the SDK, not
 # the full LeRobot stack. The two extras compose: `pip install
-# 'tether[so100,lerobot]'` gives you both code paths.
+# 'fastcrest-tether[so100,lerobot]'` gives you both code paths.
 so100 = [
     "scservo-sdk>=0.0.4",
 ]

--- a/scripts/install_digest.py
+++ b/scripts/install_digest.py
@@ -20,7 +20,7 @@ import httpx
 API = "https://pypistats.org/api/packages"
 # Pre-rename name first; "tether" 404s until its first PyPI publish and is
 # skipped gracefully until then.
-PACKAGES = ["reflex-vla", "tether"]
+PACKAGES = ["reflex-vla", "fastcrest-tether"]
 
 
 def _fetch_one(package: str, endpoint: str) -> dict:

--- a/scripts/local_pi0_gemma_parity.py
+++ b/scripts/local_pi0_gemma_parity.py
@@ -15,7 +15,7 @@ via the Optimum Gemma path. See
 reflex_context/03_research/pi0_empirical_derisk_findings.md
 
 Prerequisites:
-  pip install 'tether[native]' 'optimum[onnxruntime]>=1.22' onnx onnxruntime
+  pip install 'fastcrest-tether[native]' 'optimum[onnxruntime]>=1.22' onnx onnxruntime
   # Also: pi0_base cached in ~/.cache/huggingface (14GB), see scripts/local_full_diff.py
 """
 import sys

--- a/scripts/local_pi0_rmsnorm_swap_diff.py
+++ b/scripts/local_pi0_rmsnorm_swap_diff.py
@@ -9,7 +9,7 @@ Critical: pi0 uses GemmaRMSNorm (PaliGemma backbone) with (1+weight)
 parameterization. A naive Llama-style swap produces wrong output. This
 script uses `swap_rmsnorm_variants` which dispatches correctly.
 
-Fast local iteration. Does NOT need Modal. Requires `pip install 'tether[native]'`.
+Fast local iteration. Does NOT need Modal. Requires `pip install 'fastcrest-tether[native]'`.
 """
 import sys
 import types

--- a/scripts/local_pi0_siglip_parity.py
+++ b/scripts/local_pi0_siglip_parity.py
@@ -13,7 +13,7 @@ Companion to scripts/local_pi0_gemma_parity.py. Together they validate
 both halves of PaliGemma (vision + language) independently via Optimum.
 
 Prerequisites:
-  pip install 'tether[native]' 'optimum[onnxruntime]>=1.22' onnx onnxruntime
+  pip install 'fastcrest-tether[native]' 'optimum[onnxruntime]>=1.22' onnx onnxruntime
 """
 import sys
 import types

--- a/scripts/modal_a2c2_real_traces.py
+++ b/scripts/modal_a2c2_real_traces.py
@@ -111,7 +111,7 @@ image = (
     .run_commands(
         "mkdir -p /tmp/libero_data",
         f'echo "build_bust={_BUILD_BUST}"',
-        f'pip install "tether[serve,gpu] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[serve,gpu] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_act_from_scratch_smoke.py
+++ b/scripts/modal_act_from_scratch_smoke.py
@@ -85,7 +85,7 @@ image = (
         "rich",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_action_fast_path_smoke.py
+++ b/scripts/modal_action_fast_path_smoke.py
@@ -98,7 +98,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_b4_gate_fire.py
+++ b/scripts/modal_b4_gate_fire.py
@@ -68,7 +68,7 @@ image = (
     .pip_install("Pillow>=10.0.0")  # for synthetic input image generation
     .run_commands(
         # SHA-pinned so the image rebuilds on every commit (avoids stale-image cache).
-        f'pip install "tether[serve,gpu] @ '
+        f'pip install "fastcrest-tether[serve,gpu] @ '
         f'git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[_gh_secret()],
     )

--- a/scripts/modal_curate_rlds_smoke.py
+++ b/scripts/modal_curate_rlds_smoke.py
@@ -1,7 +1,7 @@
 """Smoke test for the [curate-rlds] format converters on Modal.
 
 Validates:
-  1. `pip install tether[curate-rlds]` resolves cleanly with tensorflow +
+  1. `pip install fastcrest-tether[curate-rlds]` resolves cleanly with tensorflow +
      tensorflow_datasets pinned in pyproject.toml.
   2. `tether curate convert --format rlds` against a synthetic JSONL trace
      produces TFRecord + dataset_info.json + features.json output.
@@ -60,7 +60,7 @@ image = (
         "tensorflow-datasets>=4.9.0",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_customer_dogfood.py
+++ b/scripts/modal_customer_dogfood.py
@@ -4,7 +4,7 @@ Pretends to be a first-time user who has only read the README.md of
 tether. Uses NVIDIA's TRT container (as the README recommends for
 GPU) and follows the quickstart verbatim:
 
-  1. Install (pip install 'tether[serve,gpu] @ git+...')
+  1. Install (pip install 'fastcrest-tether[serve,gpu] @ git+...')
   2. Explore CLI (tether --help, tether models, tether targets, tether doctor)
   3. Export (tether export lerobot/smolvla_base --target desktop --output ./smol)
   4. Serve (tether serve ./smol --port 8000 &)
@@ -57,11 +57,11 @@ image = (
     # from the public git URL. If this fails, that's a real customer failure.
     .run_commands(
         # Customers don't get a pre-cloned repo; they install from the public URL.
-        # README (post-fix) says: pip install 'tether[serve,gpu,monolithic] @ git+...'
+        # README (post-fix) says: pip install 'fastcrest-tether[serve,gpu,monolithic] @ git+...'
         # SHA-pinning the install URL is what forces Modal to rebuild the image
         # when we commit — without this, the cached image from the previous dogfood
         # run is reused and the new fixes aren't actually tested.
-        f'pip install "tether[serve,gpu,monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[serve,gpu,monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
     )
 )
 

--- a/scripts/modal_export_pi05_libero_teacher.py
+++ b/scripts/modal_export_pi05_libero_teacher.py
@@ -69,7 +69,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_export_snapflow_student.py
+++ b/scripts/modal_export_snapflow_student.py
@@ -70,7 +70,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_fast_kernels_day4_smoke.py
+++ b/scripts/modal_fast_kernels_day4_smoke.py
@@ -64,7 +64,7 @@ image = (
         # Reference HEAD SHA (not branch name) so each new commit forces a
         # rebuild of this layer — bypasses Modal's pip-layer caching when
         # iterating on bugs.
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_fast_kernels_day5_l1_parity.py
+++ b/scripts/modal_fast_kernels_day5_l1_parity.py
@@ -56,7 +56,7 @@ image = (
         "ninja",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_fast_kernels_day6_l2_parity.py
+++ b/scripts/modal_fast_kernels_day6_l2_parity.py
@@ -52,7 +52,7 @@ image = (
         "ninja",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_fast_kernels_day7_cuda_graph.py
+++ b/scripts/modal_fast_kernels_day7_cuda_graph.py
@@ -53,7 +53,7 @@ image = (
         "ninja",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_fast_kernels_headline_bench.py
+++ b/scripts/modal_fast_kernels_headline_bench.py
@@ -63,7 +63,7 @@ image = (
         "lerobot==0.5.1", "num2words",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({"CUDA_HOME": "/usr/local/cuda"})

--- a/scripts/modal_fast_kernels_l3_diagnostic.py
+++ b/scripts/modal_fast_kernels_l3_diagnostic.py
@@ -87,7 +87,7 @@ image = (
     .add_local_file("scripts/patch_libero.py", "/root/patch_libero.py", copy=True)
     .run_commands("python /root/patch_libero.py")
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_fast_kernels_l3_side_by_side.py
+++ b/scripts/modal_fast_kernels_l3_side_by_side.py
@@ -114,7 +114,7 @@ image = (
     .add_local_file("scripts/patch_libero.py", "/root/patch_libero.py", copy=True)
     .run_commands("python /root/patch_libero.py")
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_finetune_parity.py
+++ b/scripts/modal_finetune_parity.py
@@ -66,7 +66,7 @@ image = (
     )
     .run_commands(
         # GITHUB_TOKEN from modal secret `github-token` (repo now private).
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_fluxvla_checkpoint_eval.py
+++ b/scripts/modal_fluxvla_checkpoint_eval.py
@@ -176,7 +176,7 @@ image = (
     .run_commands("python /root/patch_libero.py")
     .run_commands(
         f'echo "build_bust={_BUILD_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_fp16_convert.py
+++ b/scripts/modal_fp16_convert.py
@@ -63,7 +63,7 @@ image = (
         "numpy",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
             secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_fp16_parity.py
+++ b/scripts/modal_fp16_parity.py
@@ -54,7 +54,7 @@ image = (
         "onnxruntime-gpu>=1.20",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
             secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_fp16_snapflow_student.py
+++ b/scripts/modal_fp16_snapflow_student.py
@@ -60,7 +60,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUST}"',
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_fresh_install_test.py
+++ b/scripts/modal_fresh_install_test.py
@@ -18,7 +18,7 @@ image = (
     modal.Image.debian_slim(python_version="3.12")
     .apt_install("git")
     .pip_install(
-        "tether[serve,onnx] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether.git"
+        "fastcrest-tether[serve,onnx] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether.git"
     )
 )
 

--- a/scripts/modal_gr00t_e2e_chain_test.py
+++ b/scripts/modal_gr00t_e2e_chain_test.py
@@ -69,7 +69,7 @@ image = (
         "rich",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
             secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_gr00t_eagle_vlm_export.py
+++ b/scripts/modal_gr00t_eagle_vlm_export.py
@@ -68,7 +68,7 @@ image = (
         "rich",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
             secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_gr00t_spine_parity.py
+++ b/scripts/modal_gr00t_spine_parity.py
@@ -64,7 +64,7 @@ image = (
         "rich",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
             secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_gr00t_state_encoder_sanity.py
+++ b/scripts/modal_gr00t_state_encoder_sanity.py
@@ -63,7 +63,7 @@ image = (
         "rich",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
             secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_gr00t_vlm_parity.py
+++ b/scripts/modal_gr00t_vlm_parity.py
@@ -63,7 +63,7 @@ image = (
         "rich",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
             secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_hf_push_snapflow_v031.py
+++ b/scripts/modal_hf_push_snapflow_v031.py
@@ -74,7 +74,7 @@ Net: **+3.4 percentage points over teacher at ~10× fewer denoising steps.**
 Full reproduction via [Tether VLA](https://github.com/FastCrest/tether):
 
 ```bash
-pip install tether
+pip install fastcrest-tether
 tether distill \\
     --teacher lerobot/pi05_libero_finetuned_v044 \\
     --steps 10000 \\

--- a/scripts/modal_inference_weights_parity.py
+++ b/scripts/modal_inference_weights_parity.py
@@ -56,7 +56,7 @@ image = (
     )
     .run_commands(
         # tether first (may pull plain onnxruntime as transitive)
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         # Force GPU build (uninstall plain ORT first to avoid the silent
         # CUDAExecutionProvider-unavailable failure we hit on first fire).
         "pip uninstall -y onnxruntime || true",

--- a/scripts/modal_inference_weights_rss.py
+++ b/scripts/modal_inference_weights_rss.py
@@ -62,7 +62,7 @@ image = (
         "lerobot==0.5.1",  # for PI05Policy in from_lerobot_policy
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_inference_weights_rss_pi0_phase_b.py
+++ b/scripts/modal_inference_weights_rss_pi0_phase_b.py
@@ -54,7 +54,7 @@ image = (
         "lerobot==0.5.1",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_BRANCH}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_BRANCH}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_latency_pi05_decomposed.py
+++ b/scripts/modal_latency_pi05_decomposed.py
@@ -75,7 +75,7 @@ image = (
     )
     .run_commands(
         f'echo "bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_latency_v050_decomposed.py
+++ b/scripts/modal_latency_v050_decomposed.py
@@ -78,7 +78,7 @@ image = (
     )
     .run_commands(
         f'echo "bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_layer_pruning_lockstep_spike.py
+++ b/scripts/modal_layer_pruning_lockstep_spike.py
@@ -86,7 +86,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_layer_pruning_profile.py
+++ b/scripts/modal_layer_pruning_profile.py
@@ -76,7 +76,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_layer_pruning_reexport_spike.py
+++ b/scripts/modal_layer_pruning_reexport_spike.py
@@ -89,7 +89,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_libero_lerobot_native.py
+++ b/scripts/modal_libero_lerobot_native.py
@@ -116,7 +116,7 @@ image = (
     # when --snapflow-student is used. Uses the github-token secret to
     # clone the private repo. Cheap — this only pulls the Python package.
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_libero_pi05_decomposed.py
+++ b/scripts/modal_libero_pi05_decomposed.py
@@ -135,7 +135,7 @@ image = (
     .run_commands("python /root/patch_libero.py")
     .run_commands(
         f'echo "build_bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_ort_concurrent_streams_spike.py
+++ b/scripts/modal_ort_concurrent_streams_spike.py
@@ -92,7 +92,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_pi05_predict_action_parity.py
+++ b/scripts/modal_pi05_predict_action_parity.py
@@ -65,7 +65,7 @@ image = (
         "num2words",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_pi0_predict_action_parity.py
+++ b/scripts/modal_pi0_predict_action_parity.py
@@ -75,7 +75,7 @@ image = (
         "num2words",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_record_demo_gif.py
+++ b/scripts/modal_record_demo_gif.py
@@ -28,7 +28,7 @@ image = (
     .run_commands(
         # Install from the repo until `tether` is published to PyPI (the old
         # pinned 'reflex-vla==0.8.0' / 'tether-vla' package names are dead).
-        "uv pip install --system 'tether[serve,gpu] @ git+https://github.com/FastCrest/tether'",
+        "uv pip install --system 'fastcrest-tether[serve,gpu] @ git+https://github.com/FastCrest/tether'",
         "uv pip install --system 'tensorrt>=10.0,<11'",
         # agg = official asciinema gif renderer (Rust binary)
         "wget -qO /usr/local/bin/agg https://github.com/asciinema/agg/releases/download/v1.5.0/agg-x86_64-unknown-linux-gnu",

--- a/scripts/modal_reflex_distill.py
+++ b/scripts/modal_reflex_distill.py
@@ -77,7 +77,7 @@ HF_CACHE_PATH = "/root/.cache/huggingface"
 ONNX_OUTPUT_PATH = "/onnx_out"
 
 # Distill needs the same image as finetune + the SnapFlow deps land
-# automatically via the `tether[monolithic]` wheel install.
+# automatically via the `fastcrest-tether[monolithic]` wheel install.
 image = (
     modal.Image.debian_slim(python_version="3.12")
     .apt_install(
@@ -109,7 +109,7 @@ image = (
         # Local timestamp in an echo cache-busts Modal's layer cache even
         # when _HEAD falls back to 'main' on the build server.
         f'echo "build_bust={_BUILD_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_reflex_finetune.py
+++ b/scripts/modal_reflex_finetune.py
@@ -98,7 +98,7 @@ image = (
         # auto-export chain that runs after training succeeds.
         # GITHUB_TOKEN injected from modal secret `github-token` because
         # the repo is private.
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_remeasure_calibration_defaults.py
+++ b/scripts/modal_remeasure_calibration_defaults.py
@@ -100,7 +100,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUILD_BUST}"',
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_ros2_live_test.py
+++ b/scripts/modal_ros2_live_test.py
@@ -54,7 +54,7 @@ image = (
         'echo "numpy>=1.24,<2.0" > /tmp/reflex_cons.txt',
     )
     .pip_install(
-        "tether[serve,onnx] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether.git",
+        "fastcrest-tether[serve,onnx] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether.git",
         extra_options="-c /tmp/reflex_cons.txt",
     )
     .env({

--- a/scripts/modal_serve_roundtrip_test.py
+++ b/scripts/modal_serve_roundtrip_test.py
@@ -25,7 +25,7 @@ image = (
     modal.Image.debian_slim(python_version="3.12")
     .apt_install("git")
     .pip_install(
-        "tether[serve,onnx] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether.git"
+        "fastcrest-tether[serve,onnx] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether.git"
     )
 )
 

--- a/scripts/modal_smolvla_libero_parity.py
+++ b/scripts/modal_smolvla_libero_parity.py
@@ -75,7 +75,7 @@ image = (
         "num2words",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
             secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_stateout_distill_stage2.py
+++ b/scripts/modal_stateout_distill_stage2.py
@@ -78,7 +78,7 @@ image = (
     )
     .run_commands(
         f'echo "bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_stateout_smoke.py
+++ b/scripts/modal_stateout_smoke.py
@@ -67,7 +67,7 @@ image = (
     )
     .run_commands(
         f'echo "bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_test_calibration_matrix.py
+++ b/scripts/modal_test_calibration_matrix.py
@@ -69,7 +69,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUILD_BUST}"',
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/scripts/modal_verify_bench_all.py
+++ b/scripts/modal_verify_bench_all.py
@@ -152,12 +152,12 @@ def _run_all_impl(
     extras = "serve,gpu-min,monolithic"
     install_cmd = [
         "pip", "install",
-        f"tether[{extras}] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether",
+        f"fastcrest-tether[{extras}] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether",
     ]
     if source_norm == "local":
         install_cmd = ["pip", "install", "-e", f"/workspace/tether-vla[{extras}]"]
     print(
-        f"=== Installing tether[{extras}] from {source_norm} ===",
+        f"=== Installing fastcrest-tether[{extras}] from {source_norm} ===",
         flush=True,
     )
     r = _run_streamed(

--- a/scripts/modal_verify_deepening_smoke.py
+++ b/scripts/modal_verify_deepening_smoke.py
@@ -91,7 +91,7 @@ image = (
     .add_local_file("scripts/patch_libero.py", "/root/patch_libero.py", copy=True)
     .run_commands("python /root/patch_libero.py")
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_verify_install_path.py
+++ b/scripts/modal_verify_install_path.py
@@ -1,7 +1,7 @@
 """Test that the README quickstart install path actually works on a fresh box.
 
 Spins up a clean Linux container, runs the EXACT command from README:
-  pip install 'tether[serve,gpu] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether'
+  pip install 'fastcrest-tether[serve,gpu] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether'
   tether export lerobot/smolvla_base --target desktop --output ./sv
   tether serve ./sv --port 8000 --device cuda
   curl -X POST http://localhost:8000/act ...
@@ -61,8 +61,8 @@ def test_fresh_install():
 
     # Step 1: pip install with the EXACT README command
     step(
-        "1. pip install tether[serve,gpu] from git",
-        "pip install 'tether[serve,gpu] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether'",
+        "1. pip install fastcrest-tether[serve,gpu] from git",
+        "pip install 'fastcrest-tether[serve,gpu] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether'",
         timeout=600,
     )
 

--- a/scripts/modal_verify_parity_cert.py
+++ b/scripts/modal_verify_parity_cert.py
@@ -91,7 +91,7 @@ image = (
     .add_local_file("scripts/patch_libero.py", "/root/patch_libero.py", copy=True)
     .run_commands("python /root/patch_libero.py")
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_verify_snapflow_student_onnx.py
+++ b/scripts/modal_verify_snapflow_student_onnx.py
@@ -75,7 +75,7 @@ image = (
     )
     .run_commands(
         f'echo "build_bust={_BUST}"',
-        f'pip install "tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether[monolithic] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
     .env({

--- a/scripts/modal_verify_trt_with_batch.py
+++ b/scripts/modal_verify_trt_with_batch.py
@@ -48,10 +48,10 @@ def test_trt_batch():
     import urllib.request
 
     # Install tether from git
-    print("=== pip install tether[serve,gpu] ===", flush=True)
+    print("=== pip install fastcrest-tether[serve,gpu] ===", flush=True)
     r = subprocess.run(
         ["pip", "install",
-         "tether[serve,gpu] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether"],
+         "fastcrest-tether[serve,gpu] @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether"],
         capture_output=True, text=True, timeout=600,
     )
     if r.returncode != 0:

--- a/scripts/modal_zmq_vs_http_ab.py
+++ b/scripts/modal_zmq_vs_http_ab.py
@@ -47,7 +47,7 @@ image = (
         "httpx>=0.24.0",
     )
     .run_commands(
-        f'pip install "tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
+        f'pip install "fastcrest-tether @ git+https://x-access-token:$GITHUB_TOKEN@github.com/FastCrest/tether@{_HEAD}"',
         secrets=[modal.Secret.from_name("github-token")],
     )
 )

--- a/src/reflex/__init__.py
+++ b/src/reflex/__init__.py
@@ -21,7 +21,7 @@ Migration:
     reflex --help
 
     # New
-    pip install tether
+    pip install fastcrest-tether
     from tether import VLAExport
     tether --help
 

--- a/src/tether/agent/hardware.py
+++ b/src/tether/agent/hardware.py
@@ -20,7 +20,7 @@ def collect_hardware_profile() -> JsonDict:
         "platform": platform.platform(),
         "python": sys.version.split()[0],
         "agent_version": _agent_version(),
-        "tether_version": _package_version("tether"),
+        "tether_version": _package_version("fastcrest-tether"),
         "gpu_name": None,
         "cuda": None,
         "jetpack": None,

--- a/src/tether/bench/report.py
+++ b/src/tether/bench/report.py
@@ -111,7 +111,7 @@ def _ort_version() -> str:
 def _tether_version() -> str:
     try:
         from importlib.metadata import version
-        return version("tether")
+        return version("fastcrest-tether")
     except Exception:
         return "0.1.0+dev"
 

--- a/src/tether/chat/tui.py
+++ b/src/tether/chat/tui.py
@@ -1,6 +1,6 @@
 """Textual TUI for tether chat.
 
-Optional — install with `pip install 'tether[tui]'` (adds textual). Falls
+Optional — install with `pip install 'fastcrest-tether[tui]'` (adds textual). Falls
 back to `tether.chat.console.run_repl` (Rich REPL) if textual isn't installed.
 
 Layout (4 panels):
@@ -264,7 +264,7 @@ def run_tui(proxy_url: str | None = None, dry_run: bool = False) -> None:
     if not TEXTUAL_AVAILABLE:
         print(
             "Textual not installed — falling back to the Rich REPL.\n"
-            "Install the optional extra to use the TUI: pip install 'tether[tui]'\n",
+            "Install the optional extra to use the TUI: pip install 'fastcrest-tether[tui]'\n",
             flush=True,
         )
         from tether.chat.console import run_repl

--- a/src/tether/ci_template.py
+++ b/src/tether/ci_template.py
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install tether
         run: |
-          pip install 'tether[serve,onnx,dev] @ git+https://github.com/FastCrest/tether@v{tether_version}'
+          pip install 'fastcrest-tether[serve,onnx,dev] @ git+https://github.com/FastCrest/tether@v{tether_version}'
 
       - name: Export SmolVLA
         run: |
@@ -72,7 +72,7 @@ jobs:
   #       with:
   #         python-version: "3.11"
   #     - name: Install tether
-  #       run: pip install 'tether[serve,onnx,dev] @ git+https://github.com/FastCrest/tether@v{tether_version}'
+  #       run: pip install 'fastcrest-tether[serve,onnx,dev] @ git+https://github.com/FastCrest/tether@v{tether_version}'
   #     - name: Export pi0
   #       run: tether export lerobot/pi0_base --target desktop --output ./pi0_export
   #     - name: Validate round-trip parity
@@ -97,7 +97,7 @@ jobs:
   #       with:
   #         python-version: "3.11"
   #     - name: Install tether
-  #       run: pip install 'tether[serve,onnx,dev] @ git+https://github.com/FastCrest/tether@v{tether_version}'
+  #       run: pip install 'fastcrest-tether[serve,onnx,dev] @ git+https://github.com/FastCrest/tether@v{tether_version}'
   #     - name: Export GR00T
   #       run: tether export nvidia/GR00T-N1-2B --target desktop --output ./gr00t_export
   #     - name: Validate round-trip parity

--- a/src/tether/cli.py
+++ b/src/tether/cli.py
@@ -43,7 +43,7 @@ _NOARGS_SUMMARY = """[bold]tether[/bold] — deploy any VLA model to any edge ha
 
 [dim]All commands:[/dim]  tether --help
 [dim]Examples:[/dim]      https://github.com/FastCrest/tether/tree/main/examples
-[dim]Docs:[/dim]          https://fastcrest.com  ·  https://pypi.org/project/tether/
+[dim]Docs:[/dim]          https://fastcrest.com  ·  https://pypi.org/project/fastcrest-tether/
 """
 
 
@@ -188,7 +188,7 @@ def export(
              "path, one ONNX file). Opt into --decomposed only if you specifically need "
              "the 5-stage export for debugging; --decomposed is the older path with "
              "known correctness gaps. Monolithic requires `pip install "
-             "'tether[monolithic]'` (pins transformers==5.3.0).",
+             "'fastcrest-tether[monolithic]'` (pins transformers==5.3.0).",
     ),
     export_mode: str = typer.Option(
         "auto",
@@ -271,7 +271,7 @@ def export(
         except ImportError as exc:
             err_console.print(f"[red]{exc}[/red]", markup=False)
             err_console.print(
-                "\nFix: pip install 'tether[monolithic]' "
+                "\nFix: pip install 'fastcrest-tether[monolithic]' "
                 "(pins transformers==5.3.0; use a clean venv to avoid "
                 "the base transformers<5.0 conflict)",
                 style="cyan", markup=False,
@@ -288,7 +288,7 @@ def export(
         except ImportError as exc:
             err_console.print(f"Missing monolithic dep: {exc}", style="red", markup=False)
             err_console.print(
-                "\nFix: pip install 'tether[monolithic]'",
+                "\nFix: pip install 'fastcrest-tether[monolithic]'",
                 style="cyan", markup=False,
             )
             raise typer.Exit(2)
@@ -356,7 +356,7 @@ def export(
         except ImportError as exc:
             err_console.print(f"[red]{exc}[/red]", markup=False)
             err_console.print(
-                "\nFix: pip install 'tether[monolithic]' "
+                "\nFix: pip install 'fastcrest-tether[monolithic]' "
                 "(pins transformers==5.3.0; use a clean venv to avoid "
                 "the base transformers<5.0 conflict)",
                 style="cyan", markup=False,
@@ -822,7 +822,7 @@ def benchmark_cmd(
     benchmark: str = typer.Option(
         "",
         "--benchmark",
-        help="Also run task-success eval: simpler, maniskill (requires pip install 'tether[eval]'). LIBERO archived 2026-04-17 — see archive/scripts/.",
+        help="Also run task-success eval: simpler, maniskill (requires pip install 'fastcrest-tether[eval]'). LIBERO archived 2026-04-17 — see archive/scripts/.",
     ),
     episodes_per_task: int = typer.Option(
         10, help="Episodes per task for --benchmark (full suites use 50)"
@@ -884,7 +884,7 @@ def benchmark_cmd(
         except ImportError:
             console.print(
                 f"--benchmark {benchmark} requires the eval extra.\n"
-                f"  Install with: pip install 'tether[eval]'\n"
+                f"  Install with: pip install 'fastcrest-tether[eval]'\n"
                 f"  Or run without --benchmark for latency-only.",
                 style="red", markup=False,
             )
@@ -1823,7 +1823,7 @@ def serve(
              "lerobot's RTCProcessor so the robot keeps executing the tail "
              "of one chunk while the next chunk is being computed. 2-3× "
              "effective throughput on Jetson-class latency. Requires "
-             "`pip install tether[rtc]` (pulls lerobot==0.5.1).",
+             "`pip install fastcrest-tether[rtc]` (pulls lerobot==0.5.1).",
     ),
     rtc_execution_horizon: int = typer.Option(
         10,
@@ -1965,7 +1965,7 @@ def serve(
              "stdio (default), the MCP server owns stdin/stdout and FastAPI "
              "is NOT started (use for Claude Desktop / Cursor integration). "
              "With --mcp-transport http, both MCP (on --mcp-port) and FastAPI "
-             "(on --port) run concurrently. Requires `pip install tether[mcp]`.",
+             "(on --port) run concurrently. Requires `pip install fastcrest-tether[mcp]`.",
     ),
     mcp_transport: str = typer.Option(
         "stdio",
@@ -1983,7 +1983,7 @@ def serve(
         "",
         "--otel-endpoint",
         help="OTLP gRPC endpoint for trace export (e.g. 'localhost:4317' for "
-             "Phoenix, or an OTel Collector). Requires `pip install tether"
+             "Phoenix, or an OTel Collector). Requires `pip install fastcrest-tether"
              "[tracing]`. When unset, falls back to $OTEL_EXPORTER_OTLP_ENDPOINT "
              "and then 'localhost:4317'. Traces include gen_ai.operation.name, "
              "gen_ai.request.model, gen_ai.action.embodiment, gen_ai.action."
@@ -2447,7 +2447,7 @@ def serve(
         from tether.runtime.server import create_app
         import uvicorn
     except ImportError:
-        console.print("Install serve dependencies: pip install 'tether[serve]'", style="red", markup=False)
+        console.print("Install serve dependencies: pip install 'fastcrest-tether[serve]'", style="red", markup=False)
         raise typer.Exit(1)
 
     if replan_hz > 0 and execute_hz <= 0:
@@ -2618,7 +2618,7 @@ def serve(
         except ImportError:
             console.print(
                 "MCP dependency not installed. Run:\n"
-                "  pip install 'tether[mcp]'",
+                "  pip install 'fastcrest-tether[mcp]'",
                 style="red", markup=False,
             )
             raise typer.Exit(1)
@@ -3069,7 +3069,7 @@ def _check_trt_ep_load_chain(add) -> None:
         import onnxruntime as ort
     except ImportError:
         add("ORT-TRT EP active", False,
-            "onnxruntime not installed — pip install 'tether[serve,gpu]'")
+            "onnxruntime not installed — pip install 'fastcrest-tether[serve,gpu]'")
         return
 
     if "TensorrtExecutionProvider" not in ort.get_available_providers():
@@ -3078,7 +3078,7 @@ def _check_trt_ep_load_chain(add) -> None:
             False,
             "TensorrtExecutionProvider not in onnxruntime's available "
             "providers list. Either onnxruntime-gpu isn't installed (use "
-            "'tether[serve,gpu]') or you're on a CPU-only ORT build.",
+            "'fastcrest-tether[serve,gpu]') or you're on a CPU-only ORT build.",
         )
         return
 
@@ -3377,7 +3377,7 @@ def doctor(
                     f"❌ JetPack R{jetpack_major} ships CUDA 11.4. ORT 1.20+ "
                     f"requires CUDA 12.x → CUDAExecutionProvider will silently "
                     f"fall to CPU. Upgrade to JetPack R36+ (Orin) or use "
-                    f"tether[serve,onnx] for CPU-only inference.",
+                    f"fastcrest-tether[serve,onnx] for CPU-only inference.",
                 )
             elif jp_int >= 36:
                 add(
@@ -3681,9 +3681,9 @@ def doctor(
     # Tether itself
     try:
         from tether import __version__ as tether_version
-        add("tether", True, f"version {tether_version}")
+        add("fastcrest-tether", True, f"version {tether_version}")
     except Exception as e:
-        add("tether", False, str(e))
+        add("fastcrest-tether", False, str(e))
 
     # Curate data-contribution status (informational; no pass/fail).
     try:
@@ -3999,7 +3999,7 @@ def models_pull(
     try:
         from huggingface_hub import snapshot_download
     except ImportError:
-        err_console.print("[red]huggingface_hub not installed. pip install tether[/red]")
+        err_console.print("[red]huggingface_hub not installed. pip install fastcrest-tether[/red]")
         raise typer.Exit(2)
 
     try:
@@ -4140,7 +4140,7 @@ def go(
     For models that ship as raw PyTorch (requires_export=True in registry),
     this command pulls + exports inline (5-15 min) + serves. The export step
     requires the [monolithic] extra:
-      pip install 'tether[monolithic]'
+      pip install 'fastcrest-tether[monolithic]'
     Without it, `tether go` errors with the install command.
 
     Exported artifacts cache at ~/.cache/tether/exports/<model_id>/ — re-runs
@@ -4314,7 +4314,7 @@ def go(
                 console.print(f"{exc}", style="red", markup=False)
                 console.print(
                     "\n`tether go` needs the monolithic export extras to deploy this model.\n"
-                    "Fix: pip install 'tether[monolithic]'\n"
+                    "Fix: pip install 'fastcrest-tether[monolithic]'\n"
                     "(pins transformers==5.3.0; use a clean venv to avoid the "
                     "base transformers<5.0 conflict)",
                     style="cyan", markup=False,
@@ -5746,7 +5746,7 @@ def chat(
     tui: bool = typer.Option(
         False, "--tui",
         help="Use the Textual full-screen TUI (multi-panel layout, scroll-back, mouse). "
-             "Requires `pip install 'tether[tui]'`. Falls back to the Rich REPL if "
+             "Requires `pip install 'fastcrest-tether[tui]'`. Falls back to the Rich REPL if "
              "textual isn't installed.",
     ),
     resume: bool = typer.Option(

--- a/src/tether/client/client.py
+++ b/src/tether/client/client.py
@@ -103,7 +103,7 @@ def encode_image(image: Any, jpeg_quality: int = 85) -> str:
         from PIL import Image as PILImage
     except ImportError:
         raise TetherClientError(
-            "Pillow required to encode numpy arrays / PIL images; install tether[serve] or pip install Pillow"
+            "Pillow required to encode numpy arrays / PIL images; install fastcrest-tether[serve] or pip install Pillow"
         )
     if isinstance(image, PILImage.Image):
         buf = io.BytesIO()

--- a/src/tether/comply/sbom.py
+++ b/src/tether/comply/sbom.py
@@ -43,15 +43,15 @@ def generate_sbom(
     components: list[dict[str, Any]] = [
         {
             "type": "application",
-            "bom-ref": f"pkg:pypi/tether@{__version__}",
-            "name": "tether",
+            "bom-ref": f"pkg:pypi/fastcrest-tether@{__version__}",
+            "name": "fastcrest-tether",
             "version": __version__,
-            "purl": f"pkg:pypi/tether@{__version__}",
+            "purl": f"pkg:pypi/fastcrest-tether@{__version__}",
         }
     ]
 
     if include_environment:
-        seen = {"tether"}
+        seen = {"fastcrest-tether"}
         for dist in sorted(metadata.distributions(), key=lambda d: (d.metadata.get("Name") or "").lower()):
             comp = _component_from_distribution(dist)
             if comp is None:

--- a/src/tether/curate/format_converters/hdf5.py
+++ b/src/tether/curate/format_converters/hdf5.py
@@ -83,7 +83,7 @@ class HDF5Converter(FormatConverter):
             import h5py
         except ImportError as exc:
             raise ImportError(
-                "h5py required for HDF5 conversion: pip install 'tether[curate-hdf5]'"
+                "h5py required for HDF5 conversion: pip install 'fastcrest-tether[curate-hdf5]'"
             ) from exc
 
         result = ConversionResult(

--- a/src/tether/curate/format_converters/openx_embodiment.py
+++ b/src/tether/curate/format_converters/openx_embodiment.py
@@ -84,7 +84,7 @@ class OpenXEmbodimentConverter(FormatConverter):
         except ImportError as exc:
             raise ImportError(
                 "Open X-Embodiment conversion requires tensorflow + tensorflow_datasets: "
-                "pip install 'tether[curate-rlds]'"
+                "pip install 'fastcrest-tether[curate-rlds]'"
             ) from exc
 
         # Reuse RLDSConverter for the bulk of the work; we'll patch the

--- a/src/tether/curate/format_converters/rlds.py
+++ b/src/tether/curate/format_converters/rlds.py
@@ -80,7 +80,7 @@ class RLDSConverter(FormatConverter):
         except ImportError as exc:
             raise ImportError(
                 "RLDS conversion requires tensorflow + tensorflow_datasets: "
-                "pip install 'tether[curate-rlds]'"
+                "pip install 'fastcrest-tether[curate-rlds]'"
             ) from exc
 
         result = ConversionResult(

--- a/src/tether/curate/format_converters/shared/video_encoder.py
+++ b/src/tether/curate/format_converters/shared/video_encoder.py
@@ -72,7 +72,7 @@ def encode_frames_to_mp4(
     except ImportError as exc:
         raise VideoEncoderUnavailable(
             "video encoding requires imageio-ffmpeg + Pillow + numpy: "
-            "pip install 'tether[curate-video]'"
+            "pip install 'fastcrest-tether[curate-video]'"
         ) from exc
 
     # Decode first frame to learn the size + sanity-check.

--- a/src/tether/curate/uploader.py
+++ b/src/tether/curate/uploader.py
@@ -285,7 +285,7 @@ def _request_signed_url(
     try:
         import httpx
     except ImportError as exc:
-        raise UploadStub(f"httpx not available — install tether[serve]: {exc}") from exc
+        raise UploadStub(f"httpx not available — install fastcrest-tether[serve]: {exc}") from exc
 
     url = f"{_worker_url()}/v1/uploads/sign"
     payload = {

--- a/src/tether/diagnostics/check_hardware_compat.py
+++ b/src/tether/diagnostics/check_hardware_compat.py
@@ -63,7 +63,7 @@ def _run(**kwargs) -> CheckResult:
             status="fail",
             expected="onnxruntime importable for version check",
             actual="onnxruntime not installed",
-            remediation="pip install tether[serve] (CPU) or [gpu] (GPU)",
+            remediation="pip install fastcrest-tether[serve] (CPU) or [gpu] (GPU)",
             duration_ms=0.0,
             github_issue=GH_ISSUE,
         )

--- a/src/tether/diagnostics/check_image_dims.py
+++ b/src/tether/diagnostics/check_image_dims.py
@@ -83,7 +83,7 @@ def _run(model_path: str, embodiment_name: str = "custom", **kwargs) -> CheckRes
             status="skip",
             expected="onnxruntime to inspect model inputs",
             actual="onnxruntime not installed",
-            remediation="pip install tether[serve]",
+            remediation="pip install fastcrest-tether[serve]",
             duration_ms=0.0,
             github_issue=GH_ISSUE,
         )

--- a/src/tether/diagnostics/check_libero_importable.py
+++ b/src/tether/diagnostics/check_libero_importable.py
@@ -27,7 +27,7 @@ def _run(model_path: str, **kwargs) -> CheckResult:
             expected="`import libero` succeeds",
             actual=f"ImportError: {exc}",
             remediation=(
-                f"Install via `pip install 'tether[eval-local]'`. "
+                f"Install via `pip install 'fastcrest-tether[eval-local]'`. "
                 f"Required only for `tether eval --runtime local`; "
                 f"--runtime modal ships LIBERO in the bundled image. "
                 f"Phase 1 local fallback is Linux x86_64 only."

--- a/src/tether/diagnostics/check_onnx_provider.py
+++ b/src/tether/diagnostics/check_onnx_provider.py
@@ -23,7 +23,7 @@ def _run(**kwargs) -> CheckResult:
             expected="onnxruntime installed",
             actual="ImportError — onnxruntime is missing",
             remediation=(
-                "pip install tether[serve] (CPU) or tether[gpu] (GPU). "
+                "pip install fastcrest-tether[serve] (CPU) or fastcrest-tether[gpu] (GPU). "
                 "ONNX runtime is required for the inference path."
             ),
             duration_ms=0.0,
@@ -77,7 +77,7 @@ def _run(**kwargs) -> CheckResult:
         actual=f"only CPU EP available (got: {available})",
         remediation=(
             "Running CPU-only is fine for dev. For production, install onnxruntime-gpu: "
-            "pip install tether[gpu]. Per ADR 2026-04-14, --strict-providers fails "
+            "pip install fastcrest-tether[gpu]. Per ADR 2026-04-14, --strict-providers fails "
             "the server if GPU is requested but unavailable."
         ),
         duration_ms=0.0,

--- a/src/tether/diagnostics/check_vla_eval_importable.py
+++ b/src/tether/diagnostics/check_vla_eval_importable.py
@@ -32,7 +32,7 @@ def _run(model_path: str, **kwargs) -> CheckResult:
             actual=f"ImportError: {exc}",
             remediation=(
                 "Adapter import failed. Likely a missing transitive dep. "
-                "Install the eval extra: `pip install 'tether[eval]'`. "
+                "Install the eval extra: `pip install 'fastcrest-tether[eval]'`. "
                 "If reproducible after install, file a bug at "
                 f"{DOCS_URL}."
             ),

--- a/src/tether/diagnostics/check_vlm_tokenization.py
+++ b/src/tether/diagnostics/check_vlm_tokenization.py
@@ -70,7 +70,7 @@ def _run(model_path: str, **kwargs) -> CheckResult:
             expected="transformers installed for tokenizer probe",
             actual="transformers not installed",
             remediation=(
-                "pip install tether[monolithic] to enable tokenizer probes "
+                "pip install fastcrest-tether[monolithic] to enable tokenizer probes "
                 "(only needed if your client tokenizes prompts before /act)."
             ),
             duration_ms=0.0,

--- a/src/tether/embodiments/__init__.py
+++ b/src/tether/embodiments/__init__.py
@@ -53,7 +53,7 @@ def _warn_rtc_horizon_migration(
     )
 
 # Embodiment preset JSONs are bundled INSIDE the package so they ship with
-# `pip install tether` (since v0.5.2). For dev workflows the repo also
+# `pip install fastcrest-tether` (since v0.5.2). For dev workflows the repo also
 # keeps editable copies in <repo>/configs/embodiments/ — those are checked
 # as a fallback when running from source if the in-package presets are
 # missing for some reason. Canonical runtime location is the package.

--- a/src/tether/embodiments/so100/edge_runtime.py
+++ b/src/tether/embodiments/so100/edge_runtime.py
@@ -114,7 +114,7 @@ class SOArmHardware:
             raise ImportError(
                 "SOArmHardware requires the scservo_sdk Python package, which "
                 "is the Pi-side motor SDK for SO-ARM 100. Install via the "
-                "`[so100]` extra: `pip install 'tether[so100]'`. "
+                "`[so100]` extra: `pip install 'fastcrest-tether[so100]'`. "
                 "(scservo_sdk is hardware-bundled; you typically only need it "
                 "on the machine that's wired to the arm.)"
             )

--- a/src/tether/embodiments/so_arm100/__init__.py
+++ b/src/tether/embodiments/so_arm100/__init__.py
@@ -4,7 +4,7 @@ The SO-ARM100 (TheRobotStudio + HuggingFace LeRobot, ~$150-250 BOM, 6-DOF,
 3D-printable) is the reference real-robot for the LeRobot ecosystem. This
 module is Tether's first-class adapter so users with a SO-ARM100 can run:
 
-    pip install tether[lerobot]
+    pip install fastcrest-tether[lerobot]
     tether export lerobot/smolvla_base --embodiment so_arm100 --output bundle/
     tether verify bundle/ --embodiment so_arm100 --num-episodes 30
     tether serve bundle/ --embodiment so_arm100 --port /dev/ttyUSB0

--- a/src/tether/embodiments/so_arm100/adapter.py
+++ b/src/tether/embodiments/so_arm100/adapter.py
@@ -178,7 +178,7 @@ class SOARM100Adapter:
         Hardware deps (`scservo_sdk` / `lerobot.motors.feetech`) are only
         imported here, so this method raises ImportError when the user runs
         on a host without the SDK installed. Use `pip install
-        'tether[so100]'` (existing extra) to pull `scservo_sdk` on the
+        'fastcrest-tether[so100]'` (existing extra) to pull `scservo_sdk` on the
         machine wired to the arm.
         """
         if self._hw is not None:
@@ -365,7 +365,7 @@ class _FeetechAdapterRuntime:
         except ImportError as exc:
             raise ImportError(
                 "Feetech runtime requires `lerobot>=0.5` installed. "
-                "Install via `pip install 'tether[lerobot]'` on the host "
+                "Install via `pip install 'fastcrest-tether[lerobot]'` on the host "
                 "wired to the arm (Python >= 3.12)."
             ) from exc
 

--- a/src/tether/eval/__init__.py
+++ b/src/tether/eval/__init__.py
@@ -2,7 +2,7 @@
 
 Each plugin wraps a simulation benchmark (LIBERO, SimplerEnv, ManiSkill).
 Heavy sim dependencies (MuJoCo, robosuite, LIBERO) live behind the `eval` extra:
-    pip install 'tether[eval]'
+    pip install 'fastcrest-tether[eval]'
 
 The plugin framework is deliberately thin — each benchmark is one function
 that takes an export_dir and returns a standardized result dict.

--- a/src/tether/eval/modal_runner.py
+++ b/src/tether/eval/modal_runner.py
@@ -14,7 +14,7 @@ image + osmesa/MuJoCo recipe + per-suite eval loop). The wrapper:
 4. Builds EpisodeResult per (suite-task, episode) entry
 
 Customer prerequisites:
-- `pip install modal` (or `pip install 'tether[modal]'` once we
+- `pip install modal` (or `pip install 'fastcrest-tether[modal]'` once we
   add that extra)
 - `modal token new` (Modal auth)
 - The repo cloned (so scripts/modal_libero_monolithic_onnx.py is

--- a/src/tether/eval/preflight.py
+++ b/src/tether/eval/preflight.py
@@ -187,7 +187,7 @@ _REMEDIATION_BY_MODE: dict[str, str] = {
         "execute (no AppArmor / SELinux blocks)."
     ),
     "import-error": (
-        "LIBERO import failed. Install via `pip install 'tether[eval-"
+        "LIBERO import failed. Install via `pip install 'fastcrest-tether[eval-"
         "local]'` for local runs, or use --runtime modal which ships LIBERO "
         "in the bundled image."
     ),

--- a/src/tether/eval/report.py
+++ b/src/tether/eval/report.py
@@ -260,7 +260,7 @@ def _git_info(repo_dir: Path) -> tuple[str, bool]:
 def _tether_version() -> str:
     try:
         from importlib.metadata import version
-        return version("tether")
+        return version("fastcrest-tether")
     except Exception:  # noqa: BLE001
         return "0.1.0+dev"
 

--- a/src/tether/exporters/monolithic.py
+++ b/src/tether/exporters/monolithic.py
@@ -6,7 +6,7 @@ onnx-diagnostic patches; same torch.export + torch.onnx.export pipeline;
 same post-export Where-type fix.
 
 Usage (local):
-    pip install 'tether[monolithic]'
+    pip install 'fastcrest-tether[monolithic]'
     tether export lerobot/smolvla_base --monolithic --output ./smol
 
 Requires (pinned in the ``monolithic`` extra):
@@ -148,7 +148,7 @@ def _require_monolithic_deps() -> None:
         raise ImportError(
             "Missing dependencies for monolithic export:\n  - "
             + "\n  - ".join(missing)
-            + "\n\nInstall with: pip install 'tether[monolithic]'"
+            + "\n\nInstall with: pip install 'fastcrest-tether[monolithic]'"
         )
 
 

--- a/src/tether/mcp/server.py
+++ b/src/tether/mcp/server.py
@@ -87,13 +87,13 @@ def create_mcp_server(
 
     Raises:
         ImportError: if `fastmcp` is not installed. Install via
-            `pip install tether[mcp]` or `pip install fastmcp`.
+            `pip install fastcrest-tether[mcp]` or `pip install fastmcp`.
     """
     try:
         from fastmcp import FastMCP
     except ImportError as exc:
         raise ImportError(
-            "fastmcp not installed. Install via `pip install tether[mcp]` "
+            "fastmcp not installed. Install via `pip install fastcrest-tether[mcp]` "
             "or `pip install fastmcp`."
         ) from exc
 

--- a/src/tether/models/adapt.py
+++ b/src/tether/models/adapt.py
@@ -131,7 +131,7 @@ class EmbodimentAdapter:
             return cls(config)
 
         except ImportError:
-            logger.warning("yourdfpy not installed. Install with: pip install 'tether[safety]'")
+            logger.warning("yourdfpy not installed. Install with: pip install 'fastcrest-tether[safety]'")
             raise
 
     @classmethod

--- a/src/tether/pro/telemetry.py
+++ b/src/tether/pro/telemetry.py
@@ -169,7 +169,7 @@ def emit(
     url = endpoint or os.environ.get("TETHER_TELEMETRY_ENDPOINT", DEFAULT_TELEMETRY_ENDPOINT)
 
     # Lazy httpx import — Tether's [serve] extra includes httpx; bare
-    # `pip install tether` includes it as a base dep, so this is safe.
+    # `pip install fastcrest-tether` includes it as a base dep, so this is safe.
     try:
         import httpx
     except ImportError:
@@ -181,7 +181,7 @@ def emit(
             url,
             json=payload.to_dict(),
             timeout=_REQUEST_TIMEOUT_S,
-            headers={"User-Agent": f"tether/{tether_version}"},
+            headers={"User-Agent": f"fastcrest-tether/{tether_version}"},
         )
         if 200 <= resp.status_code < 300:
             logger.debug("Telemetry heartbeat posted: %s", payload.org_hash)
@@ -426,7 +426,7 @@ def emit_free(
                 data=data,
                 headers={
                     "Content-Type": "application/json",
-                    "User-Agent": f"tether/{tether_version}",
+                    "User-Agent": f"fastcrest-tether/{tether_version}",
                 },
                 method="POST",
             )
@@ -445,7 +445,7 @@ def emit_free(
             url,
             json=payload.to_dict(),
             timeout=_REQUEST_TIMEOUT_S,
-            headers={"User-Agent": f"tether/{tether_version}"},
+            headers={"User-Agent": f"fastcrest-tether/{tether_version}"},
         )
         if 200 <= resp.status_code < 300:
             _write_free_cache()

--- a/src/tether/runtime/adapters/vla_eval.py
+++ b/src/tether/runtime/adapters/vla_eval.py
@@ -166,7 +166,7 @@ def build_adapter_class():
 
     Deferred-import pattern: vla-eval's base class is only imported when the
     adapter is actually built, so importing this module (for the pure helpers
-    or for introspection) does not require ``tether[eval]``.
+    or for introspection) does not require ``fastcrest-tether[eval]``.
     """
     try:
         from vla_eval.model_servers.predict import PredictModelServer
@@ -176,7 +176,7 @@ def build_adapter_class():
         except ImportError as e:
             raise ImportError(
                 "vla-eval is not installed. Install with:\n"
-                "    pip install 'tether[eval]'\n"
+                "    pip install 'fastcrest-tether[eval]'\n"
                 "or\n"
                 "    pip install vla-eval"
             ) from e
@@ -427,7 +427,7 @@ def main() -> None:
     except ImportError as e:
         raise ImportError(
             "vla-eval is not installed. Install with:\n"
-            "    pip install 'tether[eval]'"
+            "    pip install 'fastcrest-tether[eval]'"
         ) from e
 
     adapter_cls = build_adapter_class()

--- a/src/tether/runtime/calibration.py
+++ b/src/tether/runtime/calibration.py
@@ -555,7 +555,7 @@ def _probe_ram_gb() -> int:
 
 def _probe_tether_version() -> str:
     """Probe installed tether version. Returns 'unknown' on any failure."""
-    return _safe_pkg_version("tether") or "unknown"
+    return _safe_pkg_version("fastcrest-tether") or "unknown"
 
 
 def _safe_pkg_version(pkg: str) -> str | None:

--- a/src/tether/runtime/ros2_bridge.py
+++ b/src/tether/runtime/ros2_bridge.py
@@ -425,7 +425,7 @@ def run_ros2_bridge(
             from tether.mcp import create_mcp_server, register_ros2_tools
         except ImportError as exc:
             raise ImportError(
-                "MCP optional dep not installed. Run: pip install 'tether[mcp]'"
+                "MCP optional dep not installed. Run: pip install 'fastcrest-tether[mcp]'"
             ) from exc
 
         mcp_srv = create_mcp_server(server)

--- a/src/tether/runtime/rtc_adapter.py
+++ b/src/tether/runtime/rtc_adapter.py
@@ -55,7 +55,7 @@ def require_rtc() -> None:
     """Raise if lerobot's RTC module isn't installed in this env."""
     if not _RTC_AVAILABLE:
         raise ImportError(
-            "lerobot.policies.rtc not available. Install tether[rtc] "
+            "lerobot.policies.rtc not available. Install fastcrest-tether[rtc] "
             "or pip install lerobot>=0.5.1."
         )
 

--- a/src/tether/runtime/server.py
+++ b/src/tether/runtime/server.py
@@ -1227,7 +1227,7 @@ def create_app(
         from fastapi import Depends, FastAPI, Header, HTTPException
         from fastapi.responses import JSONResponse
     except ImportError:
-        raise ImportError("Install fastapi: pip install 'tether[serve]'")
+        raise ImportError("Install fastapi: pip install 'fastcrest-tether[serve]'")
 
     # Route: decomposed-ONNX by default; native PyTorch path under TETHER_NATIVE=1.
     # The native path bypasses our ONNX export and runs lerobot's SmolVLAPolicy

--- a/src/tether/runtime/tracing.py
+++ b/src/tether/runtime/tracing.py
@@ -66,7 +66,7 @@ def setup_tracing(
 
     if not _check_otel_available():
         logger.info(
-            "OTel tracing skipped — `pip install tether[tracing]` to enable."
+            "OTel tracing skipped — `pip install fastcrest-tether[tracing]` to enable."
         )
         return False
 

--- a/src/tether/safety/guard.py
+++ b/src/tether/safety/guard.py
@@ -70,7 +70,7 @@ class SafetyLimits:
                 effort_max=eff_max,
             )
         except ImportError:
-            logger.warning("yourdfpy not installed. Install with: pip install 'tether[safety]'")
+            logger.warning("yourdfpy not installed. Install with: pip install 'fastcrest-tether[safety]'")
             return cls()
 
     @classmethod

--- a/src/tether/upgrade_check.py
+++ b/src/tether/upgrade_check.py
@@ -14,7 +14,7 @@ import time
 from pathlib import Path
 
 CACHE_TTL_SECONDS = 24 * 60 * 60
-PYPI_URL = "https://pypi.org/pypi/tether/json"
+PYPI_URL = "https://pypi.org/pypi/fastcrest-tether/json"
 
 
 def _cache_path() -> Path:
@@ -28,11 +28,11 @@ def _is_dev_install() -> bool:
     presumably developing tether itself and doesn't want a nag.
 
     Only `.pth`-style editable installs trigger this. Regular `pip install .`
-    or `pip install tether` from PyPI both proceed normally.
+    or `pip install fastcrest-tether` from PyPI both proceed normally.
     """
     try:
         from importlib.metadata import distribution
-        dist = distribution("tether")
+        dist = distribution("fastcrest-tether")
         # Editable installs (pip install -e .) leave a __editable__*.pth
         # file in site-packages that re-routes to the source dir.
         files = dist.files or []
@@ -113,6 +113,6 @@ def maybe_nag(current_version: str) -> None:
 
     if _parse_version(latest) > _parse_version(current_version):
         sys.stderr.write(
-            f"\033[2m[tether] {latest} is available — upgrade: pip install -U tether "
+            f"\033[2m[tether] {latest} is available — upgrade: pip install -U fastcrest-tether "
             f"(you have {current_version}, set TETHER_NO_UPGRADE_CHECK=1 to silence)\033[0m\n"
         )

--- a/src/tether/validation/dataset_checks.py
+++ b/src/tether/validation/dataset_checks.py
@@ -230,7 +230,7 @@ def check_shape_consistency(ctx: DatasetContext) -> CheckResult:
         return CheckResult(
             check_id="dataset.shape-consistency",
             decision=Decision.SKIPPED,
-            summary="pyarrow not installed; install tether[validation] to enable",
+            summary="pyarrow not installed; install fastcrest-tether[validation] to enable",
         )
     declared_shape = ctx.info["features"]["action"].get("shape", [])
     declared_dim = declared_shape[0] if declared_shape else None
@@ -290,7 +290,7 @@ def check_action_finite(ctx: DatasetContext) -> CheckResult:
         return CheckResult(
             check_id="dataset.action-finite",
             decision=Decision.SKIPPED,
-            summary="pyarrow not installed; install tether[validation] to enable",
+            summary="pyarrow not installed; install fastcrest-tether[validation] to enable",
         )
     table, err = _load_parquet_table(ctx.data_files[0])
     if err or table is None:


### PR DESCRIPTION
## Why

`pip install tether` was broken site-wide because **PyPI prohibits the project name `tether`** — upload returns `400: The name 'tether' isn't allowed` (reserved/blocked list, confirmed: the name 404s yet can't be registered). Published v0.12.0 as **`fastcrest-tether`** instead.

The import package (`import tether`) and the CLI command (`tether …`) are **unchanged** — only the pip distribution name differs. Same dist/command split `reflex-vla` → `reflex` already used.

## ✅ Published & verified live
- https://pypi.org/project/fastcrest-tether/0.12.0/
- `uv pip install fastcrest-tether` in a clean env → `tether --version` prints `tether 0.12.0`; `importlib.metadata.version('fastcrest-tether')` resolves
- twine check PASSED on both sdist + wheel; `reflex` compat shim still imports with its deprecation warning

## Changes
- **pyproject**: `name = "fastcrest-tether"`
- **All install specs** (`pip install 'tether[...]'`, `tether @ git+…`) across README, docs, install.sh, examples, launch, contrib, ci_template, ~60 Modal scripts → `fastcrest-tether`. CLI command strings `tether …` left untouched.
- **Badges + pypistats** → fastcrest-tether
- **Functional metadata lookups rewired** to the real dist name so they don't silently break (same bug class as #221): `upgrade_check.distribution()`, bench/eval `version()`, calibration `_safe_pkg_version`, `agent/hardware._package_version` (JSON key `tether_version` kept), comply/sbom purl+name, doctor label, telemetry User-Agent, install_digest PACKAGES.

## Kept as `tether`
import package, CLI command + entry point, git repo + clone dir (FastCrest/tether), GHCR image, OTel service name, `TETHER_*` env, `tether_version` wire field, `src/reflex` shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)