### PR TITLE
fix(security): contain unauthenticated revoke cascade

### DIFF
--- a/infra/contribution-worker/README.md
+++ b/infra/contribution-worker/README.md
@@ -17,12 +17,17 @@ Sibling workers (each in its own folder under `infra/`):
 - `POST /admin/init-bucket` — sanity-check the R2 binding
 - `GET  /admin/contributors` — list contributors + stats
 - `POST /admin/manual-purge` — trigger cascade for a specific contributor
+- `POST /admin/cascade-execute/:request_id` — force cascade progression
+- `POST /v1/revoke/cascade` — mark a contributor for purge (temporary admin-only containment)
 
 ### Customer (Phase 1 soft-auth: `contributor_id` + `opted_in_at` body fields)
 - `POST /v1/uploads/sign` — issue signed PUT URL for an upload
 - `POST /v1/uploads/complete` — record successful upload, increment stats
-- `POST /v1/revoke/cascade` — mark contributor for purge (30-day SLA)
+- `GET  /v1/revoke/cascade-status/:request_id` — read cascade state without advancing it
 - `GET  /v1/contributors/:id/stats` — return contribution totals
+
+Timed revoke stages advance through the private Cloudflare cron trigger every
+five minutes. Public `GET` requests never perform a tombstone or R2 deletion.
 
 ## Storage
 
@@ -47,6 +52,12 @@ on-disk consent receipt. **Anyone with a valid `contributor_id` could upload as
 that contributor** — privacy-acceptable because contributor_ids are anonymous
 and uploads are subject to the same anonymization filters that ship in
 `reflex.curate.uploader`.
+
+Destructive revoke operations are excluded from this soft-auth model. As an
+emergency containment measure, they require `Authorization: Bearer
+<ADMIN_TOKEN>` and use a fixed-length digest comparison. A contributor-facing
+revoke flow must not be re-enabled until it binds the requested contributor ID
+to proof of possession.
 
 **Phase 1.5:** add Ed25519 challenge-response. The user-side keypair lives in
 the consent receipt (`consent_signature`); the worker challenges the client
@@ -84,8 +95,9 @@ After deploy:
 - Update `src/reflex/curate/uploader.py:_request_signed_url` and `_put_to_r2`
   to make real httpx calls (currently raise `UploadStub`).
 - Flip `live=True` in `src/reflex/runtime/server.py` curate-uploader scaffolding.
-- Update `src/reflex/curate/opt_in_cli.py:_cmd_revoke` to actually POST to
-  `/v1/revoke/cascade` instead of logging.
+- Do not wire the contributor CLI to `/v1/revoke/cascade` while the emergency
+  admin-only containment is active. A public revoke flow requires the signed
+  proof-of-possession protocol first.
 
 ## Layout convention (per ADR decision #1)
 
@@ -109,7 +121,6 @@ key from the request body's `tier` field.
   defaults so older rows still satisfy NOT NULL constraints.
 - `daily_uploads` is the hot table on the upload path. Indexed on
   `(contributor_id, utc_date)` (PK) + `utc_date` for retention prune jobs.
-- Revoke cascade runs OUT OF BAND from this worker — the worker only
-  enqueues the request and flags the contributor. The actual R2 deletion
-  + derived-dataset rebuild + buyer notifications are operator-driven jobs
-  triggered by the Slack alert. Phase 2 automates the cascade.
+- Revoke cascade progression runs through the Worker's private scheduled hook.
+  The public status route is read-only; an administrator can force progression
+  through the authenticated `/admin/cascade-execute/:request_id` route.

--- a/infra/contribution-worker/deploy.sh
+++ b/infra/contribution-worker/deploy.sh
@@ -132,6 +132,6 @@ echo "    1. Update src/reflex/curate/uploader.py:_request_signed_url + _put_to_
 echo "       to make real httpx POST/PUT calls (replace UploadStub)."
 echo "    2. Flip the curate uploader's live=False to live=True in"
 echo "       src/reflex/runtime/server.py."
