### PR TITLE
Fix/episode cache bytes metric wiring

### DIFF
--- a/src/tether/runtime/episode_cache.py
+++ b/src/tether/runtime/episode_cache.py
@@ -41,7 +41,7 @@ import hashlib
 import logging
 import time
 from collections import OrderedDict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -174,9 +174,19 @@ class EpisodeCache:
         past_kv: list[np.ndarray],
         prefix_pad_masks: np.ndarray,
     ) -> EpisodePrefix:
-        """Insert a fresh VLM prefix for an episode. Evicts LRU if needed."""
+        """Insert a fresh VLM prefix for an episode. Evicts LRU if needed.
+
+        Safe to call for a key already present (replaces it) — the
+        existing entry's bytes are backed out first so `_total_bytes`
+        never double-counts and the capacity check below doesn't evict
+        an unrelated entry to make room that was never needed."""
         key = (episode_id, lang_hash(lang_tokens))
         now = time.monotonic_ns()
+
+        is_new_episode = key not in self._cache
+        replaced = self._cache.pop(key, None)
+        if replaced is not None:
+            self._total_bytes -= replaced.bytes_size
 
         # Evict LRU if at capacity
         while len(self._cache) >= self.max_episodes:
@@ -198,7 +208,8 @@ class EpisodeCache:
         )
         self._cache[key] = prefix
         self._total_bytes += entry_bytes
-        self.stats.episode_count += 1
+        if is_new_episode:
+            self.stats.episode_count += 1
         self._emit_bytes_metric()
         return prefix
 

--- a/src/tether/runtime/pi05_decomposed_server.py
+++ b/src/tether/runtime/pi05_decomposed_server.py
@@ -371,7 +371,15 @@ class Pi05DecomposedInference:
         self._episode_cache = None
         if cache_level == "episode":
             from tether.runtime.episode_cache import EpisodeCache
