### PR TITLE
fix(docker): align Jetson arm64 image tag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ Filter dimensions: `--since` (`7d` / `24h` / `30m`), `--task` (case-insensitive 
 | Ampere (RTX 30-series, A10G, A100) | sm_8.0–8.6 | ✅ Supported | Tested on Modal A10G + A100, RTX 4090 |
 | Ada Lovelace (RTX 40-series, L4) | sm_8.9 | ✅ Supported | |
 | Hopper (H100, H200) | sm_9.0 | ✅ Supported | |
-| Jetson Orin (Orin Nano / NX / AGX) | sm_8.7 | ✅ Supported | JetPack 5.x or 6.x |
+| Jetson Orin (Orin Nano / NX / AGX) | sm_8.7 | ✅ Supported | JetPack 6.x |
 | Jetson Thor | sm_10.x | ⚠️ Untested | Should work — same Blackwell silicon as desktop, but ORT-bundled CUDA EP needs Blackwell support (see below) |
 | **Blackwell desktop (RTX 5090, RTX PRO 6000, B200, GB200)** | **sm_10.0** | **❌ Not yet supported** | ORT's bundled cuBLAS/cuDNN don't ship sm_100 kernels. Server segfaults at `InferenceSession` init. **Workaround:** use `tether chat` (no GPU needed), or `/act` testing on Modal cloud or non-Blackwell GPU until ORT updates ship. Tracking: [microsoft/onnxruntime#blackwell](https://github.com/microsoft/onnxruntime/issues) |
 | Older NVIDIA (Turing RTX 20, GTX 16) | sm_7.5 | ⚠️ Best-effort | Should work but not in CI matrix |

--- a/install.sh
+++ b/install.sh
@@ -301,8 +301,10 @@ if [ "$IS_JETSON" -eq 1 ] || [ "$FORCE_JETSON" -eq 1 ]; then
   echo "  tether go --preset franka    # one-command deploy (after ONNX export)"
   echo "  tether serve /path/to/export  # serve a pre-exported model"
   echo
-  note "For a fully-bundled JetPack Docker image:"
-  note "  docker pull ghcr.io/fastcrest/tether:latest-jetpack"
+  note "For the published Jetson/arm64 Docker image:"
+  note "  docker pull ghcr.io/fastcrest/tether:latest-arm64"
+  note "  # Bring-your-own JetPack CUDA/cuDNN/TensorRT via nvidia-container-runtime."
+  note "  # For fully-bundled local experiments, build Dockerfile.jetpack yourself."
 fi
 
 note "Source: https://github.com/FastCrest/tether"

--- a/tests/test_docker_arm64.py
+++ b/tests/test_docker_arm64.py
@@ -78,6 +78,7 @@ class TestPublishWorkflow:
         Multi-arch manifest merging is a separate future workflow."""
         content = self.WORKFLOW_PATH.read_text()
         assert "-arm64" in content
+        assert "latest-arm64" in content
 
     def test_uses_dockerfile_arm64(self):
         """The workflow must point at Dockerfile.arm64, not the default
@@ -99,3 +100,15 @@ class TestPublishWorkflow:
         # PyYAML maps the 'on:' key to Python True (bool) because `on`
         # is a YAML 1.1 boolean. Accept either spelling.
         assert "on" in parsed or True in parsed
+
+
+class TestJetsonPublishedTagDocs:
+    def test_installer_points_to_published_arm64_tag(self):
+        content = (REPO_ROOT / "install.sh").read_text()
+        assert "ghcr.io/fastcrest/tether:latest-arm64" in content
+        assert "latest-jetpack" not in content
+
+    def test_readme_points_to_published_arm64_tag(self):
+        content = (REPO_ROOT / "README.md").read_text()
+        assert "ghcr.io/fastcrest/tether:latest-arm64" in content
+        assert "latest-jetpack" not in content


### PR DESCRIPTION
## Summary
- replace the installer hint for unpublished `latest-jetpack` with the published `latest-arm64` tag
- clarify that the published arm64 image uses host JetPack CUDA/cuDNN/TensorRT through `nvidia-container-runtime`
- keep `Dockerfile.jetpack` framed as a local fully-bundled experiment, not a published GHCR promise
- correct the README support table to JetPack 6.x for Jetson Orin
- add tests that lock installer/README/workflow docs to `latest-arm64` and prevent `latest-jetpack` from coming back

## Tests
- `PYTHONPATH=$PWD/src /Users/romirjain/Desktop/building\ projects/fastcrest/tether/.venv/bin/python -m pytest tests/test_docker_arm64.py -p no:cacheprovider`
- `/Users/romirjain/Desktop/building\ projects/fastcrest/tether/.venv/bin/ruff check tests/test_docker_arm64.py`
- `bash -n install.sh`
- `rg -n "latest-jetpack" . -S --glob '!tests/test_docker_arm64.py'`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)