### PR TITLE
feat(runtime): add temporal VLA cache and adaptive chunking

### DIFF
--- a/src/tether/cli.py
+++ b/src/tether/cli.py
@@ -1882,6 +1882,13 @@ def serve(
         help="With --rtc: enable lerobot's debug Tracker for per-step state "
              "capture. Useful for replay forensics; small per-call overhead.",
     ),
+    adaptive_action_chunking: bool = typer.Option(
+        False,
+        "--adaptive-action-chunking",
+        help="With --rtc: adapt the RTC execution horizon from runtime signals. "
+             "Stable/high-latency chunks execute longer before replanning; "
+             "uncertain or discontinuous chunks replan sooner.",
+    ),
     record: str = typer.Option(
         "",
         help="If set, write every /act request+response to a JSONL trace in "
@@ -2363,6 +2370,7 @@ def serve(
                 prefix_attention_schedule=rtc_schedule,
                 max_guidance_weight=rtc_max_guidance_weight,
                 debug=rtc_debug,
+                adaptive_chunking_enabled=adaptive_action_chunking,
             )
         except ValueError as exc:
             err_console.print(f"[red]Invalid RTC config: {exc}[/red]")
@@ -2457,6 +2465,7 @@ def serve(
     if rtc:
         composed.append(
             f"[cyan]rtc[/cyan]=horizon{rtc_execution_horizon}/{rtc_schedule}"
+            f"{'/aac' if adaptive_action_chunking else ''}"
         )
     if composed:
         console.print(f"  Wedges:  {' · '.join(composed)}")

--- a/src/tether/runtime/adaptive_chunking.py
+++ b/src/tether/runtime/adaptive_chunking.py
@@ -1,0 +1,198 @@
+"""Adaptive action chunk horizon selection.
+
+The controller converts runtime signals into an execution horizon: how many
+actions from the current chunk the robot can safely trust before replanning.
+High uncertainty or low safety margin shortens the horizon; stable scenes under
+latency pressure lengthen it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class AdaptiveChunkConfig:
+    enabled: bool = False
+    min_horizon: int = 1
+    base_horizon: int = 10
+    max_horizon: int | None = None
+    low_uncertainty: float = 0.20
+    high_uncertainty: float = 0.65
+    low_guard_margin: float = 0.05
+    high_correction_magnitude: float = 0.20
+    high_action_delta: float = 0.25
+    high_latency_ms: float = 120.0
+
+    def __post_init__(self) -> None:
+        if self.min_horizon < 1:
+            raise ValueError("min_horizon must be >= 1")
+        if self.base_horizon < self.min_horizon:
+            raise ValueError("base_horizon must be >= min_horizon")
+        if self.max_horizon is not None and self.max_horizon < self.base_horizon:
+            raise ValueError("max_horizon must be >= base_horizon when set")
+        if self.low_uncertainty < 0 or self.high_uncertainty <= self.low_uncertainty:
+            raise ValueError("uncertainty thresholds must satisfy 0 <= low < high")
+
+
+@dataclass(frozen=True)
+class AdaptiveChunkSignal:
+    uncertainty: float | None = None
+    guard_margin: float | None = None
+    correction_magnitude: float | None = None
+    action_delta: float | None = None
+    latency_ms: float | None = None
+
+    def as_dict(self) -> dict[str, float | None]:
+        return {
+            "uncertainty": self.uncertainty,
+            "guard_margin": self.guard_margin,
+            "correction_magnitude": self.correction_magnitude,
+            "action_delta": self.action_delta,
+            "latency_ms": self.latency_ms,
+        }
+
+    def has_values(self) -> bool:
+        return any(value is not None for value in self.as_dict().values())
+
+
+@dataclass(frozen=True)
+class AdaptiveChunkDecision:
+    horizon: int
+    replan_threshold_ratio: float
+    reason: str
+    risk_score: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "horizon": self.horizon,
+            "replan_threshold_ratio": self.replan_threshold_ratio,
+            "reason": self.reason,
+            "risk_score": self.risk_score,
+        }
+
+
+def overlapping_action_delta(
+    previous: np.ndarray | None,
+    current: np.ndarray | None,
+    *,
+    window: int = 5,
+) -> float | None:
+    """L2 delta between the previous chunk tail and current chunk head."""
+    if previous is None or current is None:
+        return None
+    prev = np.asarray(previous, dtype=np.float32)
+    cur = np.asarray(current, dtype=np.float32)
+    if prev.ndim != 2 or cur.ndim != 2:
+        return None
+    if prev.shape[1] != cur.shape[1]:
+        return None
+    k = min(window, prev.shape[0], cur.shape[0])
+    if k <= 0:
+        return None
+    return float(np.linalg.norm(prev[-k:] - cur[:k]) / k)
+
+
+class AdaptiveChunkController:
+    """Selects an execution horizon from current runtime signals."""
+
+    __slots__ = ("config",)
+
+    def __init__(self, config: AdaptiveChunkConfig | None = None):
+        self.config = config or AdaptiveChunkConfig()
+
+    def decide(
+        self,
+        signal: AdaptiveChunkSignal | None,
+        *,
+        capacity: int,
+    ) -> AdaptiveChunkDecision:
+        if capacity < 1:
+            raise ValueError("capacity must be >= 1")
+
+        cfg = self.config
+        max_horizon = min(capacity, cfg.max_horizon or capacity)
+        base_horizon = min(max(cfg.base_horizon, cfg.min_horizon), max_horizon)
+        min_horizon = min(cfg.min_horizon, max_horizon)
+        if not cfg.enabled:
+            return self._decision(base_horizon, capacity, "disabled", 0.0)
+
+        signal = signal or AdaptiveChunkSignal()
+        risk, reason = self._risk(signal)
+
+        if risk >= 0.66:
+            return self._decision(min_horizon, capacity, reason, risk)
+
+        latency_high = (
+            signal.latency_ms is not None and signal.latency_ms >= cfg.high_latency_ms
+        )
+        if risk <= 0.25 and latency_high:
+            return self._decision(max_horizon, capacity, "stable_high_latency", risk)
+        if risk <= 0.25:
+            return self._decision(base_horizon, capacity, "stable", risk)
+
+        span = max_horizon - min_horizon
+        horizon = max_horizon - int(round(risk * span))
+        horizon = min(max(horizon, min_horizon), max_horizon)
+        return self._decision(horizon, capacity, reason, risk)
+
+    def _risk(self, signal: AdaptiveChunkSignal) -> tuple[float, str]:
+        cfg = self.config
+        risks: list[tuple[float, str]] = []
+
+        if signal.uncertainty is not None:
+            risks.append((
+                _scale(signal.uncertainty, cfg.low_uncertainty, cfg.high_uncertainty),
+                "uncertainty",
+            ))
+        if signal.guard_margin is not None:
+            guard_risk = 1.0 - _scale(signal.guard_margin, 0.0, cfg.low_guard_margin)
+            risks.append((guard_risk, "guard_margin"))
+        if signal.correction_magnitude is not None:
+            risks.append((
+                _scale(signal.correction_magnitude, 0.0, cfg.high_correction_magnitude),
+                "correction",
+            ))
+        if signal.action_delta is not None:
+            risks.append((
+                _scale(signal.action_delta, 0.0, cfg.high_action_delta),
+                "action_delta",
+            ))
+
+        if not risks:
+            return 0.0, "no_signal"
+        risk, reason = max(risks, key=lambda item: item[0])
+        return float(min(max(risk, 0.0), 1.0)), reason
+
+    @staticmethod
+    def _decision(
+        horizon: int,
+        capacity: int,
+        reason: str,
+        risk: float,
+    ) -> AdaptiveChunkDecision:
+        threshold = 1.0 - (horizon / capacity)
+        threshold = min(max(threshold, 0.0), 1.0)
+        return AdaptiveChunkDecision(
+            horizon=int(horizon),
+            replan_threshold_ratio=float(threshold),
+            reason=reason,
+            risk_score=float(risk),
+        )
+
+
+def _scale(value: float, low: float, high: float) -> float:
+    if high <= low:
+        return 1.0 if value >= high else 0.0
+    return min(max((float(value) - low) / (high - low), 0.0), 1.0)
+
+
+__all__ = [
+    "AdaptiveChunkConfig",
+    "AdaptiveChunkController",
+    "AdaptiveChunkDecision",
+    "AdaptiveChunkSignal",
+    "overlapping_action_delta",
+]

--- a/src/tether/runtime/buffer.py
+++ b/src/tether/runtime/buffer.py
@@ -22,9 +22,12 @@ import threading
 import time
 from collections import deque
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from tether.runtime.adaptive_chunking import AdaptiveChunkDecision
 
 
 @dataclass
@@ -139,14 +142,26 @@ class ActionChunkBuffer:
                 return None
             return np.stack(list(self._buf), axis=0).copy()
 
-    def should_replan(self, threshold_ratio: float = 0.5) -> bool:
+    def should_replan(
+        self,
+        threshold_ratio: float = 0.5,
+        *,
+        adaptive_decision: "AdaptiveChunkDecision | None" = None,
+    ) -> bool:
         """True when the buffer size has dropped to or below threshold.
 
         Default threshold_ratio=0.5 means: when half or fewer of the
         planned actions remain, it's time to replan. Caller decides
         whether to actually trigger predict() — the buffer just
         advises.
+
+        When an AdaptiveChunkDecision is supplied, its threshold wins. This
+        keeps the existing fixed-ratio behavior as the default while allowing
+        AAC-style horizons to replan sooner under uncertainty and later when
+        the scene is stable.
         """
+        if adaptive_decision is not None:
+            threshold_ratio = adaptive_decision.replan_threshold_ratio
         with self._lock:
             return len(self._buf) <= self._capacity * threshold_ratio
 

--- a/src/tether/runtime/pi05_decomposed_server.py
+++ b/src/tether/runtime/pi05_decomposed_server.py
@@ -27,7 +27,7 @@ import hashlib
 import json
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -57,6 +57,7 @@ class ActionCacheEntry:
     matching obs is effectively zero-cost."""
     image_phashes: tuple[bytes, ...]
     lang_hash: bytes
+    state_signature: np.ndarray | None
     step_index: int
     actions: np.ndarray
 
@@ -198,6 +199,11 @@ class Pi05DecomposedInference:
         self.cache_ignore_lang = cache_ignore_lang
         self._call_index: int = 0  # monotonic call counter for step-count TTL
         self._action_cache: ActionCacheEntry | None = None
+        from tether.runtime.temporal_vla_cache import TemporalVLAReusePolicy
+        self._temporal_reuse_policy = TemporalVLAReusePolicy(
+            phash_hamming_threshold=phash_hamming_threshold,
+        )
+        self._last_temporal_action_decision = None
         # Action-similarity fast path (FlashVLA, Phase 1.5). Disabled when
         # threshold == 0; enabled when threshold > 0. Defaults to off so
         # existing behavior is unchanged unless --action-similarity-threshold
@@ -371,6 +377,18 @@ class Pi05DecomposedInference:
                 episode_cache_max_episodes,
             )
 
+    def _ensure_temporal_reuse_policy(self) -> Any:
+        """Create temporal-cache fields for restored/test-built instances."""
+        if not hasattr(self, "_temporal_reuse_policy"):
+            from tether.runtime.temporal_vla_cache import TemporalVLAReusePolicy
+
+            self._temporal_reuse_policy = TemporalVLAReusePolicy(
+                phash_hamming_threshold=getattr(self, "phash_hamming_threshold", 6),
+            )
+        if not hasattr(self, "_last_temporal_action_decision"):
+            self._last_temporal_action_decision = None
+        return self._temporal_reuse_policy
+
     # ---- Public API -------------------------------------------------
 
     def predict_action_chunk(
@@ -423,17 +441,28 @@ class Pi05DecomposedInference:
             self._phash(img_wrist_r),
         )
         lang_hash = self._lang_hash(lang_tokens)
+        temporal_policy = self._ensure_temporal_reuse_policy()
+        state_signature = temporal_policy.state_signature(state)
 
         # ---- Action-chunk cache (skip full forward on hit) --------------
         if self.cache_level == "action" and self._action_cache is not None:
             entry = self._action_cache
-            steps_since = self._call_index - entry.step_index
-            lang_ok = self.cache_ignore_lang or entry.lang_hash == lang_hash
-            if (steps_since <= self.action_cache_max_age_steps
-                and lang_ok
-                and self._phashes_match(entry.image_phashes, image_phashes)):
+            decision = temporal_policy.assess(
+                cached_image_phashes=entry.image_phashes,
+                current_image_phashes=image_phashes,
+                cached_lang_hash=entry.lang_hash,
+                current_lang_hash=lang_hash,
+                cached_state=entry.state_signature,
+                current_state=state_signature,
+                cached_step_index=entry.step_index,
+                current_step_index=self._call_index,
+                max_age_steps=self.action_cache_max_age_steps,
+                allow_lang_mismatch=self.cache_ignore_lang,
+            )
+            self._last_temporal_action_decision = decision
+            if decision.reuse:
                 self._stats.action_hits += 1
-                return entry.actions
+                return entry.actions.copy()
         if self.cache_level == "action":
             self._stats.action_misses += 1
 
@@ -499,8 +528,9 @@ class Pi05DecomposedInference:
             self._action_cache = ActionCacheEntry(
                 image_phashes=image_phashes,
                 lang_hash=lang_hash,
+                state_signature=state_signature,
                 step_index=self._call_index,
-                actions=actions,
+                actions=actions.copy(),
             )
 
         return actions
@@ -573,17 +603,23 @@ class Pi05DecomposedInference:
         cache_level='episode' this also clears the episode cache."""
         self._cache = None
         self._action_cache = None
+        self._last_temporal_action_decision = None
         self._call_index = 0
-        if self._episode_cache is not None:
-            self._episode_cache.reset()
+        episode_cache = getattr(self, "_episode_cache", None)
+        if episode_cache is not None:
+            episode_cache.reset()
         # Reset action-similarity fast path — last episode's action chunk
         # has no relevance to the next task's first chunk.
         self._fast_path.reset()
 
     def get_stats(self) -> dict[str, Any]:
         base = self._stats.as_dict()
-        if self._episode_cache is not None:
-            base["episode_cache"] = self._episode_cache.stats.as_dict()
+        episode_cache = getattr(self, "_episode_cache", None)
+        if episode_cache is not None:
+            base["episode_cache"] = episode_cache.stats.as_dict()
+        temporal_decision = getattr(self, "_last_temporal_action_decision", None)
+        if temporal_decision is not None:
+            base["temporal_action_cache"] = temporal_decision.as_dict()
         return base
 
     def _predict_with_episode_cache(

--- a/src/tether/runtime/rtc_adapter.py
+++ b/src/tether/runtime/rtc_adapter.py
@@ -24,6 +24,13 @@ from typing import Any, Protocol
 
 import numpy as np
 
+from tether.runtime.adaptive_chunking import (
+    AdaptiveChunkConfig,
+    AdaptiveChunkController,
+    AdaptiveChunkDecision,
+    AdaptiveChunkSignal,
+    overlapping_action_delta,
+)
 from tether.runtime.buffer import ActionChunkBuffer
 
 logger = logging.getLogger(__name__)
@@ -111,6 +118,9 @@ class RtcAdapterConfig:
     guidance_space: str = "normalized"  # 'normalized' | 'processed'
     gripper_dim_indices: list[int] = field(default_factory=list)
     skip_gripper_smoothing: bool = True
+    adaptive_chunking_enabled: bool = False
+    adaptive_min_horizon: int = 1
+    adaptive_high_latency_ms: float = 120.0
 
     def __post_init__(self) -> None:
         """Validate the Tether-side extras. lerobot's RTCConfig validates
@@ -131,6 +141,15 @@ class RtcAdapterConfig:
         if not 1 <= self.latency_percentile <= 99:
             raise ValueError(
                 f"latency_percentile must be in [1, 99], got {self.latency_percentile}"
+            )
+        if self.adaptive_min_horizon < 1:
+            raise ValueError(
+                f"adaptive_min_horizon must be >= 1, got {self.adaptive_min_horizon}"
+            )
+        if self.adaptive_high_latency_ms <= 0:
+            raise ValueError(
+                "adaptive_high_latency_ms must be positive, "
+                f"got {self.adaptive_high_latency_ms}"
             )
 
 
@@ -276,6 +295,20 @@ class RtcAdapter:
         self._active_episode_id: str | None = None
         self._chunk_count: int = 0
         self._prev_chunk_left_over: Any = None  # set in merge_and_update (Day 3)
+        self._last_action_delta: float | None = None
+        self._last_adaptive_signal = AdaptiveChunkSignal()
+        self._last_adaptive_decision: AdaptiveChunkDecision | None = None
+        self._adaptive_chunker: AdaptiveChunkController | None = None
+        if config.adaptive_chunking_enabled:
+            self._adaptive_chunker = AdaptiveChunkController(
+                AdaptiveChunkConfig(
+                    enabled=True,
+                    min_horizon=config.adaptive_min_horizon,
+                    base_horizon=config.rtc_execution_horizon,
+                    max_horizon=action_buffer.capacity,
+                    high_latency_ms=config.adaptive_high_latency_ms,
+                )
+            )
 
     # ---- Public API ---------------------------------------------
 
@@ -304,6 +337,7 @@ class RtcAdapter:
         # Step 1+2: latency → actions_consumed
         latency_s = self.latency.estimate()
         actions_consumed = int(latency_s * self.config.execute_hz)
+        adaptive_decision = self._decide_adaptive_horizon(latency_s)
         logger.debug(
             "[rtc] predict — latency p%d=%.3fs → %d actions consumed",
             self.config.latency_percentile, latency_s, actions_consumed,
@@ -318,7 +352,11 @@ class RtcAdapter:
             "prev_chunk_left_over": self._prev_chunk_left_over,
         }
         if self.config.enabled:
-            rtc_kwargs["execution_horizon"] = self.config.rtc_execution_horizon
+            rtc_kwargs["execution_horizon"] = (
+                adaptive_decision.horizon
+                if adaptive_decision is not None
+                else self.config.rtc_execution_horizon
+            )
 
         t0 = time.monotonic()
         try:
@@ -338,6 +376,48 @@ class RtcAdapter:
         self.latency.record(elapsed_s)
 
         return actions
+
+    def record_adaptive_signal(
+        self,
+        *,
+        uncertainty: float | None = None,
+        guard_margin: float | None = None,
+        correction_magnitude: float | None = None,
+    ) -> None:
+        """Record external runtime signals for the next AAC decision.
+
+        The /act handler calls this after guard/A2C2 post-processing. Keeping
+        it separate from predict preserves the current response while allowing
+        the next chunk horizon to react to the latest safety/correction facts.
+        """
+        self._last_adaptive_signal = AdaptiveChunkSignal(
+            uncertainty=_clean_signal_value(uncertainty),
+            guard_margin=_clean_signal_value(guard_margin),
+            correction_magnitude=_clean_signal_value(correction_magnitude),
+        )
+
+    def _decide_adaptive_horizon(
+        self,
+        latency_s: float,
+    ) -> AdaptiveChunkDecision | None:
+        """Return current AAC decision, or None when disabled."""
+        if self._adaptive_chunker is None:
+            self._last_adaptive_decision = None
+            return None
+        decision = self._adaptive_chunker.decide(
+            AdaptiveChunkSignal(
+                uncertainty=self._last_adaptive_signal.uncertainty,
+                guard_margin=self._last_adaptive_signal.guard_margin,
+                correction_magnitude=(
+                    self._last_adaptive_signal.correction_magnitude
+                ),
+                latency_ms=latency_s * 1000.0,
+                action_delta=self._last_action_delta,
+            ),
+            capacity=self.buffer.capacity,
+        )
+        self._last_adaptive_decision = decision
+        return decision
 
     def merge_and_update(
         self,
@@ -367,6 +447,7 @@ class RtcAdapter:
             chunk_2d = actions[0]
         else:
             chunk_2d = actions
+        self._last_action_delta = overlapping_action_delta(prev_leftover, chunk_2d)
         self.buffer.push_chunk(chunk_2d)
 
         # 3. Stash the snapshot for the NEXT predict call's guidance
@@ -385,6 +466,9 @@ class RtcAdapter:
         self._active_episode_id = episode_id
         self._chunk_count = 0
         self._prev_chunk_left_over = None
+        self._last_action_delta = None
+        self._last_adaptive_signal = AdaptiveChunkSignal()
+        self._last_adaptive_decision = None
         # Clear the latency window — old samples are stale on a fresh episode
         self.latency = LatencyTracker(
             percentile=self.config.latency_percentile,
@@ -399,13 +483,32 @@ class RtcAdapter:
     def get_stats(self) -> dict[str, Any]:
         """Stats for logging / metrics. Consumed by Prometheus exporter
         (Phase 0.5.8) + ``tether monitor``."""
-        return {
+        stats = {
             "enabled": self.config.enabled,
             "chunk_count": self._chunk_count,
             "active_episode_id": self._active_episode_id,
             "latency": self.latency.summary(),
             "rtc_available": _RTC_AVAILABLE,
         }
+        if self._last_action_delta is not None:
+            stats["last_action_delta"] = self._last_action_delta
+        if self._last_adaptive_signal.has_values():
+            stats["adaptive_signal"] = self._last_adaptive_signal.as_dict()
+        if self._last_adaptive_decision is not None:
+            stats["adaptive_chunking"] = self._last_adaptive_decision.as_dict()
+        return stats
+
+
+def _clean_signal_value(value: float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        cleaned = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(cleaned):
+        return None
+    return cleaned
 
 
 __all__ = [

--- a/src/tether/runtime/server.py
+++ b/src/tether/runtime/server.py
@@ -80,6 +80,48 @@ except ImportError:
     _TETHER_VERSION = ""
 
 
+def _coerce_optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(out):
+        return None
+    return out
+
+
+def _record_rtc_adaptive_signal(
+    rtc_adapter: Any,
+    result: dict[str, Any],
+    *,
+    guard_margin: float | None = None,
+) -> None:
+    """Feed latest guard/A2C2/uncertainty telemetry into RTC AAC state."""
+    if rtc_adapter is None or not hasattr(rtc_adapter, "record_adaptive_signal"):
+        return
+
+    uncertainty = None
+    for key in ("uncertainty_score", "uncertainty", "model_uncertainty"):
+        uncertainty = _coerce_optional_float(result.get(key))
+        if uncertainty is not None:
+            break
+
+    if guard_margin is None:
+        guard_margin = _coerce_optional_float(result.get("guard_margin"))
+    else:
+        guard_margin = _coerce_optional_float(guard_margin)
+
+    rtc_adapter.record_adaptive_signal(
+        uncertainty=uncertainty,
+        guard_margin=guard_margin,
+        correction_magnitude=_coerce_optional_float(
+            result.get("a2c2_correction_magnitude")
+        ),
+    )
+
+
 # ─── Blackwell auto-detect ──────────────────────────────────────────────────
 # ORT-bundled TensorRT predates Blackwell (RTX 50-series, sm_100). On those
 # GPUs, TRT EP segfaults at session-init because TRT can't register kernels
@@ -2596,6 +2638,7 @@ def create_app(
             # the chunk + reports a violation. No-op when guard absent.
             _eg = getattr(server, "embodiment_guard", None)
             _guard_violations: list[str] = []
+            _guard_margin: float | None = None
             if (
                 _eg is not None
                 and isinstance(result, dict)
@@ -2606,6 +2649,9 @@ def create_app(
                 try:
                     _arr = np.asarray(result["actions"], dtype=np.float32)
                     _safe, _check_results = _eg.check(_arr)
+                    _guard_margin = _eg.safety_margin(_safe)
+                    if _guard_margin is not None:
+                        result["guard_margin"] = round(_guard_margin, 6)
                     _was_modified = not np.array_equal(_arr, _safe)
                     if _was_modified:
                         result["actions"] = _safe.tolist()
@@ -2744,6 +2790,16 @@ def create_app(
                         span.set_attribute("tether.a2c2.reason", decision.reason)
                 except Exception as exc:  # noqa: BLE001 — A2C2 must never break /act
                     logger.warning("a2c2_hook.apply_failed: %s", exc)
+
+            if _rtc is not None and isinstance(result, dict) and "error" not in result:
+                try:
+                    _record_rtc_adaptive_signal(
+                        _rtc,
+                        result,
+                        guard_margin=_guard_margin,
+                    )
+                except Exception as exc:  # noqa: BLE001 — RTC signal must not break /act
+                    logger.warning("RTC adaptive signal update failed: %s", exc)
 
             # JSONL record hook (B.2). Writes inside the OTel span context
             # so the seq attribute below cross-links the two ledgers. Recorder

--- a/src/tether/runtime/temporal_vla_cache.py
+++ b/src/tether/runtime/temporal_vla_cache.py
@@ -1,0 +1,224 @@
+"""Temporal reuse policy for VLA runtime caches.
+
+The Pi0.5 decomposed server already has prefix/action/episode cache layers.
+This module centralizes the safety checks that decide whether a cached entry is
+still valid for the next control tick: age, language identity, visual stability,
+state drift, and optional guard/action-change margins.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class TemporalCacheDecision:
+    """Decision returned by TemporalVLAReusePolicy.assess."""
+
+    reuse: bool
+    reason: str
+    steps_since: int | None = None
+    image_hamming: int | None = None
+    state_delta: float | None = None
+    guard_margin: float | None = None
+    action_delta: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "reuse": self.reuse,
+            "reason": self.reason,
+            "steps_since": self.steps_since,
+            "image_hamming": self.image_hamming,
+            "state_delta": self.state_delta,
+            "guard_margin": self.guard_margin,
+            "action_delta": self.action_delta,
+        }
+
+
+class TemporalVLAReusePolicy:
+    """Conservative policy for temporal cache reuse.
+
+    The policy is intentionally model-agnostic. Callers pass the cache key
+    material they already have and the policy returns a bounded reason for
+    telemetry and tests.
+    """
+
+    __slots__ = (
+        "enabled",
+        "phash_hamming_threshold",
+        "state_delta_threshold",
+        "min_guard_margin",
+        "action_delta_threshold",
+    )
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        phash_hamming_threshold: int = 6,
+        state_delta_threshold: float = 0.05,
+        min_guard_margin: float | None = None,
+        action_delta_threshold: float | None = None,
+    ):
+        if phash_hamming_threshold < 0:
+            raise ValueError("phash_hamming_threshold must be >= 0")
+        if state_delta_threshold < 0:
+            raise ValueError("state_delta_threshold must be >= 0")
+        if min_guard_margin is not None and min_guard_margin < 0:
+            raise ValueError("min_guard_margin must be >= 0 when set")
+        if action_delta_threshold is not None and action_delta_threshold < 0:
+            raise ValueError("action_delta_threshold must be >= 0 when set")
+
+        self.enabled = bool(enabled)
+        self.phash_hamming_threshold = int(phash_hamming_threshold)
+        self.state_delta_threshold = float(state_delta_threshold)
+        self.min_guard_margin = min_guard_margin
+        self.action_delta_threshold = action_delta_threshold
+
+    @staticmethod
+    def state_signature(state: np.ndarray | list[float] | None) -> np.ndarray | None:
+        """Normalize state for cache comparisons."""
+        if state is None:
+            return None
+        arr = np.asarray(state, dtype=np.float32)
+        if arr.size == 0:
+            return None
+        return arr.reshape(-1).copy()
+
+    @staticmethod
+    def max_hamming(
+        cached: tuple[bytes, ...],
+        current: tuple[bytes, ...],
+    ) -> int | None:
+        if len(cached) != len(current):
+            return None
+        max_dist = 0
+        for left, right in zip(cached, current):
+            dist = sum((a ^ b).bit_count() for a, b in zip(left, right))
+            max_dist = max(max_dist, dist)
+        return max_dist
+
+    @staticmethod
+    def state_delta(
+        cached: np.ndarray | None,
+        current: np.ndarray | None,
+    ) -> float | None:
+        if cached is None and current is None:
+            return 0.0
+        if cached is None or current is None:
+            return None
+        if cached.shape != current.shape:
+            return None
+        return float(np.linalg.norm(current - cached))
+
+    def assess(
+        self,
+        *,
+        cached_image_phashes: tuple[bytes, ...] | None,
+        current_image_phashes: tuple[bytes, ...] | None,
+        cached_lang_hash: bytes | None,
+        current_lang_hash: bytes | None,
+        cached_state: np.ndarray | None = None,
+        current_state: np.ndarray | None = None,
+        cached_step_index: int | None = None,
+        current_step_index: int | None = None,
+        max_age_steps: int | None = None,
+        allow_lang_mismatch: bool = False,
+        guard_margin: float | None = None,
+        action_delta: float | None = None,
+    ) -> TemporalCacheDecision:
+        if not self.enabled:
+            return TemporalCacheDecision(False, "disabled")
+        if (
+            cached_image_phashes is None
+            or current_image_phashes is None
+            or cached_lang_hash is None
+            or current_lang_hash is None
+        ):
+            return TemporalCacheDecision(False, "missing_key")
+
+        steps_since = None
+        if cached_step_index is not None and current_step_index is not None:
+            steps_since = current_step_index - cached_step_index
+            if steps_since < 0:
+                return TemporalCacheDecision(False, "negative_age", steps_since=steps_since)
+            if max_age_steps is not None and steps_since > max_age_steps:
+                return TemporalCacheDecision(False, "stale", steps_since=steps_since)
+
+        if not allow_lang_mismatch and cached_lang_hash != current_lang_hash:
+            return TemporalCacheDecision(False, "language_changed", steps_since=steps_since)
+
+        image_hamming = self.max_hamming(cached_image_phashes, current_image_phashes)
+        if image_hamming is None:
+            return TemporalCacheDecision(False, "image_shape_changed", steps_since=steps_since)
+        if image_hamming > self.phash_hamming_threshold:
+            return TemporalCacheDecision(
+                False,
+                "image_changed",
+                steps_since=steps_since,
+                image_hamming=image_hamming,
+            )
+
+        state_delta = self.state_delta(cached_state, current_state)
+        if state_delta is None:
+            return TemporalCacheDecision(
+                False,
+                "state_shape_changed",
+                steps_since=steps_since,
+                image_hamming=image_hamming,
+            )
+        if state_delta > self.state_delta_threshold:
+            return TemporalCacheDecision(
+                False,
+                "state_changed",
+                steps_since=steps_since,
+                image_hamming=image_hamming,
+                state_delta=state_delta,
+            )
+
+        if (
+            self.min_guard_margin is not None
+            and guard_margin is not None
+            and guard_margin < self.min_guard_margin
+        ):
+            return TemporalCacheDecision(
+                False,
+                "guard_margin_low",
+                steps_since=steps_since,
+                image_hamming=image_hamming,
+                state_delta=state_delta,
+                guard_margin=guard_margin,
+            )
+
+        if (
+            self.action_delta_threshold is not None
+            and action_delta is not None
+            and action_delta > self.action_delta_threshold
+        ):
+            return TemporalCacheDecision(
+                False,
+                "action_delta_high",
+                steps_since=steps_since,
+                image_hamming=image_hamming,
+                state_delta=state_delta,
+                guard_margin=guard_margin,
+                action_delta=action_delta,
+            )
+
+        return TemporalCacheDecision(
+            True,
+            "stable",
+            steps_since=steps_since,
+            image_hamming=image_hamming,
+            state_delta=state_delta,
+            guard_margin=guard_margin,
+            action_delta=action_delta,
+        )
+
+
+__all__ = [
+    "TemporalCacheDecision",
+    "TemporalVLAReusePolicy",
+]

--- a/src/tether/safety/guard.py
+++ b/src/tether/safety/guard.py
@@ -228,6 +228,87 @@ class ActionGuard:
     def _clamp_value(value: float, lower: float, upper: float) -> float:
         return float(min(max(value, lower), upper))
 
+    @staticmethod
+    def _interval_margin(value: float, lower: float, upper: float) -> float | None:
+        """Normalized distance to the nearest interval boundary.
+
+        Returns 1.0 at interval center, 0.0 at or outside a boundary, and None
+        for invalid intervals.
+        """
+        if upper <= lower:
+            return None
+        half_span = (upper - lower) / 2.0
+        if half_span <= 0:
+            return None
+        distance = min(value - lower, upper - value)
+        return float(min(max(distance / half_span, 0.0), 1.0))
+
+    def safety_margin(self, actions: np.ndarray) -> float | None:
+        """Return the closest normalized margin to any configured limit.
+
+        The value is in [0, 1], where 0 means at/outside a configured safety
+        boundary and 1 means centered under every applicable bound. It covers
+        position, effort, velocity between consecutive chunk actions, and
+        explicit workspace-index bounds. Returns None when no comparable limits
+        apply.
+        """
+        arr = np.asarray(actions, dtype=np.float32)
+        if arr.size == 0:
+            return None
+        if arr.ndim == 1:
+            arr = arr.reshape(1, -1)
+        if arr.ndim != 2 or not np.isfinite(arr).all():
+            return 0.0
+
+        margins: list[float] = []
+        num_joints = min(arr.shape[1], len(self.limits.position_max))
+        for row in arr:
+            for i in range(num_joints):
+                pos_margin = self._interval_margin(
+                    float(row[i]),
+                    float(self.limits.position_min[i]),
+                    float(self.limits.position_max[i]),
+                )
+                if pos_margin is not None:
+                    margins.append(pos_margin)
+
+                if i < len(self.limits.effort_max):
+                    effort_limit = float(self.limits.effort_max[i])
+                    if effort_limit > 0:
+                        effort_margin = (effort_limit - abs(float(row[i]))) / effort_limit
+                        margins.append(float(min(max(effort_margin, 0.0), 1.0)))
+
+            for workspace_axis, action_idx in enumerate(self.limits.workspace_indices):
+                if action_idx < 0 or action_idx >= arr.shape[1]:
+                    continue
+                if (
+                    workspace_axis >= len(self.limits.workspace_min)
+                    or workspace_axis >= len(self.limits.workspace_max)
+                ):
+                    continue
+                workspace_margin = self._interval_margin(
+                    float(row[action_idx]),
+                    float(self.limits.workspace_min[workspace_axis]),
+                    float(self.limits.workspace_max[workspace_axis]),
+                )
+                if workspace_margin is not None:
+                    margins.append(workspace_margin)
+
+        if arr.shape[0] >= 2:
+            num_velocity = min(arr.shape[1], len(self.limits.velocity_max))
+            for prev, cur in zip(arr[:-1], arr[1:]):
+                for i in range(num_velocity):
+                    velocity_limit = float(self.limits.velocity_max[i])
+                    if velocity_limit <= 0:
+                        continue
+                    delta = abs(float(cur[i] - prev[i]))
+                    velocity_margin = (velocity_limit - delta) / velocity_limit
+                    margins.append(float(min(max(velocity_margin, 0.0), 1.0)))
+
+        if not margins:
+            return None
+        return min(margins)
+
     def check_single(
         self,
         action: np.ndarray,

--- a/tests/test_adaptive_chunking.py
+++ b/tests/test_adaptive_chunking.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tether.runtime.adaptive_chunking import (
+    AdaptiveChunkConfig,
+    AdaptiveChunkController,
+    AdaptiveChunkSignal,
+    overlapping_action_delta,
+)
+from tether.runtime.buffer import ActionChunkBuffer
+
+
+def test_disabled_controller_returns_base_horizon():
+    controller = AdaptiveChunkController(
+        AdaptiveChunkConfig(enabled=False, base_horizon=5, max_horizon=10)
+    )
+    decision = controller.decide(AdaptiveChunkSignal(uncertainty=1.0), capacity=10)
+    assert decision.horizon == 5
+    assert decision.reason == "disabled"
+    assert decision.replan_threshold_ratio == pytest.approx(0.5)
+
+
+def test_high_uncertainty_shortens_horizon():
+    controller = AdaptiveChunkController(
+        AdaptiveChunkConfig(enabled=True, min_horizon=2, base_horizon=5, max_horizon=10)
+    )
+    decision = controller.decide(AdaptiveChunkSignal(uncertainty=0.9), capacity=10)
+    assert decision.horizon == 2
+    assert decision.reason == "uncertainty"
+    assert decision.replan_threshold_ratio == pytest.approx(0.8)
+
+
+def test_stable_high_latency_extends_horizon():
+    controller = AdaptiveChunkController(
+        AdaptiveChunkConfig(
+            enabled=True,
+            min_horizon=2,
+            base_horizon=5,
+            max_horizon=10,
+            high_latency_ms=100,
+        )
+    )
+    decision = controller.decide(
+        AdaptiveChunkSignal(uncertainty=0.0, latency_ms=150),
+        capacity=10,
+    )
+    assert decision.horizon == 10
+    assert decision.reason == "stable_high_latency"
+    assert decision.replan_threshold_ratio == pytest.approx(0.0)
+
+
+def test_low_guard_margin_shortens_horizon():
+    controller = AdaptiveChunkController(
+        AdaptiveChunkConfig(enabled=True, min_horizon=1, base_horizon=5, max_horizon=10)
+    )
+    decision = controller.decide(AdaptiveChunkSignal(guard_margin=0.0), capacity=10)
+    assert decision.horizon == 1
+    assert decision.reason == "guard_margin"
+
+
+def test_buffer_accepts_adaptive_decision_threshold():
+    buf = ActionChunkBuffer(capacity=10)
+    buf.push_chunk(np.ones((10, 1), dtype=np.float32))
+    controller = AdaptiveChunkController(
+        AdaptiveChunkConfig(enabled=True, min_horizon=2, base_horizon=5, max_horizon=10)
+    )
+    decision = controller.decide(AdaptiveChunkSignal(uncertainty=0.9), capacity=10)
+    assert buf.should_replan(adaptive_decision=decision) is False
+    for _ in range(2):
+        buf.pop_next()
+    assert buf.should_replan(adaptive_decision=decision) is True
+
+
+def test_overlapping_action_delta_uses_tail_and_head():
+    previous = np.array([[0.0], [1.0], [2.0]], dtype=np.float32)
+    current = np.array([[2.0], [3.0], [4.0]], dtype=np.float32)
+    assert overlapping_action_delta(previous, current, window=1) == pytest.approx(0.0)
+    assert overlapping_action_delta(previous, current, window=2) == pytest.approx(
+        np.linalg.norm(np.array([[-1.0], [-1.0]], dtype=np.float32)) / 2
+    )
+

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -3,6 +3,7 @@
 import json
 
 import numpy as np
+import pytest
 
 from tether.safety.guard import ActionGuard, SafetyLimits
 
@@ -154,6 +155,36 @@ class TestActionGuard:
 
         assert result.safe
         assert result.safe_action == [3.0, -3.0, -3.0]
+
+    def test_safety_margin_reports_centered_actions_high(self):
+        guard = ActionGuard.default(num_joints=2)
+
+        margin = guard.safety_margin(np.array([[0.0, 0.0]], dtype=np.float32))
+
+        assert margin == 1.0
+
+    def test_safety_margin_reports_boundary_as_zero(self):
+        guard = ActionGuard.default(num_joints=2)
+
+        margin = guard.safety_margin(np.array([[3.14, 0.0]], dtype=np.float32))
+
+        assert margin == 0.0
+
+    def test_safety_margin_includes_velocity_delta(self):
+        limits = SafetyLimits(
+            joint_names=["j1"],
+            position_min=[-10.0],
+            position_max=[10.0],
+            velocity_max=[1.0],
+            effort_max=[50.0],
+        )
+        guard = ActionGuard(limits=limits)
+
+        margin = guard.safety_margin(
+            np.array([[0.0], [0.8]], dtype=np.float32)
+        )
+
+        assert margin == pytest.approx(0.2)
 
     def test_batch_check(self):
         guard = ActionGuard.default(num_joints=3)

--- a/tests/test_rtc_adapter_day1.py
+++ b/tests/test_rtc_adapter_day1.py
@@ -70,6 +70,15 @@ class TestRtcAdapterConfigValidation:
         cfg = RtcAdapterConfig(latency_percentile=99)
         assert cfg.latency_percentile == 99
 
+    def test_adaptive_chunking_config_defaults_off(self):
+        cfg = RtcAdapterConfig()
+        assert cfg.adaptive_chunking_enabled is False
+        assert cfg.adaptive_min_horizon == 1
+
+    def test_invalid_adaptive_min_horizon_rejected(self):
+        with pytest.raises(ValueError, match="adaptive_min_horizon"):
+            RtcAdapterConfig(adaptive_min_horizon=0)
+
 
 # ---------------------------------------------------------------------------
 # LatencyTracker (already shipped in skeleton)
@@ -238,10 +247,6 @@ class TestRtcAdapterReset:
         adapter._prev_chunk_left_over = "fake"
         adapter.latency.record(0.1)
         adapter.latency.record(0.2)
-        # Need at least discard_first+1 records to actually fill the window
-        # (default discard_first=10, so 2 records won't reach the window)
-        n_before_reset = adapter.latency.summary()["n"]
-
         adapter.reset(episode_id="ep-2")
 
         assert adapter._chunk_count == 0

--- a/tests/test_rtc_adapter_day4.py
+++ b/tests/test_rtc_adapter_day4.py
@@ -11,12 +11,9 @@ merge_and_update skipped; coexistence with OTel + JSONL hooks.
 """
 from __future__ import annotations
 
-import json
-from typing import Any
-
 import numpy as np
 import pytest
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
@@ -24,6 +21,7 @@ from pydantic import BaseModel
 
 from tether.runtime.buffer import ActionChunkBuffer
 from tether.runtime.rtc_adapter import RtcAdapter, RtcAdapterConfig
+from tether.runtime.server import _record_rtc_adaptive_signal
 
 
 # ---------------------------------------------------------------------------
@@ -325,3 +323,29 @@ class TestEpisodeResetMergeOrder:
         r = client.post("/act", json={"image": "y", "episode_id": "ep-2"})
         # Chunk count is back to 1 (reset cleared, then merge bumped)
         assert r.json()["_test_chunk_count"] == 1
+
+
+class TestAdaptiveSignalHelper:
+    def test_server_helper_records_guard_a2c2_and_uncertainty(self):
+        adapter = RtcAdapter(
+            policy=_StubServer(GOOD_RESPONSE),
+            action_buffer=ActionChunkBuffer(capacity=10),
+            config=RtcAdapterConfig(
+                enabled=False,
+                adaptive_chunking_enabled=True,
+            ),
+        )
+
+        _record_rtc_adaptive_signal(
+            adapter,
+            {
+                "a2c2_correction_magnitude": 0.25,
+                "uncertainty_score": 0.4,
+            },
+            guard_margin=0.03,
+        )
+
+        stats = adapter.get_stats()
+        assert stats["adaptive_signal"]["guard_margin"] == pytest.approx(0.03)
+        assert stats["adaptive_signal"]["correction_magnitude"] == pytest.approx(0.25)
+        assert stats["adaptive_signal"]["uncertainty"] == pytest.approx(0.4)

--- a/tests/test_rtc_adapter_integration.py
+++ b/tests/test_rtc_adapter_integration.py
@@ -147,6 +147,92 @@ class TestMultiCycleIntegration:
         # Allow slack for timer noise: 1-10 actions reasonable for 30ms target
         assert 1 <= last_call["inference_delay"] <= 10
 
+    def test_adaptive_chunking_overrides_execution_horizon(self):
+        from tether.runtime.rtc_adapter import _RTC_AVAILABLE
+        if not _RTC_AVAILABLE:
+            pytest.skip("lerobot not installed")
+        policy = _SyntheticPolicy()
+        cfg = RtcAdapterConfig(
+            enabled=True,
+            execute_hz=100.0,
+            cold_start_discard=0,
+            rtc_execution_horizon=5,
+            adaptive_chunking_enabled=True,
+            adaptive_high_latency_ms=50.0,
+        )
+        adapter = RtcAdapter(
+            policy=policy,
+            action_buffer=ActionChunkBuffer(capacity=10),
+            config=cfg,
+        )
+        adapter.latency.record(0.10)
+        adapter.latency.record(0.10)
+        adapter.latency.record(0.10)
+        adapter.predict_chunk_with_rtc({"image": "x"})
+        assert policy.calls[-1]["execution_horizon"] == 10
+        stats = adapter.get_stats()
+        assert stats["adaptive_chunking"]["reason"] == "stable_high_latency"
+
+    def test_adaptive_chunking_uses_guard_margin_signal(self):
+        policy = _SyntheticPolicy()
+        cfg = RtcAdapterConfig(
+            enabled=False,
+            cold_start_discard=0,
+            rtc_execution_horizon=5,
+            adaptive_chunking_enabled=True,
+        )
+        adapter = RtcAdapter(
+            policy=policy,
+            action_buffer=ActionChunkBuffer(capacity=10),
+            config=cfg,
+        )
+
+        adapter.record_adaptive_signal(guard_margin=0.01)
+        decision = adapter._decide_adaptive_horizon(0.01)
+
+        assert decision is not None
+        assert decision.horizon == 1
+        assert decision.reason == "guard_margin"
+        stats = adapter.get_stats()
+        assert stats["adaptive_signal"]["guard_margin"] == pytest.approx(0.01)
+
+    def test_adaptive_chunking_uses_a2c2_correction_signal(self):
+        policy = _SyntheticPolicy()
+        cfg = RtcAdapterConfig(
+            enabled=False,
+            cold_start_discard=0,
+            rtc_execution_horizon=5,
+            adaptive_chunking_enabled=True,
+        )
+        adapter = RtcAdapter(
+            policy=policy,
+            action_buffer=ActionChunkBuffer(capacity=10),
+            config=cfg,
+        )
+
+        adapter.record_adaptive_signal(correction_magnitude=0.3)
+        decision = adapter._decide_adaptive_horizon(0.01)
+
+        assert decision is not None
+        assert decision.horizon == 1
+        assert decision.reason == "correction"
+
+    def test_reset_clears_adaptive_signal(self):
+        adapter = RtcAdapter(
+            policy=_SyntheticPolicy(),
+            action_buffer=ActionChunkBuffer(capacity=10),
+            config=RtcAdapterConfig(
+                enabled=False,
+                adaptive_chunking_enabled=True,
+            ),
+        )
+        adapter.record_adaptive_signal(guard_margin=0.01)
+        assert "adaptive_signal" in adapter.get_stats()
+
+        adapter.reset(episode_id="fresh")
+
+        assert "adaptive_signal" not in adapter.get_stats()
+
 
 # ---------------------------------------------------------------------------
 # Episode lifecycle
@@ -162,8 +248,6 @@ class TestEpisodeLifecycle:
         adapter.reset(episode_id="A")
         for _ in range(5):
             _run_cycle(adapter)
-        latency_after_a = adapter.latency.summary()["n"]
-        carry_after_a = adapter._prev_chunk_left_over
 
         adapter.reset(episode_id="B")
         # Latency window cleared, carry cleared

--- a/tests/test_temporal_vla_cache.py
+++ b/tests/test_temporal_vla_cache.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tether.runtime.temporal_vla_cache import TemporalVLAReusePolicy
+
+
+def _hash(byte: int) -> tuple[bytes, ...]:
+    return (bytes([byte] * 8),)
+
+
+def test_stable_inputs_reuse():
+    policy = TemporalVLAReusePolicy(phash_hamming_threshold=2)
+    decision = policy.assess(
+        cached_image_phashes=_hash(0),
+        current_image_phashes=_hash(0),
+        cached_lang_hash=b"task",
+        current_lang_hash=b"task",
+        cached_state=np.array([0.0, 0.0], dtype=np.float32),
+        current_state=np.array([0.01, 0.0], dtype=np.float32),
+        cached_step_index=1,
+        current_step_index=2,
+        max_age_steps=2,
+    )
+    assert decision.reuse is True
+    assert decision.reason == "stable"
+    assert decision.steps_since == 1
+    assert decision.state_delta == pytest.approx(0.01)
+
+
+def test_rejects_stale_entry():
+    policy = TemporalVLAReusePolicy()
+    decision = policy.assess(
+        cached_image_phashes=_hash(0),
+        current_image_phashes=_hash(0),
+        cached_lang_hash=b"task",
+        current_lang_hash=b"task",
+        cached_step_index=1,
+        current_step_index=5,
+        max_age_steps=2,
+    )
+    assert decision.reuse is False
+    assert decision.reason == "stale"
+
+
+def test_rejects_image_change():
+    policy = TemporalVLAReusePolicy(phash_hamming_threshold=1)
+    decision = policy.assess(
+        cached_image_phashes=_hash(0),
+        current_image_phashes=_hash(255),
+        cached_lang_hash=b"task",
+        current_lang_hash=b"task",
+    )
+    assert decision.reuse is False
+    assert decision.reason == "image_changed"
+    assert decision.image_hamming == 64
+
+
+def test_rejects_state_change():
+    policy = TemporalVLAReusePolicy(state_delta_threshold=0.05)
+    decision = policy.assess(
+        cached_image_phashes=_hash(0),
+        current_image_phashes=_hash(0),
+        cached_lang_hash=b"task",
+        current_lang_hash=b"task",
+        cached_state=np.array([0.0, 0.0], dtype=np.float32),
+        current_state=np.array([0.2, 0.0], dtype=np.float32),
+    )
+    assert decision.reuse is False
+    assert decision.reason == "state_changed"
+
+
+def test_can_ignore_language_mismatch_for_state_in_language_modes():
+    policy = TemporalVLAReusePolicy()
+    decision = policy.assess(
+        cached_image_phashes=_hash(0),
+        current_image_phashes=_hash(0),
+        cached_lang_hash=b"old-state-text",
+        current_lang_hash=b"new-state-text",
+        allow_lang_mismatch=True,
+    )
+    assert decision.reuse is True
+
+
+def test_state_signature_flattens_and_copies():
+    state = np.array([[1.0, 2.0]], dtype=np.float32)
+    sig = TemporalVLAReusePolicy.state_signature(state)
+    assert sig is not None
+    state[0, 0] = 99.0
+    np.testing.assert_array_equal(sig, np.array([1.0, 2.0], dtype=np.float32))

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -320,7 +320,7 @@ def test_parity_cert_writes_json_and_optional_signature(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_cli_verify_pass(monkeypatch):
+def test_cli_verify_pass(monkeypatch, tmp_path):
     typer_testing = pytest.importorskip("typer.testing")
     from tether.cli import app
     import tether.verify as verify_mod
@@ -336,20 +336,20 @@ def test_cli_verify_pass(monkeypatch):
     monkeypatch.setattr(verify_mod, "gather_paired_samples", gather)
 
     runner = typer_testing.CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            app,
-            [
-                "verify",
-                "/fake/export",
-                "--target",
-                "orin",
-                "--num-episodes",
-                str(_EPS),
-                "--output",
-                "verify_out",
-            ],
-        )
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            "/fake/export",
+            "--target",
+            "orin",
+            "--num-episodes",
+            str(_EPS),
+            "--output",
+            "verify_out",
+        ],
+    )
     assert result.exit_code == 0, result.output
     assert "PASS" in result.output
 


### PR DESCRIPTION
## Summary
- add conservative TemporalVLAReusePolicy for action-cache reuse decisions using age, language, phash, state, guard, and action-delta signals
- add AdaptiveChunkController and wire RTC execution horizon selection behind --adaptive-action-chunking
- feed real ActionGuard safety margins plus A2C2 correction/uncertainty telemetry into the next adaptive RTC decision
- add focused tests for temporal cache policy, adaptive chunking, guard margins, RTC signal wiring, and Typer runner compatibility

## Validation
- PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/ -q -p no:cacheprovider -> 3055 passed, 82 skipped, 3 warnings
- .venv/bin/ruff check touched runtime/test files -> passed
- PYTHONPATH=$PWD/src .venv/bin/python -m py_compile edited runtime files -> passed

## Notes
- src/tether/cli.py still has pre-existing Ruff debt outside this change; the new CLI flag compiles and is covered by the full test smoke.
