### PR TITLE
fix(cli): replace default logging with RichHandler

### DIFF
--- a/src/tether/cli.py
+++ b/src/tether/cli.py
@@ -1,6 +1,7 @@
 """Tether CLI — deploy VLA models to edge hardware."""
 
 from __future__ import annotations
+from rich.logging import RichHandler
 
 import json
 import logging
@@ -59,10 +60,15 @@ _NOARGS_SUMMARY = """[bold]tether[/bold] — deployment confidence for VLA robot
 def _setup_logging(verbose: bool = False) -> None:
     level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(
-        level=level,
-        format="%(levelname)s %(name)s: %(message)s",
-        stream=sys.stderr,
-    )
+    level=level,
+    format="%(message)s",
+    handlers=[
+        RichHandler(
+            rich_tracebacks=True,
+            show_path=False,
+        )
+    ],
+)
 
 
 def _tether_home() -> Path:

--- a/src/tether/cli.py
+++ b/src/tether/cli.py
@@ -1,7 +1,6 @@
 """Tether CLI — deploy VLA models to edge hardware."""
 
 from __future__ import annotations
-from rich.logging import RichHandler
 
 import json
 import logging
@@ -12,6 +11,7 @@ from typing import Any, Optional
 
 import typer
 from rich.console import Console
+from rich.logging import RichHandler
 from rich.table import Table
 
 from tether import __version__
@@ -60,15 +60,18 @@ _NOARGS_SUMMARY = """[bold]tether[/bold] — deployment confidence for VLA robot
 def _setup_logging(verbose: bool = False) -> None:
     level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(
-    level=level,
-    format="%(message)s",
-    handlers=[
-        RichHandler(
-            rich_tracebacks=True,
-            show_path=False,
-        )
-    ],
-)
+        level=level,
+        format="%(name)s: %(message)s",
+        handlers=[
+            RichHandler(
+                # stderr keeps stdout clean for `--json` consumers and shell
+                # pipelines; RichHandler's default console writes to stdout.
+                console=Console(stderr=True),
+                rich_tracebacks=True,
+                show_path=False,
+            )
+        ],
+    )
 
 
 def _tether_home() -> Path:


### PR DESCRIPTION
## Description
Replaced the default CLI logging handler with `rich.logging.RichHandler` to improve log readability with colored log levels while preserving the existing logging behavior. This fixes #73 

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure / CI update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
- [X] `pytest tests/` passes locally
- [X] `tether doctor` sanity check
- [ ] Other (please specify):

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I have kept the PR scoped to a single concern (one concern per PR)
