### PR TITLE
fix(client): make `from tether import TetherClient` work + ReflexClient alias

### DIFF
--- a/src/tether/__init__.py
+++ b/src/tether/__init__.py
@@ -29,7 +29,30 @@ __all__ = [
     "SUPPORTED_MODEL_TYPES",
     "UNSUPPORTED_MODEL_MESSAGE",
     "load_fixtures",
+    # Customer SDK surface — re-exported from tether.client so a bare
+    # `pip install fastcrest-tether` gives `from tether import TetherClient`.
+    # httpx is a base dep, so this is cheap (no torch); lazy-loaded below.
+    "TetherClient",
+    "TetherAsyncClient",
+    "TetherClientError",
+    "TetherAuthError",
+    "TetherServerDegradedError",
+    "TetherServerNotReadyError",
+    "TetherValidationError",
+    "encode_image",
 ]
+
+# Names re-exported from tether.client (lazy — see __getattr__).
+_CLIENT_EXPORTS = frozenset({
+    "TetherClient",
+    "TetherAsyncClient",
+    "TetherClientError",
+    "TetherAuthError",
+    "TetherServerDegradedError",
+    "TetherServerNotReadyError",
+    "TetherValidationError",
+    "encode_image",
+})
 
 
 # ─── ORT-TRT EP first-class support (v0.7) ──────────────────────────────────
@@ -125,7 +148,6 @@ def _eager_dlopen_nvidia_libs() -> None:
     cached handle. No-op on macOS/Windows or when libs don't exist.
     """
     import ctypes
-    import glob
     import os
     import sys
 
@@ -193,4 +215,7 @@ def __getattr__(name: str):
     if name == "load_fixtures":
         from tether.fixtures import load_fixtures
         return load_fixtures
+    if name in _CLIENT_EXPORTS:
+        import tether.client as _client
+        return getattr(_client, name)
     raise AttributeError(f"module 'tether' has no attribute {name!r}")

--- a/src/tether/client/__init__.py
+++ b/src/tether/client/__init__.py
@@ -42,6 +42,41 @@ from tether.client.client import (
     encode_image,
 )
 
+class ReflexClient(TetherClient):
+    """Deprecated alias for :class:`TetherClient`. Removed in v0.14.0.
+
+    Kept so pre-rename code (`from tether.client import ReflexClient`) keeps
+    working through the v0.13.x compat window, matching the `reflex` import
+    shim's removal schedule.
+    """
+
+    def __init__(self, *args, **kwargs):
+        import warnings
+
+        warnings.warn(
+            "ReflexClient is deprecated; use TetherClient. "
+            "The alias is removed in tether v0.14.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class ReflexAsyncClient(TetherAsyncClient):
+    """Deprecated alias for :class:`TetherAsyncClient`. Removed in v0.14.0."""
+
+    def __init__(self, *args, **kwargs):
+        import warnings
+
+        warnings.warn(
+            "ReflexAsyncClient is deprecated; use TetherAsyncClient. "
+            "The alias is removed in tether v0.14.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
 __all__ = [
     "TetherClient",
     "TetherAsyncClient",
@@ -51,4 +86,7 @@ __all__ = [
     "TetherServerNotReadyError",
     "TetherValidationError",
     "encode_image",
+    # Deprecated rename-compat aliases (removed v0.14.0).
+    "ReflexClient",
+    "ReflexAsyncClient",
 ]

--- a/src/tether/client/client.py
+++ b/src/tether/client/client.py
@@ -99,6 +99,18 @@ def encode_image(image: Any, jpeg_quality: int = 85) -> str:
         if len(image) >= 8 and image[:8] == b"\x89PNG\r\n\x1a\n":
             return base64.b64encode(image).decode("ascii")
         return base64.b64encode(image).decode("ascii")
+    # The only remaining valid inputs are numpy.ndarray and PIL.Image, both of
+    # which need Pillow. Reject obviously-unsupported types (dict, int, list…)
+    # BEFORE requiring Pillow, so the error names the real problem rather than
+    # blaming a missing optional dep on a caller who passed garbage.
+    _cls = type(image)
+    _image_like = (
+        _cls.__module__.split(".")[0] in ("PIL", "numpy")
+        or hasattr(image, "__array_interface__")
+        or (hasattr(image, "save") and hasattr(image, "size"))
+    )
+    if not _image_like:
+        raise TetherClientError(f"unsupported image type: {_cls.__name__}")
     try:
         from PIL import Image as PILImage
     except ImportError:
@@ -211,7 +223,6 @@ class TetherClient:
     # ---- Internals -------------------------------------------------------
 
     def _request_with_retry(self, method: str, path: str, **kw) -> httpx.Response:
-        last_exc: TetherClientError | None = None
         attempt = 0
         backoff = self.initial_backoff_s
         while True:
@@ -244,7 +255,6 @@ class TetherClient:
             )
             time.sleep(wait)
             attempt += 1
-            last_exc = err
 
     # ---- Public surface --------------------------------------------------
 


### PR DESCRIPTION
Completes the SDK side of the v0.12.0 rename (audit §3.9, client H1/H2 + L1/L6).

## Changes

| # | Fix | Detail |
|---|---|---|
| H2 | `from tether import TetherClient` now works | The pyproject comment + reflex shim docstring promised it, but the top-level `__getattr__` only exposed the validate/fixtures surface → `AttributeError`. Now re-exports the full SDK lazily from `tether.client` (httpx is a base dep, so no torch cost). |
| H1 | `ReflexClient` / `ReflexAsyncClient` deprecation aliases | Pre-rename code doing `from tether.client import ReflexClient` keeps working through v0.13.x (warns once, removed v0.14.0 — matches the `reflex` import-shim schedule). README snippets were already fixed to `TetherClient` in #224; this covers users with the old name in their own code. |
| L6 | `encode_image` error accuracy | Passing an unsupported type (dict/int/…) when Pillow was absent reported "Pillow required" instead of "unsupported image type". Now rejects non-image-like inputs before requiring Pillow; real ndarray/PIL inputs still get the Pillow message. |
| L1 | dead-code cleanup | removed unused `last_exc` (sync retry loop) and an unused `glob` import. |

## Verification
- `tests/test_client.py`: **29 passed, 2 skipped** (the previously-failing `test_encode_unsupported_type_raises` now passes — it was asserting the L6 behavior).
- Top-level import + `tether.TetherClient is TetherClient` + alias DeprecationWarning unit-checked.
- `ruff check` clean on all touched files.

Not included (needs a customer-facing API decision, flagged separately): client **M5** — capping a server-supplied `Retry-After` would add a new constructor kwarg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
