### PR TITLE
fix(infra): deploy workers as tether-* + accept tether_version field

### DIFF
--- a/infra/contribution-worker/README.md
+++ b/infra/contribution-worker/README.md
@@ -6,7 +6,7 @@ stats, and revoke-cascade requests for the data contribution program.
 Sibling workers (each in its own folder under `infra/`):
 - `license-worker` — Pro license issuance + revocation (deployed)
 - `telemetry-worker` — opt-in telemetry (built, not yet deployed)
-- `contribution-worker` — this one (deployed at `https://reflex-contributions.fastcrest.workers.dev`)
+- `contribution-worker` — this one (deployed at `https://tether-contributions.fastcrest.workers.dev`)
 
 ## Endpoints
 
@@ -74,7 +74,7 @@ wrangler secret put SLACK_WEBHOOK_URL    # optional
 wrangler deploy
 
 # 6. Smoke test
-curl https://reflex-contributions.<account>.workers.dev/healthz
+curl https://tether-contributions.<account>.workers.dev/healthz
 
 # 7. Bind a custom domain (optional)
 # Edit wrangler.toml routes section, then redeploy.

--- a/infra/contribution-worker/wrangler.toml
+++ b/infra/contribution-worker/wrangler.toml
@@ -1,4 +1,4 @@
-name = "reflex-contributions"
+name = "tether-contributions"
 main = "worker.js"
 compatibility_date = "2026-05-01"
 

--- a/infra/data-worker/wrangler.toml
+++ b/infra/data-worker/wrangler.toml
@@ -1,4 +1,4 @@
-name = "reflex-data"
+name = "tether-data"
 main = "worker.js"
 compatibility_date = "2026-05-01"
 

--- a/infra/license-worker/README.md
+++ b/infra/license-worker/README.md
@@ -44,10 +44,10 @@ wrangler secret put SLACK_WEBHOOK_URL
 
 # 7. Deploy the worker
 wrangler deploy
-# → note the URL (e.g. https://reflex-licenses.<subdomain>.workers.dev)
+# → note the URL (e.g. https://tether-licenses.<subdomain>.workers.dev)
 
 # 8. Generate the Ed25519 keypair (one-time)
-curl -X POST https://reflex-licenses.<subdomain>.workers.dev/admin/init \
+curl -X POST https://tether-licenses.<subdomain>.workers.dev/admin/init \
     -H "Authorization: Bearer <YOUR_ADMIN_TOKEN>"
 # → response includes public_key_b64 + private_key_b64
 # IMMEDIATELY:
@@ -62,15 +62,15 @@ curl -X POST https://reflex-licenses.<subdomain>.workers.dev/admin/init \
 # 10. Commit + push the public-key + endpoint changes
 
 # Test the live worker
-curl https://reflex-licenses.<subdomain>.workers.dev/healthz
-curl https://reflex-licenses.<subdomain>.workers.dev/v1/pubkey
+curl https://tether-licenses.<subdomain>.workers.dev/healthz
+curl https://tether-licenses.<subdomain>.workers.dev/v1/pubkey
 ```
 
 ## Issue your first license
 
 ```bash
 # From your laptop (admin CLI talks to the worker)
-export TETHER_LICENSE_ENDPOINT=https://reflex-licenses.<subdomain>.workers.dev
+export TETHER_LICENSE_ENDPOINT=https://tether-licenses.<subdomain>.workers.dev
 export REFLEX_ADMIN_TOKEN=<your_admin_token>
 
 python -m tether.admin.issue_license \

