### PR TITLE
docs: fix inaccurate README/docs claims (verb count, dead links, stale what's-new, bad example flags)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ uv pip install -e .
 # sanity check your box
 tether doctor
 
-# run a test policy
-tether serve --policy smolvla --device cuda
+# run a smoke test (one-command deploy: probe -> pull -> export -> serve)
+tether go --model smolvla-base
 ```
 
 full setup details in `examples/01-chat-quickstart.md`.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 **The deployment layer for VLAs** — take a Vision-Language-Action model off the training cluster and onto a robot. Now with **`tether chat`** — talk to your robot fleet in plain English.
 
-**Verified parity across ALL four major open VLAs.** Tether's monolithic ONNX export matches the reference PyTorch policy to **cos = +1.000000** end-to-end on SmolVLA, pi0, pi0.5 (canonical 10-step flow-matching unrolled) and GR00T N1.6 (canonical 4-step DDIM loop external to the ONNX). Per-model first-action max_abs: SmolVLA 5.96e-07, pi0 2.09e-07, pi0.5 2.38e-07, GR00T 8.34e-07 — all at machine precision, shared seeded inputs. Full claim ledger in [reflex_context/measured_numbers.md](reflex_context/measured_numbers.md).
+**Verified parity across ALL four major open VLAs.** Tether's monolithic ONNX export matches the reference PyTorch policy to **cos = +1.000000** end-to-end on SmolVLA, pi0, pi0.5 (canonical 10-step flow-matching unrolled) and GR00T N1.6 (canonical 4-step DDIM loop external to the ONNX). Per-model first-action max_abs: SmolVLA 5.96e-07, pi0 2.09e-07, pi0.5 2.38e-07, GR00T 8.34e-07 — all at machine precision, shared seeded inputs. Full claim ledger in the private `reflex_context/measured_numbers.md` vault (not in this repo).
 
-One CLI, eleven verbs, plus a chat agent.
+One CLI, a focused set of verbs, plus a chat agent.
 
 ## Install
 
@@ -34,6 +34,10 @@ pip install 'fastcrest-tether[serve,onnx]'              # Mac / CPU runtime
 ```
 
 Requires Python ≥ 3.10.
+
+### What's new in v0.12.0 (2026-06-03)
+
+- **Project renamed Reflex to Tether.** PyPI distribution is now `fastcrest-tether`; CLI command is `tether`; Python import is `from tether import ...`; env vars are `TETHER_*`. A backwards-compat shim keeps the old `reflex` names working through v0.13.x and removes them in v0.14.0.
 
 ### What's new in v0.11.2 (2026-05-29)
 
@@ -113,7 +117,7 @@ modal profile activate <your-profile>
 modal run scripts/modal_v07_runtime_spike.py
 ```
 
-Full reproducer + 9-iteration debug log: [`reflex_context/03_experiments/2026-04-29-v07-runtime-spike.md`](reflex_context/03_experiments/2026-04-29-v07-runtime-spike.md).
+Full reproducer + 9-iteration debug log: `reflex_context/03_experiments/2026-04-29-v07-runtime-spike.md` (private vault, not in this repo).
 
 ### Caveats
 
@@ -268,7 +272,7 @@ tether pro     {activate, status, deactivate}   # Pro tier license
 tether contribute  {opt-in, opt-out, status}    # Curate data contribution
 ```
 
-11 visible verbs. 8 advanced/SO-100/internal commands stay callable directly (config, calibrate, bench-game, status, inspect bench/targets/guard/doctor) but hidden from `--help` to reduce cognitive load. Power-users can still invoke them; they just don't crowd the discovery surface.
+Core user-facing verbs shown above. Additional advanced/SO-100/internal commands stay callable directly (config, calibrate, bench-game, status, inspect bench/targets/guard/doctor) but hidden from `--help` to reduce cognitive load. Power-users can still invoke them; they just don't crowd the discovery surface.
 
 Hidden legacy commands (`export`, `bench`, `replay`, etc.) stay callable as alias bridges.
 
@@ -481,7 +485,7 @@ Plus PyTorch-level native-path sanity checks (`SmolVLAPolicy` with DecomposedRMS
 
 **About the production defaults**: flow-matching VLAs (SmolVLA, pi0, pi0.5) canonically integrate the velocity field with 10 Euler steps — the ONNX bakes in the unrolled loop. GR00T is DDPM-style diffusion with 4 canonical steps — the ONNX exports one velocity step, and `tether serve` wraps it in the loop. All four match canonical PyTorch to machine precision. Getting pi0 / pi0.5 there required three interacting patches under `torch.export` (F.pad causal mask, frozen `DynamicLayer.update`, `past_kv.get_seq_length()` for mask assembly); GR00T's simpler DiT graph (no DynamicCache, no PaliGemma masking) traces cleanly via plain `torch.onnx.export(opset=19)` — no patches needed. Details in `reflex_context/01_architecture/pi0_monolithic_wrap_pattern.md`.
 
-Full ledger: [reflex_context/measured_numbers.md](reflex_context/measured_numbers.md).
+Full ledger: `reflex_context/measured_numbers.md` (private vault, not in this repo).
 
 **Latency numbers are intentionally not in the README yet** — earlier TRT FP16 tables were measured on a now-abandoned decomposed-ONNX path. `tether bench <export_dir>` reproduces on any hardware.
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,6 +1,6 @@
 # Third-party licenses
 
-Reflex VLA bundles or vendors code from the following projects. Each
+Tether bundles or vendors code from the following projects. Each
 project's full license text is reproduced below in alphabetical order.
 
 ## auto_soarm (MIT)
@@ -10,14 +10,14 @@ Vendored: 2026-05-06 (initial lift)
 Scope: tablet-tap automation rig for SO-ARM 100 + Android tablet.
 
 Lifted into:
-- `src/reflex/embodiments/so100/calibration/` — calibration scripts +
+- `src/tether/embodiments/so100/calibration/` — calibration scripts +
   motion + tapper logic
-- `src/reflex/embodiments/so100/edge_runtime.py` — no-torch arm driver
+- `src/tether/embodiments/so100/edge_runtime.py` — no-torch arm driver
   (`arm_hardware.py`)
-- `src/reflex/bench/games/_base/` — generic game scaffold
+- `src/tether/bench/games/_base/` — generic game scaffold
   (`base_game.py`, `tablet_setup.py`, `circle_runtime.py`,
   `touch_server.py`)
-- `src/reflex/bench/games/circle_lr/` — canonical circle-tap benchmark
+- `src/tether/bench/games/circle_lr/` — canonical circle-tap benchmark
 - `examples/01_circle_tap_so100/` — end-to-end recipe (collect + train + eval)
 
 Per-file headers identify ported files:
@@ -26,7 +26,7 @@ Per-file headers identify ported files:
 # Source: https://github.com/0o8o0-blip/auto_soarm
 ```
 
-Architectural decisions: `reflex_context/01_decisions/2026-05-06-vendor-auto-soarm.md`.
+Architectural decisions: `reflex_context/01_decisions/2026-05-06-vendor-auto-soarm.md` (private vault, not in this repo).
 
 ### MIT License
 

--- a/examples/02-deploy-smolvla-jetson.md
+++ b/examples/02-deploy-smolvla-jetson.md
@@ -62,7 +62,7 @@ Since monolithic export requires Python 3.12+ (for `lerobot`), the typical Jetso
 ```bash
 # On your desktop / cloud GPU (Python 3.12+)
 pip install 'fastcrest-tether[serve,monolithic]'
-tether export --model smolvla-base --out ./smolvla-export/
+tether export smolvla-base --output ./smolvla-export/
 ```
 
 Then copy the export directory to the Jetson:


### PR DESCRIPTION
## Summary

- **Verb count fixed**: README line 16 said "eleven verbs" and line 275 said "11 visible verbs" — the actual CLI has 18+ visible top-level commands (6 standalone `@app.command()` + 12 non-hidden `app.add_typer()` groups). Rephrased both to "a focused set of verbs" / "Core user-facing verbs shown above" to avoid a brittle exact count.
- **Dead `reflex_context/` hyperlinks removed**: Three clickable markdown links in README pointed into the private `reflex_context/` vault (not in this repo): `reflex_context/measured_numbers.md` (×2) and `reflex_context/03_experiments/2026-04-29-v07-runtime-spike.md`. Each link is de-linked; surrounding prose is kept, with a note that it is in the private vault.
- **v0.12.0 "What's new" entry added**: The top of the README's version history stopped at v0.11.2 (2026-05-29). Added a brief v0.12.0 (2026-06-03) entry covering the Reflex→Tether rename, the `fastcrest-tether` PyPI dist, `tether` CLI/import, and the `reflex` compat shim lifecycle (supported through v0.13.x, removed in v0.14.0). Mirrors CHANGELOG.md `d444db8`.
- **CONTRIBUTING.md quickstart fixed**: The dev-setup snippet told contributors to run `tether serve --policy smolvla --device cuda`. The `--policy` flag does not exist on `tether serve` (which takes a positional `export_dir`). Replaced with `tether go --model smolvla-base`, the correct one-command smoke-test path.
- **Jetson example flags fixed** (`examples/02-deploy-smolvla-jetson.md` line 65): `tether export --model smolvla-base --out ./smolvla-export/` used two nonexistent flags. The real `export` signature has `MODEL` as a positional argument and `--output` (not `--out`). Fixed to `tether export smolvla-base --output ./smolvla-export/`.
- **THIRD_PARTY_LICENSES.md updated**: Header said "Reflex VLA bundles or vendors code" — updated to "Tether bundles or vendors code". Four `src/reflex/` paths describing where this project's own vendored code was lifted into were updated to `src/tether/`. Upstream third-party names, licenses, and the MIT license text are untouched.

## Before / after (key changes)

| File | Before | After |
|---|---|---|
| README.md:16 | "One CLI, eleven verbs, plus a chat agent." | "One CLI, a focused set of verbs, plus a chat agent." |
| README.md:275 | "11 visible verbs." | "Core user-facing verbs shown above." |
| README.md:14,484 | `[reflex_context/measured_numbers.md](...)` | `` `reflex_context/measured_numbers.md` (private vault, not in this repo) `` |
| README.md:116 | `` [`reflex_context/03_experiments/...`](...) `` | `` `reflex_context/03_experiments/...` (private vault, not in this repo) `` |
| README.md | _(no v0.12.0 entry)_ | Added v0.12.0 rename bullet |
| CONTRIBUTING.md | `tether serve --policy smolvla --device cuda` | `tether go --model smolvla-base` |
| examples/02-deploy-smolvla-jetson.md:65 | `tether export --model smolvla-base --out ./smolvla-export/` | `tether export smolvla-base --output ./smolvla-export/` |
| THIRD_PARTY_LICENSES.md | "Reflex VLA bundles..." / `src/reflex/` paths | "Tether bundles..." / `src/tether/` paths |

## Test plan

- [ ] Verify README renders correctly in GitHub preview (no broken link syntax)
- [ ] Confirm `tether export --help` shows `MODEL` as positional and `--output` (not `--out`) in the real CLI
- [ ] Confirm `tether serve --help` shows no `--policy` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)