### PR TITLE
docs: correct README parity claim — 4 verified families, not 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Every response surfaces telemetry from each enabled wedge (`guard_clamped`, `gua
 
 ## What Tether is and isn't
 
-**Is:** the deployment layer between a trained VLA and a real robot. Cross-framework export verified at cos=+1.0000000 on six VLA families — SmolVLA + pi0 + pi0.5 (flow-matching, num_steps=10) + GR00T N1.6 (DDPM DiT, num_steps=4, **with Eagle 2.5 VL backbone producing live image+language KV**) + DreamZero (world-action model, joint video + action diffusion) + OpenVLA (shim) — plus a composable runtime (serve + safety + turbo + split), edge-first design targeting Jetson + desktop NVIDIA GPUs.
+**Is:** the deployment layer between a trained VLA and a real robot. Cross-framework export verified at cos=+1.0000000 on four VLA families — SmolVLA + pi0 + pi0.5 (flow-matching, num_steps=10) + GR00T N1.6 (DDPM DiT, num_steps=4, **with Eagle 2.5 VL backbone producing live image+language KV**). DreamZero (world-action model — config + PyTorch runtime today, DiT ONNX in progress) and OpenVLA (optimum-cli shim + postprocess helper) are supported but not yet numerically verified through a Tether ONNX export. Plus a composable runtime (serve + safety + turbo + split), edge-first design targeting Jetson + desktop NVIDIA GPUs.
 
 **Isn't:** a training framework (PyTorch/JAX own that) or a cloud inference provider (vLLM/Baseten own that). Tether's moat is the deployment toolchain: cross-framework ONNX with verified numerical parity, composable safety wedges, ROS2 + Docker + HTTP serving, and a deterministic export receipt (`VERIFICATION.md`) your QA team can audit.
 


### PR DESCRIPTION
Audit §3.3 (exporter-parity investigation, Claim 4). The parity claim is the product, so an over-claim a prospect can falsify is exactly the trust-killer to remove.

README:459 claimed `cos=+1.0000000` on **six** VLA families including DreamZero and OpenVLA. Verified against the code:
- **DreamZero** — `exporters/dreamzero.py:91` returns `status="config_only"`; DiT ONNX export explicitly deferred (`:94,108`). No ONNX.
- **OpenVLA** — `exporters/openvla.py:92,99` raise `NotImplementedError` (points to optimum-cli). No Tether ONNX.

Only **SmolVLA, pi0, pi0.5, GR00T N1.6** have a verified cos=1.0 Tether ONNX export — matching the hero paragraph (line 14, already "ALL four major open VLAs") and the parity table. Corrected line 459 to four verified families; DreamZero/OpenVLA described accurately as supported-but-not-yet-ONNX-verified.

Doc-only, zero code risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)