--- a/infra/license-worker/worker.js
+++ b/infra/license-worker/worker.js
@@ -122,7 +122,7 @@ async function adminInit(request, env) {
     next_steps: [
       `1. Set the private key as a Worker Secret IMMEDIATELY:`,
       `     echo '${privB64}' | wrangler secret put PRIVATE_KEY`,
-      `2. Paste the public_key_b64 into src/reflex/pro/_public_key.py BUNDLED_PUBLIC_KEY_B64`,
+      `2. Paste the public_key_b64 into src/tether/pro/_public_key.py BUNDLED_PUBLIC_KEY_B64`,
       `3. Commit + push the public key change`,
       `4. The private key from this response is ONE-TIME — discard it after setting the Secret`,
     ],
@@ -292,7 +292,11 @@ async function postHeartbeat(request, env) {
   const body = await request.json().catch(() => ({}));
   const licenseId = String(body.license_id || "").trim();
   const hardwareFingerprint = String(body.hardware_fingerprint || "").trim();
-  const reflexVersion = String(body.reflex_version || "unknown").slice(0, 64);
+  // Accept tether_version (current clients) or reflex_version (legacy). Without
+  // this the renamed client sends tether_version and this column was recorded
+  // as all-"unknown" — silent version-analytics loss. D1 column stays
+  // reflex_version for continuity.
+  const tetherVersion = String(body.tether_version || body.reflex_version || "unknown").slice(0, 64);
   if (!licenseId || !hardwareFingerprint) {
     return jsonResponse(400, { error: "license_id_and_hardware_fingerprint_required" });
   }
@@ -322,7 +326,7 @@ async function postHeartbeat(request, env) {
     `INSERT INTO heartbeats
      (license_id, hardware_fingerprint, ip_country, reflex_version, server_timestamp)
      VALUES (?, ?, ?, ?, ?)`
-  ).bind(licenseId, hardwareFingerprint, country, reflexVersion, new Date().toISOString()).run();
+  ).bind(licenseId, hardwareFingerprint, country, tetherVersion, new Date().toISOString()).run();
 
   // Sharing-detection check (async; doesn't block response).
   detectSharing(licenseId, env).catch((e) => console.error("sharing-detect failed:", e.message));

--- a/infra/license-worker/wrangler.toml
+++ b/infra/license-worker/wrangler.toml
@@ -1,4 +1,4 @@
-name = "reflex-licenses"
+name = "tether-licenses"
 main = "worker.js"
 compatibility_date = "2026-05-01"
 

--- a/infra/telemetry-worker/README.md
+++ b/infra/telemetry-worker/README.md
@@ -53,7 +53,7 @@ wrangler deploy
 # Edit wrangler.toml, uncomment the `routes` block, redeploy
 ```
 
-After deploy, the default URL is `https://reflex-telemetry.<your-subdomain>.workers.dev`. Update `DEFAULT_TELEMETRY_ENDPOINT` in `src/tether/pro/telemetry.py` if you use a different URL than `https://telemetry.fastcrest.workers.dev/v1/heartbeat`.
+After deploy, the default URL is `https://tether-telemetry.<your-subdomain>.workers.dev`. The client default is `DEFAULT_TELEMETRY_ENDPOINT = https://tether-telemetry.fastcrest.workers.dev/v1/heartbeat` in `src/tether/pro/telemetry.py` — update it there if your deployed subdomain differs.
 
 ## Common queries
 

--- a/infra/telemetry-worker/worker.js
+++ b/infra/telemetry-worker/worker.js
@@ -56,8 +56,17 @@ export default {
       });
     }
 
+    // Accept tether_version (current clients) OR reflex_version (legacy
+    // reflex-vla clients) and normalize to tether_version. Without this the
+    // renamed client (which sends tether_version) hit "missing_field" 400 on
+    // every heartbeat — 100% telemetry loss. The D1 column stays reflex_version
+    // for data continuity.
+    if (payload.tether_version == null && payload.reflex_version != null) {
+      payload.tether_version = payload.reflex_version;
+    }
+
     // Schema validation. v1 fields are LOCKED — additive-only Phase 2.
-    const required = ["schema_version", "license_id", "org_hash", "workload", "reflex_version", "timestamp"];
+    const required = ["schema_version", "license_id", "org_hash", "workload", "tether_version", "timestamp"];
     for (const field of required) {
       if (!(field in payload)) {
         return new Response(
@@ -83,7 +92,7 @@ export default {
     if (
       typeof payload.license_id !== "string" || payload.license_id.length > 256 ||
       typeof payload.org_hash !== "string" || payload.org_hash.length !== 16 ||
-      typeof payload.reflex_version !== "string" || payload.reflex_version.length > 64 ||
+      typeof payload.tether_version !== "string" || payload.tether_version.length > 64 ||
       typeof payload.timestamp !== "string" || payload.timestamp.length > 64 ||
       typeof payload.workload !== "object" || payload.workload === null
     ) {
@@ -125,7 +134,7 @@ export default {
             payload.org_hash,
             vlaFamily,
             hardwareTier,
-            payload.reflex_version,
+            payload.tether_version,  // D1 column stays `reflex_version` (continuity)
             payload.timestamp,
             new Date().toISOString(),
             modelName,

--- a/infra/telemetry-worker/wrangler.toml
+++ b/infra/telemetry-worker/wrangler.toml
@@ -1,4 +1,4 @@
-name = "reflex-telemetry"
+name = "tether-telemetry"
 main = "worker.js"
 compatibility_date = "2026-05-01"
 


### PR DESCRIPTION
Audit §3.11 / Part 1 #18 — every networked feature was silently dead by default.

## Problem
All 4 Cloudflare workers deployed under `reflex-*` names while every v0.12.0 client defaults to `tether-*.workers.dev` — so activation, license heartbeat, telemetry, curate uploads, and episode uploads all hit **dead hostnames** (failures swallowed at debug).

Plus field drift: the telemetry worker **required** `reflex_version` and the license worker read `body.reflex_version`, but the renamed client sends `tether_version` → telemetry 400'd on every heartbeat (100% loss); license version recorded as all-"unknown".

## Fix
- Renamed worker `name` in all 4 `wrangler.toml` to `tether-*`. **D1 `database_name` stays `reflex-*`** (data continuity — intentional).
- Both workers now accept `tether_version || reflex_version` (D1 columns keep the `reflex_version` name).
- Fixed the license worker's `/admin/init` pointer (`src/reflex/` → `src/tether/`) and updated deploy READMEs to the `tether-*` hostnames.

Both `worker.js` pass `node --check`.

## Operator action
Redeploy the 4 workers (`wrangler deploy`) for the new names to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)