-            self._episode_cache = EpisodeCache(max_episodes=episode_cache_max_episodes)
+            # Reuse the embodiment/model_id already threaded in for CUDA
+            # graph metrics — same process, same labels — so the
+            # tether_episode_cache_bytes_total gauge actually emits instead
+            # of silently no-opping (EpisodeCache requires both to be set).
+            self._episode_cache = EpisodeCache(
+                max_episodes=episode_cache_max_episodes,
+                embodiment=cuda_graphs_embodiment,
+                model_id=cuda_graphs_model_id,
+            )
             logger.info(
                 "[decomposed] episode cache enabled (max_episodes=%d)",
                 episode_cache_max_episodes,

--- a/tests/test_episode_cache_bytes.py
+++ b/tests/test_episode_cache_bytes.py
@@ -7,7 +7,6 @@ Prometheus Gauge value matches `bytes_resident()` when labels are wired.
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from tether.runtime.episode_cache import (
     EpisodeCache,
@@ -79,6 +78,37 @@ class TestByteTotal:
         cache.lookup("ep0", lang)
         cache.lookup("ep0", lang)
         assert cache.bytes_resident() == before
+
+    def test_reinsert_same_key_does_not_double_count_bytes(self):
+        """insert() called twice for the same (episode_id, lang) must
+        replace, not accumulate — regression test for a byte leak where
+        the old entry's bytes were never backed out of _total_bytes."""
+        cache = EpisodeCache(max_episodes=4)
+        past_kv, masks, lang = _fixture()
+        cache.insert("ep0", lang, past_kv, masks)
+        first_bytes = cache.bytes_resident()
+        cache.insert("ep0", lang, past_kv, masks)
+        assert cache.bytes_resident() == first_bytes
+        assert len(cache) == 1
+
+    def test_reinsert_same_key_does_not_inflate_episode_count(self):
+        cache = EpisodeCache(max_episodes=4)
+        past_kv, masks, lang = _fixture()
+        cache.insert("ep0", lang, past_kv, masks)
+        cache.insert("ep0", lang, past_kv, masks)
+        assert cache.stats.episode_count == 1
+
+    def test_reinsert_same_key_at_capacity_does_not_evict_others(self):
+        """Replacing an existing key while at capacity must not evict a
+        different entry to make room that was never needed."""
+        cache = EpisodeCache(max_episodes=2)
+        past_kv_a, masks_a, lang_a = _fixture()
+        past_kv_b, masks_b, lang_b = _fixture()
+        cache.insert("ep0", lang_a, past_kv_a, masks_a)
+        cache.insert("ep1", lang_b, past_kv_b, masks_b)
+        cache.insert("ep0", lang_a, past_kv_a, masks_a)  # replace, cache at capacity
+        assert cache.stats.evictions == 0
+        assert len(cache) == 2
 
 
 class TestPrometheusEmission:

--- a/tests/test_episode_cache_production_wiring.py
+++ b/tests/test_episode_cache_production_wiring.py
@@ -1,0 +1,116 @@
+"""Regression test for the EpisodeCache -> Pi05DecomposedInference wiring.
+
+tests/test_episode_cache_bytes.py covers EpisodeCache's byte tracking and
+Prometheus emission in isolation (constructing EpisodeCache directly with
+embodiment/model_id). This test covers the one place EpisodeCache is
+actually constructed in production: Pi05DecomposedInference.__init__ with
+cache_level="episode" (src/tether/runtime/pi05_decomposed_server.py).
+
+Until this fix, that call site built EpisodeCache with no embodiment/model_id,
+so tether_episode_cache_bytes_total silently never emitted once episode mode
+was enabled (EpisodeCache._emit_bytes_metric is a no-op unless both are set).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+
+def _stub_ort_session_with_io(input_names: list[str], output_shape=(1, 50, 7)):
+    """Mock ort.InferenceSession — same shape as test_cuda_graphs_integration.py."""
+    sess = MagicMock()
+    inputs = []
+    for name in input_names:
+        inp = MagicMock()
+        inp.name = name
+        inp.shape = [1, 4]
+        inp.type = "tensor(float)"
+        inputs.append(inp)
+    sess.get_inputs.return_value = inputs
+    sess.get_outputs.return_value = []
+    sess.get_providers.return_value = ["CPUExecutionProvider"]
+    sess.run.return_value = [np.ones(output_shape, dtype=np.float32) * 0.1]
+    return sess
+
+
+@pytest.fixture
+def decomposed_export_dir(tmp_path: Path) -> Path:
+    """Minimal decomposed export dir Pi05DecomposedInference.__init__ accepts."""
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    (export_dir / "vlm_prefix.onnx").write_bytes(b"stub-prefix")
+    (export_dir / "expert_denoise.onnx").write_bytes(b"stub-expert")
+    (export_dir / "tether_config.json").write_text(json.dumps({
+        "model_type": "pi05",
+        "export_kind": "decomposed",
+        "num_denoising_steps": 10,
+        "chunk_size": 50,
+        "action_chunk_size": 50,
+        "action_dim": 7,
+        "max_state_dim": 32,
+        "decomposed": {
+            "vlm_prefix_onnx": "vlm_prefix.onnx",
+            "expert_denoise_onnx": "expert_denoise.onnx",
+            "past_kv_tensor_names": [f"past_kv_{i}" for i in range(2)],
+            "paligemma_layers": 2,
+        },
+    }))
+    return export_dir
+
+
+def test_episode_cache_level_wires_embodiment_and_model_id(
+    decomposed_export_dir, monkeypatch,
+):
+    """cache_level='episode' must construct EpisodeCache with the same
+    embodiment/model_id already threaded in for CUDA-graph metrics, so the
+    byte gauge actually emits instead of silently no-opping."""
+    import onnxruntime as ort
+
+    monkeypatch.setattr(
+        ort, "InferenceSession",
+        lambda *a, **kw: _stub_ort_session_with_io(["x"]),
+    )
+
+    from tether.runtime.pi05_decomposed_server import Pi05DecomposedInference
+
+    inference = Pi05DecomposedInference(
+        decomposed_export_dir,
+        enable_cache=False,
+        cache_level="episode",
+        cuda_graphs_embodiment="franka",
+        cuda_graphs_model_id="pi05-test",
+    )
+
+    assert inference._episode_cache is not None
+    assert inference._episode_cache._embodiment == "franka"
+    assert inference._episode_cache._model_id == "pi05-test"
+
+
+def test_episode_cache_level_defaults_still_wire_through(
+    decomposed_export_dir, monkeypatch,
+):
+    """Even without explicit cuda_graphs_* kwargs, the (default 'unknown')
+    values must still reach EpisodeCache — the gauge should emit under an
+    'unknown' label rather than not emit at all."""
+    import onnxruntime as ort
+
+    monkeypatch.setattr(
+        ort, "InferenceSession",
+        lambda *a, **kw: _stub_ort_session_with_io(["x"]),
+    )
+
+    from tether.runtime.pi05_decomposed_server import Pi05DecomposedInference
+
+    inference = Pi05DecomposedInference(
+        decomposed_export_dir,
+        enable_cache=False,
+        cache_level="episode",
+    )
+
+    assert inference._episode_cache is not None
+    assert inference._episode_cache._embodiment == "unknown"
+    assert inference._episode_cache._model_id == "unknown"


### PR DESCRIPTION
## Description
Closes the loop on #103. The requested tracking (`EpisodeCache` byte accounting + `tether_episode_cache_bytes_total` Prometheus gauge) was already implemented in #106. This PR fixes two correctness gaps left in that implementation:

1. **Metric never emits in production.** The only real call site, `Pi05DecomposedInference.__init__` with `cache_level="episode"` (src/tether/runtime/pi05_decomposed_server.py:378), constructed `EpisodeCache` without `embodiment`/`model_id`. Since `EpisodeCache._emit_bytes_metric()` no-ops unless both are set, the gauge silently never emitted once episode mode was enabled. Fixed by reusing `cuda_graphs_embodiment`/`cuda_graphs_model_id`, already threaded into the same constructor for CUDA graph metrics.

2. **`insert()` double-counts bytes on a same-key re-insert.** Calling `insert()` twice for the same `(episode_id, lang_hash)` never backed out the old entry's bytes before adding the new ones - a permanent leak in `_total_bytes` (and therefore the gauge), a chance of evicting an unrelated LRU entry at capacity, and inflated `stats.episode_count` ("unique episodes seen"). Not reachable via today's only caller (which always checks `lookup()` first), but `insert()` is public API on the exact class #103 asked to be byte-accurate, so it's fixed directly rather than left latent.

Note: `cache_level="episode"` isn't wired to any `tether serve` CLI flag yet, so this doesn't make the feature live today, it makes the byte-tracking and metric correct for when it becomes reachable.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Infrastructure / CI update

## How Has This Been Tested?
- [x] `pytest tests/` passes locally
- [ ] `tether doctor` sanity check
- [x] Other: manual end-to-end script against the real (non-mocked)
  classes, reproducible with:

  ```bash
  pytest tests/test_episode_cache_bytes.py \
         tests/test_episode_cache_production_wiring.py \
         tests/test_episode_cache_utils.py \
         tests/test_decomposed_server.py \
         tests/test_cuda_graphs_integration.py \
         tests/test_pi05_action_fast_path_integration.py -v
  # -> 51 passed, 1 skipped (CUDA-only test, expected without a GPU)
  ```

  Confirmed both new test groups fail against the pre-fix code before passing with it:
  `assert None == 'franka'` (gap 1), `assert 1032 == 516` / episode_count 2-vs-1 / evictions 1-vs-0 (gap 2).

  Also drove the real `Pi05DecomposedInference` class (mocked ORT session only - no real model export available here) through `cache_level="episode"` and read the actual rendered Prometheus output:

  ```
  tether_episode_cache_bytes_total{embodiment="franka",model_id="pi05-real-check",policy_slot="prod"} 516.0
  ```
- `ruff check` clean on all touched files.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have kept the PR scoped to a single concern