### PR TITLE
fix(safety): preserve velocity constraints across clamped rows

### DIFF
--- a/src/tether/safety/guard.py
+++ b/src/tether/safety/guard.py
@@ -328,10 +328,6 @@ class ActionGuard:
         num_joints = min(len(action), len(self.limits.position_max))
 
         for i in range(num_joints):
-            # Marks where this joint's own violations start. The velocity gate
-            # below reads it instead of scanning the shared cross-joint list.
-            joint_violation_start = len(violations)
-
             # Position bounds
             if safe_action[i] < self.limits.position_min[i]:
                 violations.append(
@@ -363,11 +359,17 @@ class ActionGuard:
                         )
                         clamped = True
 
-            if (
-                previous_action is not None
-                and len(violations) == joint_violation_start
-                and i < len(self.limits.velocity_max)
-            ):
+        # Compose the velocity constraint with the position and effort bounds.
+        # The caller executes ``safe_action``, so its delta from the previously
+        # emitted action must remain within the configured velocity limit even
+        # when this joint also needed a static clamp.
+        if previous_action is not None:
+            num_velocity = min(
+                len(safe_action),
+                len(previous_action),
+                len(self.limits.velocity_max),
+            )
+            for i in range(num_velocity):
                 velocity_limit = self.limits.velocity_max[i]
                 delta = float(safe_action[i] - previous_action[i])
                 if velocity_limit > 0 and abs(delta) > velocity_limit:
@@ -468,13 +470,10 @@ class ActionGuard:
                 )
                 results.append(result)
                 safe_actions[i] = np.array(result.safe_action)
-                if result.safe or (
-                    result.violations
-                    and all("velocity limit" in v for v in result.violations)
-                ):
-                    previous_safe = safe_actions[i]
-                else:
-                    previous_safe = None
+                # The returned action is what the caller will execute. Preserve
+                # it as the next velocity reference in both clamp and reject
+                # modes, including rows that contained static violations.
+                previous_safe = safe_actions[i]
             all_violations = [v for r in results for v in r.violations]
             chunk_clamped = any(r.clamped for r in results)
 

--- a/tests/test_action_guard_embodiment.py
+++ b/tests/test_action_guard_embodiment.py
@@ -118,8 +118,11 @@ class TestActionGuardFromEmbodiment:
         safe, results = guard.check(chunk)
         # Action 0 unchanged (was mean)
         np.testing.assert_array_equal(safe[0], mean)
-        # Action 1 clamped on joint_0; other dims preserved
-        assert safe[1, 0] == pytest.approx(2.8973)
+        # Action 1 satisfies both the static Franka bound and the 1 rad/step
+        # velocity bound from the action that will actually precede it.
+        assert safe[1, 0] == pytest.approx(1.0)
+        assert any("joint_0 above max" in v for v in results[1].violations)
+        assert any("joint_0 velocity limit" in v for v in results[1].violations)
         np.testing.assert_array_equal(safe[1, 1:], mean[1:])
         # Action 2 unchanged (was mean)
         np.testing.assert_array_equal(safe[2], mean)

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -173,7 +173,7 @@ class TestActionGuard:
         assert any("joint_1 velocity limit" in v for v in results[1].violations)
         assert results[1].clamped
 
-    def test_position_clamp_still_takes_precedence_on_the_same_joint(self):
+    def test_same_joint_position_and_velocity_limits_both_hold(self):
         limits = SafetyLimits(
             joint_names=["j0", "j1"],
             position_min=[-1.0, -10.0],
@@ -187,8 +187,42 @@ class TestActionGuard:
             np.array([5.0, 0.0]), previous_action=np.zeros(2)
         )
 
-        assert result.safe_action[0] == 1.0
-        assert not any("joint_0 velocity limit" in v for v in result.violations)
+        assert result.safe_action[0] == pytest.approx(0.1)
+        assert any("joint_0 above max" in v for v in result.violations)
+        assert any("joint_0 velocity limit" in v for v in result.violations)
+
+    def test_chunk_preserves_velocity_reference_after_position_clamp(self):
+        limits = SafetyLimits(
+            joint_names=["j0"],
+            position_min=[-1.0],
+            position_max=[1.0],
+            velocity_max=[0.5],
+            effort_max=[50.0],
+        )
+        guard = ActionGuard(limits=limits, mode="clamp")
+
+        safe_actions, results = guard.check(np.array([[0.0], [2.0], [-1.0]]))
+
+        np.testing.assert_allclose(safe_actions[:, 0], [0.0, 0.5, 0.0])
+        assert any("joint_0 above max" in v for v in results[1].violations)
+        assert any("joint_0 velocity limit" in v for v in results[1].violations)
+        assert any("joint_0 velocity limit" in v for v in results[2].violations)
+
+    def test_reject_mode_uses_emitted_zero_as_next_velocity_reference(self):
+        limits = SafetyLimits(
+            joint_names=["j0"],
+            position_min=[-1.0],
+            position_max=[1.0],
+            velocity_max=[0.5],
+            effort_max=[50.0],
+        )
+        guard = ActionGuard(limits=limits, mode="reject")
+
+        safe_actions, results = guard.check(np.array([[0.0], [2.0], [1.0]]))
+
+        np.testing.assert_allclose(safe_actions[:, 0], [0.0, 0.0, 0.0])
+        assert any("joint_0 above max" in v for v in results[1].violations)
+        assert any("joint_0 velocity limit" in v for v in results[2].violations)
 
     def test_velocity_check_skips_joints_without_a_configured_limit(self):
         limits = SafetyLimits(
@@ -287,7 +321,8 @@ class TestActionGuard:
         assert len(results) == 3
         assert results[0].safe
         assert not results[1].safe
-        assert results[2].safe
+        assert not results[2].safe
+        assert any("joint_1 velocity limit" in v for v in results[2].violations)
         assert safe_actions.shape == actions.shape
 
     def test_inference_count(self):


### PR DESCRIPTION
## Summary
- compose velocity enforcement with same-joint position and effort clamping
- preserve every finite emitted action as the next chunk-row velocity reference in clamp and reject modes
- add direct, clamp-chain, reject-chain, and embodiment regressions

## Validation
- `pytest tests/test_guard.py tests/test_action_guard_embodiment.py`: 49 passed
- `ruff check`: passed
- `git diff --check`: passed
- independent re-review: approved after correcting the affected embodiment expectation

Fixes #306.