-echo "    3. Update src/reflex/curate/opt_in_cli.py:_cmd_revoke to POST to"
-echo "       \$WORKER_URL/v1/revoke/cascade."
+echo "    3. Keep contributor revoke disabled until signed proof-of-possession"
+echo "       replaces the temporary admin-only containment."
 echo "    4. (Optional) bind a custom domain in wrangler.toml + redeploy."

--- a/infra/contribution-worker/package.json
+++ b/infra/contribution-worker/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  }
+}

--- a/infra/contribution-worker/test/revoke-auth.test.js
+++ b/infra/contribution-worker/test/revoke-auth.test.js
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "../worker.js";
+
+const ADMIN_TOKEN = "test-admin-token-with-enough-entropy";
+
+function request(path, { method = "GET", token, body } = {}) {
+  const headers = {};
+  if (token !== undefined) headers.Authorization = `Bearer ${token}`;
+  if (body !== undefined) headers["content-type"] = "application/json";
+  return new Request(`https://worker.test${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function revokeRow(overrides = {}) {
+  return {
+    request_id: "rev_test",
+    contributor_id: "contributor_test",
+    requested_at: "2099-01-01T00:00:00.000Z",
+    scope: "all",
+    status: "pending",
+    tombstone_at: null,
+    r2_purge_started_at: null,
+    r2_purge_completed_at: null,
+    r2_objects_purged: 0,
+    derived_rebuild_completed_at: "2099-01-01T00:00:00.000Z",
+    buyer_notification_completed_at: "2099-01-01T00:00:00.000Z",
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+function dbMock({ first = null, all = { results: [] } } = {}) {
+  const calls = [];
+  return {
+    calls,
+    prepare(sql) {
+      const call = { sql, bindings: [], operation: null };
+      calls.push(call);
+      return {
+        bind(...bindings) {
+          call.bindings = bindings;
+          return this;
+        },
+        async first() {
+          call.operation = "first";
+          return typeof first === "function" ? first(call) : first;
+        },
+        async all() {
+          call.operation = "all";
+          return typeof all === "function" ? all(call) : all;
+        },
+        async run() {
+          call.operation = "run";
+          return { success: true };
+        },
+      };
+    },
+  };
+}
+
+test("unauthenticated revoke is rejected before any database mutation", async () => {
+  const DB = dbMock();
+  const response = await worker.fetch(request("/v1/revoke/cascade", {
+    method: "POST",
+    body: { contributor_id: "victim", scope: "all" },
+  }), { DB, ADMIN_TOKEN });
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: "unauthorized" });
+  assert.equal(DB.calls.length, 0);
+});
+
+test("every HTTP cascade mutation rejects a missing admin bearer", async () => {
+  const cases = [
+    ["/v1/revoke/cascade", { contributor_id: "victim", scope: "all" }],
+    ["/admin/manual-purge", { contributor_id: "victim" }],
+    ["/admin/cascade-execute/rev_test", undefined],
+  ];
+  for (const [path, body] of cases) {
+    const DB = dbMock();
+    const response = await worker.fetch(request(path, {
+      method: "POST",
+      body,
+    }), { DB, ADMIN_TOKEN });
+    assert.equal(response.status, 401, path);
+    assert.equal(DB.calls.length, 0, path);
+  }
+});
+
+test("incorrect bearer tokens of different lengths are rejected", async () => {
+  for (const token of ["x", `${ADMIN_TOKEN}-wrong`, ""]) {
+    const DB = dbMock();
+    const response = await worker.fetch(request("/v1/revoke/cascade", {
+      method: "POST",
+      token,
+      body: { contributor_id: "victim", scope: "all" },
+    }), { DB, ADMIN_TOKEN });
+    assert.equal(response.status, 401);
+    assert.equal(DB.calls.length, 0);
+  }
+});
+
+test("correct bearer token authorizes an idempotent revoke enqueue", async () => {
+  const DB = dbMock();
+  const response = await worker.fetch(request("/v1/revoke/cascade", {
+    method: "POST",
+    token: ADMIN_TOKEN,
+    body: { contributor_id: "contributor_test", scope: "all" },
+  }), { DB, ADMIN_TOKEN });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.contributor_id, "contributor_test");
+  assert.match(payload.request_id, /^rev_[0-9a-f]{32}$/);
+  assert.equal(DB.calls.filter((call) => call.operation === "run").length, 2);
+});
+
+test("cascade status GET is read-only even when a stage is due", async () => {
+  const DB = dbMock({
+    first: revokeRow({ requested_at: "2000-01-01T00:00:00.000Z" }),
+  });
+  const response = await worker.fetch(
+    request("/v1/revoke/cascade-status/rev_test"),
+    { DB },
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(DB.calls.length, 1);
+  assert.equal(DB.calls[0].operation, "first");
+  assert.match(DB.calls[0].sql, /^SELECT \* FROM revoke_requests/);
+});
+
+test("scheduled event uses the private progression path", async () => {
+  const DB = dbMock({ all: { results: [] } });
+  const work = [];
+  worker.scheduled({}, { DB }, { waitUntil: (promise) => work.push(promise) });
+
+  assert.equal(work.length, 1);
+  await Promise.all(work);
+  assert.equal(DB.calls.length, 1);
+  assert.equal(DB.calls[0].operation, "all");
+  assert.match(DB.calls[0].sql, /status != 'completed'/);
+});

--- a/infra/contribution-worker/worker.js
+++ b/infra/contribution-worker/worker.js
@@ -6,13 +6,15 @@
  *   POST /admin/init-bucket                      → confirm R2 bucket exists (admin auth)
  *   GET  /admin/contributors                     → list contributors + stats (admin auth)
  *   POST /admin/manual-purge                     → trigger cascade purge for contributor_id (admin auth)
+ *   POST /admin/cascade-execute/:request_id       → force cascade progression (admin auth)
  *   POST /v1/uploads/sign                        → issue signed PUT URL for an upload
  *   POST /v1/uploads/complete                    → record successful upload, update stats
- *   POST /v1/revoke/cascade                      → mark contributor for purge (30-day SLA)
+ *   POST /v1/revoke/cascade                      → mark contributor for purge (admin auth)
+ *   GET  /v1/revoke/cascade-status/:request_id   → read cascade status (never mutates)
  *   GET  /v1/contributors/:id/stats              → return contribution stats for `reflex contribute --status`
  *
  * Auth (Phase 1):
- *   - Admin endpoints: Authorization: Bearer <ADMIN_TOKEN>
+ *   - Admin and revoke-mutation endpoints: Authorization: Bearer <ADMIN_TOKEN>
  *   - Customer endpoints: contributor_id + opted_in_at as soft-proof.
  *     Phase 1.5 will add Ed25519 challenge-response signed by the
  *     consent receipt's user-side key.
@@ -66,7 +68,7 @@ export default {
       if (method === "POST" && path === "/v1/uploads/complete")
         return await postUploadsComplete(request, env);
       if (method === "POST" && path === "/v1/revoke/cascade")
-        return await postRevokeCascade(request, env);
+        return await adminAuth(request, env, () => postRevokeCascade(request, env));
       if (method === "GET" && path.startsWith("/v1/revoke/cascade-status/")) {
         const requestId = path.split("/").pop();
         return await getRevokeCascadeStatus(requestId, env);
@@ -88,17 +90,49 @@ export default {
       return jsonResponse(500, { error: "internal_error", message: e.message });
     }
   },
+
+  scheduled(_controller, env, ctx) {
+    // Timed cascade progression is deliberately unavailable over public HTTP.
+    // Cloudflare invokes this hook from the configured cron trigger.
+    ctx.waitUntil(progressPendingCascades(env));
+  },
 };
 
 // ---------- middleware ----------
 
 async function adminAuth(request, env, handler) {
-  const auth = request.headers.get(ADMIN_TOKEN_HEADER) || "";
-  const expected = `Bearer ${env.ADMIN_TOKEN}`;
-  if (!env.ADMIN_TOKEN || auth !== expected) {
+  if (!(await hasValidAdminBearer(request, env))) {
     return jsonResponse(401, { error: "unauthorized" });
   }
   return await handler();
+}
+
+/**
+ * Verify the admin bearer without an early-exit string comparison.
+ *
+ * Both values are reduced to fixed-length SHA-256 digests before the XOR
+ * comparison, so differing token lengths and the first mismatching byte do
+ * not change the comparison loop. An absent server-side secret always fails.
+ */
+async function hasValidAdminBearer(request, env) {
+  const authorization = request.headers.get(ADMIN_TOKEN_HEADER) || "";
+  const supplied = authorization.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length)
+    : "";
+  const expected = typeof env.ADMIN_TOKEN === "string" ? env.ADMIN_TOKEN : "";
+  const encoder = new TextEncoder();
+  const [suppliedDigest, expectedDigest] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(supplied)),
+    crypto.subtle.digest("SHA-256", encoder.encode(expected)),
+  ]);
+
+  const suppliedBytes = new Uint8Array(suppliedDigest);
+  const expectedBytes = new Uint8Array(expectedDigest);
+  let mismatch = expected.length === 0 ? 1 : 0;
+  for (let i = 0; i < expectedBytes.length; i += 1) {
+    mismatch |= suppliedBytes[i] ^ expectedBytes[i];
+  }
+  return mismatch === 0;
 }
 
 // ---------- handlers: health + admin ----------
@@ -418,6 +452,8 @@ async function postUploadsComplete(request, env) {
  *
  * Body: { contributor_id: string, scope: "all" | "future_only" }
  *
+ * Emergency containment: this endpoint requires the same admin bearer as
+ * /admin routes until contributor proof-of-possession authentication ships.
  * Marks the contributor for revoke. The actual purge cascade (delete R2
  * objects + rebuild derived datasets + email buyers) runs as a separate
  * background job; this endpoint only enqueues the request and updates
@@ -432,7 +468,7 @@ async function postRevokeCascade(request, env) {
   if (!["all", "future_only"].includes(scope)) {
     return jsonResponse(400, { error: "invalid_scope", got: scope });
   }
-  return await initiateRevoke(env, contributorId, scope, "customer");
+  return await initiateRevoke(env, contributorId, scope, "admin_api");
 }
 
 /**
@@ -498,12 +534,14 @@ async function initiateRevoke(env, contributorId, scope, source) {
 /**
  * GET /v1/revoke/cascade-status/<request_id>
  *
- * Returns the current cascade state for a request. Lazily progresses the
- * cascade through any stages whose SLA has elapsed (no separate cron needed).
+ * Returns the current cascade state for a request. This handler is strictly
+ * read-only; timed progression runs only from the Worker's scheduled hook.
  */
 async function getRevokeCascadeStatus(requestId, env) {
   if (!requestId) return jsonResponse(400, { error: "missing_request_id" });
-  const fresh = await loadAndProgressCascade(requestId, env, { force: false });
+  const fresh = await env.DB.prepare(
+    `SELECT * FROM revoke_requests WHERE request_id = ?`
+  ).bind(requestId).first();
   if (!fresh) return jsonResponse(404, { error: "request_not_found" });
   return jsonResponse(200, formatCascadeStatus(fresh));
 }
@@ -514,6 +552,21 @@ async function adminExecuteCascade(requestId, env) {
   const fresh = await loadAndProgressCascade(requestId, env, { force: true });
   if (!fresh) return jsonResponse(404, { error: "request_not_found" });
   return jsonResponse(200, formatCascadeStatus(fresh));
+}
+
+
+/**
+ * Progress pending cascades from Cloudflare's non-HTTP scheduled event.
+ * Each stage remains idempotent in loadAndProgressCascade, so retrying a
+ * scheduled event is safe.
+ */
+async function progressPendingCascades(env) {
+  const pending = await env.DB.prepare(
+    `SELECT request_id FROM revoke_requests WHERE status != 'completed' LIMIT 100`
+  ).all();
+  for (const row of pending.results || []) {
+    await loadAndProgressCascade(row.request_id, env, { force: false });
+  }
 }
 
 

--- a/infra/contribution-worker/wrangler.toml
+++ b/infra/contribution-worker/wrangler.toml
@@ -2,6 +2,11 @@ name = "reflex-contributions"
 main = "worker.js"
 compatibility_date = "2026-05-01"
 
+# Cascade status GETs are read-only. This private scheduler hook is the only
+# non-admin path that advances elapsed revoke stages.
+[triggers]
+crons = ["*/5 * * * *"]
+
 # D1 binding for contributor metadata + upload tracking + revoke cascade.
 # Fill in `database_id` after `wrangler d1 create reflex-contributions`.
 [[d1_databases]]
@@ -22,5 +27,5 @@ bucket_name = "reflex-curate"
 # routes = [{ pattern = "data.fastcrest.com/*", custom_domain = true }]
 
 # Required Secrets (set via `wrangler secret put`):
-#   ADMIN_TOKEN                — bearer token for /admin/* endpoints
+#   ADMIN_TOKEN                — bearer token for admin + revoke mutations
 #   SLACK_WEBHOOK_URL          — optional; alert on revoke + suspicious uploads

--- a/scripts/stress_test_contribution_worker.py
+++ b/scripts/stress_test_contribution_worker.py
@@ -22,7 +22,7 @@ contributor traffic hits:
    so the next stress run starts fresh.
 
 Usage:
-    python scripts/stress_test_contribution_worker.py
+    TETHER_CONTRIB_ADMIN_TOKEN=... python scripts/stress_test_contribution_worker.py
     python scripts/stress_test_contribution_worker.py --concurrency 200
     python scripts/stress_test_contribution_worker.py --skip-cleanup  # leave D1 dirty for debugging
 
@@ -58,6 +58,11 @@ class StressOutcome:
 
 def _worker_url() -> str:
     return os.environ.get("TETHER_CONTRIB_ENDPOINT", DEFAULT_WORKER).rstrip("/")
+
+
+def _admin_headers() -> dict[str, str]:
+    token = os.environ.get("TETHER_CONTRIB_ADMIN_TOKEN", "")
+    return {"Authorization": f"Bearer {token}"}
 
 
 def _smoke_contributor_id() -> str:
@@ -210,6 +215,7 @@ def test_revoked_contributor_refusal() -> StressOutcome:
         revoke = client.post(
             f"{_worker_url()}/v1/revoke/cascade",
             json={"contributor_id": cid, "scope": "all"},
+            headers=_admin_headers(),
             timeout=30.0,
         )
 
@@ -283,6 +289,12 @@ def main():
                         "Phase 1.5 reservation-based rate limit lands.")
     p.add_argument("--skip-cleanup", action="store_true")
     args = p.parse_args()
+
+    if not os.environ.get("TETHER_CONTRIB_ADMIN_TOKEN"):
+        p.error(
+            "TETHER_CONTRIB_ADMIN_TOKEN is required because the revoke "
+            "stress case exercises an admin-only destructive endpoint"
+        )
 
     print(f"=== Stress-testing contribution-worker at {_worker_url()} ===\n")
 


### PR DESCRIPTION
## Summary
- require timing-resistant admin bearer authorization for every HTTP cascade mutation
- make public cascade status reads strictly non-mutating and move timed progression to a private cron hook
- add focused Worker tests and update live stress/docs for temporary admin-only containment

## Validation
- `npm test` (6 passed)
- `node --check worker.js`
- `npx wrangler deploy --dry-run`
- `ruff check scripts/stress_test_contribution_worker.py`
- `python -m compileall -q scripts/stress_test_contribution_worker.py`

Code containment for #260. This PR does not claim production deployment or ADMIN_TOKEN rotation; the issue should remain open until that evidence is recorded.