### PR TITLE
fix(zmq): secure low-level bind and control defaults

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -38,7 +38,7 @@ tether serve ./my_export/ --transport zmq --host 127.0.0.1 --port 5555
 from tether.runtime.transports.zmq.client import ZmqRuntimeClient
 import numpy as np
 
-client = ZmqRuntimeClient("tcp://gpu-server:5555")
+client = ZmqRuntimeClient("tcp://127.0.0.1:5555")
 obs = {
     "agentview_image": camera.read(),  # 224x224x3 uint8
     "robot0_eef_pos": robot.get_eef_pos(),
@@ -55,6 +55,13 @@ control token for operational endpoints such as `ping` and `kill`.
 `tether serve --transport zmq` refuses non-loopback binds unless both are
 configured. For isolated lab networks only, operators can pass
 `--zmq-insecure-ok` to make that risk explicit.
+
+Low-level SDK callers get the same protection. `PolicyServer` and
+`create_zmq_server` bind to `127.0.0.1` by default and reject a non-loopback
+bind unless CURVE and a control token are both configured. Passing
+`allow_insecure=True` is the SDK equivalent of `--zmq-insecure-ok` and emits a
+warning. Without a control token, `ping` and `kill` are disabled even on
+loopback; prediction and custom endpoint authentication policies are unchanged.
 
 Generate one server keypair and one client keypair:
 

--- a/src/tether/cli.py
+++ b/src/tether/cli.py
@@ -3171,27 +3171,20 @@ def serve(
     if transport == "zmq":
         console.print("[bold green]Starting ZMQ server...[/bold green]")
         from tether.runtime.transports.zmq.factory import create_zmq_server
-        from tether.runtime.transports.zmq.security import validate_zmq_bind_security
 
         try:
-            validate_zmq_bind_security(
+            zmq_server = create_zmq_server(
+                app_instance,
                 host=host,
-                curve_enabled=bool(zmq_server_cert and zmq_client_cert_dir),
-                control_auth_enabled=bool(zmq_control_token),
+                port=port,
+                curve_server_cert=zmq_server_cert or None,
+                curve_client_cert_dir=zmq_client_cert_dir or None,
+                control_token=zmq_control_token or None,
                 allow_insecure=zmq_insecure_ok,
             )
         except ValueError as exc:
             err_console.print(f"[red]{exc}[/red]", markup=False)
             raise typer.Exit(1) from exc
-
-        zmq_server = create_zmq_server(
-            app_instance,
-            host=host,
-            port=port,
-            curve_server_cert=zmq_server_cert or None,
-            curve_client_cert_dir=zmq_client_cert_dir or None,
-            control_token=zmq_control_token or None,
-        )
         composed.append("[cyan]transport=zmq[/cyan]")
         if zmq_server_cert:
             composed.append("[cyan]curve=on[/cyan]")

--- a/src/tether/runtime/transports/zmq/factory.py
+++ b/src/tether/runtime/transports/zmq/factory.py
@@ -12,6 +12,7 @@ Usage::
     server = create_zmq_server(runtime, port=5555)
     server.run()  # blocks
 """
+
 from __future__ import annotations
 
 import io
@@ -31,11 +32,12 @@ logger = logging.getLogger(__name__)
 def create_zmq_server(
     runtime: Any,
     *,
-    host: str = "*",
+    host: str = "127.0.0.1",
     port: int = 5555,
     curve_server_cert: str | Path | None = None,
     curve_client_cert_dir: str | Path | None = None,
     control_token: str | None = None,
+    allow_insecure: bool = False,
 ) -> PolicyServer:
     """Create a ZMQ server that wraps a tether PolicyRuntime.
 
@@ -51,11 +53,14 @@ def create_zmq_server(
     Args:
         runtime: A tether ``PolicyRuntime`` or any object with a
             ``predict_action_chunk`` / ``predict_async`` method.
-        host: Bind address.
+        host: Bind address. Defaults to loopback.
         port: Bind port.
         curve_server_cert: Optional pyzmq CURVE server secret certificate.
         curve_client_cert_dir: Directory of allowed client public certificates.
-        control_token: Optional token required for built-in control endpoints.
+        control_token: Token that enables and authenticates the built-in
+            control endpoints. Without one, ``ping`` and ``kill`` are disabled.
+        allow_insecure: Allow an incompletely protected non-loopback bind.
+            Intended only for isolated lab networks; emits a warning.
 
     Returns:
         A configured ``PolicyServer`` ready to ``run()``.
@@ -72,6 +77,7 @@ def create_zmq_server(
 
         if hasattr(runtime, "predict_async"):
             import asyncio
+
             loop = asyncio.new_event_loop()
             try:
                 result = loop.run_until_complete(runtime.predict_async(kwargs))
@@ -104,13 +110,15 @@ def create_zmq_server(
             total_requests += 1
             total_infer_time += infer_time
             n = total_requests
-            should_log = (n % 50 == 0)
+            should_log = n % 50 == 0
             avg = total_infer_time / n if should_log else 0.0
 
         if should_log:
             logger.info(
                 "ZMQ req=%d infer=%.1fms avg=%.1fms",
-                n, infer_time * 1000, avg * 1000,
+                n,
+                infer_time * 1000,
+                avg * 1000,
             )
 
         return {
@@ -138,6 +146,7 @@ def create_zmq_server(
         curve_server_cert=curve_server_cert,
         curve_client_cert_dir=curve_client_cert_dir,
         control_token=control_token,
+        allow_insecure=allow_insecure,
     )
     server.register_endpoint("predict_action", predict_action)
     server.register_endpoint("reset", reset, requires_input=False)

--- a/src/tether/runtime/transports/zmq/policy_server.py
+++ b/src/tether/runtime/transports/zmq/policy_server.py
@@ -14,6 +14,7 @@ Usage::
     server.register_endpoint("predict_action", my_handler)
     server.run()  # blocks
 """
+
 from __future__ import annotations
 
 import hmac
@@ -27,12 +28,16 @@ import msgpack
 import zmq
 from zmq.auth.thread import ThreadAuthenticator
 
-from tether.runtime.transports.zmq.security import load_curve_key
+from tether.runtime.transports.zmq.security import (
+    load_curve_key,
+    validate_zmq_bind_security,
+)
 
 logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 1
 FORMAT_PROTOBUF_BYTE = 0x01
+CONTROL_ENDPOINTS = frozenset({"ping", "kill"})
 
 
 class WireSchemaMismatchError(RuntimeError):
@@ -67,13 +72,17 @@ class PolicyServer:
     - ``kill`` — triggers graceful shutdown
 
     Args:
-        host: Bind address (``'*'`` for all interfaces).
+        host: Bind address. Defaults to loopback. Non-loopback binds require
+            CURVE client authentication and a control token unless
+            ``allow_insecure`` is explicitly enabled.
         port: TCP port to listen on. 0 = kernel-assigned (for testing).
+        allow_insecure: Allow an incompletely protected non-loopback bind.
+            Intended only for isolated lab networks; emits a warning.
     """
 
     def __init__(
         self,
-        host: str = "*",
+        host: str = "127.0.0.1",
         port: int = 5555,
         *,
         curve_server_cert: str | Path | None = None,
@@ -81,11 +90,23 @@ class PolicyServer:
         curve_server_secret_key: str | bytes | None = None,
         curve_client_cert_dir: str | Path | None = None,
         control_token: str | None = None,
+        allow_insecure: bool = False,
     ) -> None:
+        curve_enabled = bool(
+            curve_client_cert_dir
+            and (curve_server_cert or (curve_server_public_key and curve_server_secret_key))
+        )
+        validate_zmq_bind_security(
+            host=host,
+            curve_enabled=curve_enabled,
+            control_auth_enabled=bool(control_token),
+            allow_insecure=allow_insecure,
+        )
+
         self.running = True
         self.context = zmq.Context()
         self._authenticator: ThreadAuthenticator | None = None
-        self._control_token = control_token
+        self._control_token = control_token or None
         self.socket = self.context.socket(zmq.REP)
         self._configure_curve(
             curve_server_cert=curve_server_cert,
@@ -102,13 +123,13 @@ class PolicyServer:
             "ping",
             self._handle_ping,
             requires_input=False,
-            requires_auth=self._control_token is not None,
+            requires_auth=True,
         )
         self.register_endpoint(
             "kill",
             self._handle_kill,
             requires_input=False,
-            requires_auth=self._control_token is not None,
+            requires_auth=True,
         )
 
     @property
@@ -126,6 +147,8 @@ class PolicyServer:
         requires_input: bool = True,
         requires_auth: bool = False,
     ) -> None:
+        if name in CONTROL_ENDPOINTS:
+            requires_auth = True
         self._endpoints[name] = _EndpointHandler(handler, requires_input, requires_auth)
 
     def _configure_curve(
@@ -136,9 +159,15 @@ class PolicyServer:
         curve_server_secret_key: str | bytes | None,
         curve_client_cert_dir: str | Path | None,
     ) -> None:
-        if curve_server_cert is None and curve_server_public_key is None and curve_server_secret_key is None:
+        if (
+            curve_server_cert is None
+            and curve_server_public_key is None
+            and curve_server_secret_key is None
+        ):
             if curve_client_cert_dir is not None:
-                raise ValueError("curve_client_cert_dir requires a CURVE server certificate or keypair")
+                raise ValueError(
+                    "curve_client_cert_dir requires a CURVE server certificate or keypair"
+                )
             return
 
         if curve_server_cert is not None:
@@ -153,7 +182,9 @@ class PolicyServer:
             secret_key = load_curve_key(curve_server_secret_key, secret=True)
 
         if curve_client_cert_dir is None:
-            raise ValueError("CURVE server mode requires curve_client_cert_dir for client authentication")
+            raise ValueError(
+                "CURVE server mode requires curve_client_cert_dir for client authentication"
+            )
 
         client_cert_dir = Path(curve_client_cert_dir).expanduser()
         if not client_cert_dir.is_dir():
@@ -168,7 +199,7 @@ class PolicyServer:
 
     def _authorize_control_request(self, request: dict[str, Any]) -> None:
         if self._control_token is None:
-            return
+            raise PermissionError("ZMQ control endpoint disabled; configure a control token")
         token = request.get("auth_token")
         if not isinstance(token, str) or not hmac.compare_digest(token, self._control_token):
             raise PermissionError("ZMQ control endpoint requires a valid auth token")
@@ -211,8 +242,7 @@ class PolicyServer:
                 # Reserved protobuf first-byte check (Z-3)
                 if len(message) > 0 and message[0] == FORMAT_PROTOBUF_BYTE:
                     raise NotImplementedError(
-                        "Protobuf wire format (0x01) is reserved for v2. "
-                        "Use msgpack (the default)."
+                        "Protobuf wire format (0x01) is reserved for v2. Use msgpack (the default)."
                     )
 
                 request = msgpack.unpackb(message, raw=False)
@@ -239,9 +269,7 @@ class PolicyServer:
             except Exception as e:
                 logger.error("ZMQ server error: %s", e)
                 try:
-                    self.socket.send(
-                        msgpack.packb({"error": str(e)}, use_bin_type=True)
-                    )
+                    self.socket.send(msgpack.packb({"error": str(e)}, use_bin_type=True))
                 except Exception:
                     pass
 

--- a/src/tether/runtime/transports/zmq/security.py
+++ b/src/tether/runtime/transports/zmq/security.py
@@ -1,10 +1,14 @@
 """Shared ZMQ transport security helpers."""
+
 from __future__ import annotations
 
 import ipaddress
+import logging
 from pathlib import Path
 
 import zmq.auth
+
+logger = logging.getLogger(__name__)
 
 
 def load_curve_key(value: str | bytes | Path, *, secret: bool) -> bytes:
@@ -50,8 +54,6 @@ def validate_zmq_bind_security(
         return
     if curve_enabled and control_auth_enabled:
         return
-    if allow_insecure:
-        return
 
     missing: list[str] = []
     if not curve_enabled:
@@ -59,6 +61,14 @@ def validate_zmq_bind_security(
     if not control_auth_enabled:
         missing.append("a ZMQ control token")
     missing_text = " and ".join(missing)
+    if allow_insecure:
+        logger.warning(
+            "Allowing insecure ZMQ bind on host %r via explicit override; "
+            "missing %s. Use only on an isolated lab network.",
+            host,
+            missing_text,
+        )
+        return
     raise ValueError(
         f"Refusing insecure ZMQ bind on host {host!r}: configure {missing_text}, "
         "bind to 127.0.0.1, or pass --zmq-insecure-ok for an isolated lab network."

--- a/tests/test_zmq_client.py
+++ b/tests/test_zmq_client.py
@@ -3,6 +3,7 @@
 Client + server in same process via fixture. Validates predict_action
 round-trip, profile data, schema version, persistent socket reuse.
 """
+
 from __future__ import annotations
 
 import threading
@@ -126,10 +127,10 @@ def test_profile_overhead_minimal(server_port):
 # ── ping / reset ─────────────────────────────────────────────────────
 
 
-def test_ping(server_port):
+def test_ping_is_disabled_without_control_token(server_port):
     with ZmqRuntimeClient(f"tcp://127.0.0.1:{server_port}") as client:
         result = client.ping()
-        assert result["status"] == "ok"
+        assert result == {"error": "ZMQ control endpoint disabled; configure a control token"}
 
 
 def test_ping_sends_auth_token(auth_server_port):

--- a/tests/test_zmq_factory.py
+++ b/tests/test_zmq_factory.py
@@ -3,6 +3,7 @@
 Validates that create_zmq_server wires a mock runtime into a PolicyServer
 with predict_action, reset, and get_status endpoints.
 """
+
 from __future__ import annotations
 
 import threading
@@ -10,6 +11,7 @@ import time
 
 import msgpack
 import numpy as np
+import pytest
 import zmq
 
 from tether.runtime.transports.zmq.factory import create_zmq_server
@@ -52,10 +54,13 @@ def test_predict_action_returns_action_data():
     port = server.bound_port
     sock = _client(port)
 
-    result = _send_recv(sock, {
-        "endpoint": "predict_action",
-        "data": {"obs": "test"},
-    })
+    result = _send_recv(
+        sock,
+        {
+            "endpoint": "predict_action",
+            "data": {"obs": "test"},
+        },
+    )
 
     assert "action_data" in result
     assert "infer_time_ms" in result
@@ -63,6 +68,7 @@ def test_predict_action_returns_action_data():
 
     # Deserialize and verify shape
     import io
+
     actions = np.load(io.BytesIO(result["action_data"]))
     assert actions.shape == (1, 50, 7)
 
@@ -104,6 +110,18 @@ def test_get_status_returns_stats():
 
     server.close()
     thread.join(timeout=2)
+
+
+def test_factory_default_is_loopback():
+    server, thread = _start_server()
+    assert server.bound_address.startswith("tcp://127.0.0.1:")
+    server.close()
+    thread.join(timeout=2)
+
+
+def test_factory_rejects_public_bind_without_complete_security():
+    with pytest.raises(ValueError, match="Refusing insecure ZMQ bind"):
+        create_zmq_server(_MockRuntime(), host="0.0.0.0", port=0)
 
 
 # ── CLI flag ─────────────────────────────────────────────────────────

--- a/tests/test_zmq_policy_server.py
+++ b/tests/test_zmq_policy_server.py
@@ -3,12 +3,15 @@
 Uses real ZMQ sockets on localhost with kernel-assigned ports (port=0).
 Each test gets its own server + client pair; no shared state.
 """
+
 from __future__ import annotations
 
+import logging
 import threading
 import time
 
 import msgpack
+import pytest
 import zmq
 import zmq.auth
 
@@ -55,10 +58,10 @@ def _send_recv(sock: zmq.Socket, msg: dict) -> dict:
 
 
 def test_ping_returns_ok():
-    server, thread = _start_server()
+    server, thread = _start_server(control_token="secret")
     port = server.bound_port
     sock = _client_socket(port)
-    result = _send_recv(sock, {"endpoint": "ping"})
+    result = _send_recv(sock, {"endpoint": "ping", "auth_token": "secret"})
     assert result["status"] == "ok"
     assert "uptime_s" in result
     assert result["schema_version"] == SCHEMA_VERSION
@@ -70,13 +73,29 @@ def test_ping_returns_ok():
 
 
 def test_kill_shuts_down():
-    server, thread = _start_server()
+    server, thread = _start_server(control_token="secret")
     port = server.bound_port
     sock = _client_socket(port)
-    result = _send_recv(sock, {"endpoint": "kill"})
+    result = _send_recv(sock, {"endpoint": "kill", "auth_token": "secret"})
     assert result["status"] == "ok"
     thread.join(timeout=2)
     assert not server.running
+
+
+def test_control_endpoints_disabled_without_token():
+    server, thread = _start_server()
+    port = server.bound_port
+    sock = _client_socket(port)
+
+    result = _send_recv(sock, {"endpoint": "ping"})
+    assert result == {"error": "ZMQ control endpoint disabled; configure a control token"}
+
+    result = _send_recv(sock, {"endpoint": "kill"})
+    assert result == {"error": "ZMQ control endpoint disabled; configure a control token"}
+    assert server.running
+
+    server.close()
+    thread.join(timeout=2)
 
 
 def test_control_token_required_for_ping_and_kill():
@@ -101,6 +120,26 @@ def test_control_token_required_for_ping_and_kill():
     assert not server.running
 
 
+def test_control_endpoint_registration_cannot_disable_auth():
+    server, thread = _start_server(control_token="secret")
+    port = server.bound_port
+    sock = _client_socket(port)
+    server.register_endpoint(
+        "ping",
+        lambda: {"status": "overridden"},
+        requires_input=False,
+        requires_auth=False,
+    )
+
+    result = _send_recv(sock, {"endpoint": "ping"})
+    assert "auth token" in result["error"]
+
+    result = _send_recv(sock, {"endpoint": "ping", "auth_token": "secret"})
+    assert result == {"status": "overridden"}
+    server.close()
+    thread.join(timeout=2)
+
+
 def test_curve_client_can_connect_with_allowed_certificate(tmp_path):
     server_public, server_secret = zmq.auth.create_certificates(tmp_path, "server")
     client_cert_dir = tmp_path / "clients"
@@ -108,8 +147,10 @@ def test_curve_client_can_connect_with_allowed_certificate(tmp_path):
     _client_public, client_secret = zmq.auth.create_certificates(client_cert_dir, "robot")
 
     server, thread = _start_server(
+        host="0.0.0.0",
         curve_server_cert=server_secret,
         curve_client_cert_dir=client_cert_dir,
+        control_token="secret",
     )
     port = server.bound_port
     sock = _client_socket(
@@ -118,7 +159,7 @@ def test_curve_client_can_connect_with_allowed_certificate(tmp_path):
         curve_server_public_key=server_public,
     )
 
-    result = _send_recv(sock, {"endpoint": "ping"})
+    result = _send_recv(sock, {"endpoint": "ping", "auth_token": "secret"})
     assert result["status"] == "ok"
 
     server.close()
@@ -198,12 +239,12 @@ def test_protobuf_byte_returns_error():
 
 
 def test_request_counter_increments():
-    server, thread = _start_server()
+    server, thread = _start_server(control_token="secret")
     port = server.bound_port
     sock = _client_socket(port)
 
-    r1 = _send_recv(sock, {"endpoint": "ping"})
-    r2 = _send_recv(sock, {"endpoint": "ping"})
+    r1 = _send_recv(sock, {"endpoint": "ping", "auth_token": "secret"})
+    r2 = _send_recv(sock, {"endpoint": "ping", "auth_token": "secret"})
     assert r2["request_count"] == r1["request_count"] + 1
     server.close()
     thread.join(timeout=2)
@@ -217,5 +258,30 @@ def test_bound_port_returns_real_port():
     port = server.bound_port
     assert isinstance(port, int)
     assert port > 0
+    server.close()
+    thread.join(timeout=2)
+
+
+def test_default_bind_is_loopback():
+    server, thread = _start_server()
+    assert server.bound_address.startswith("tcp://127.0.0.1:")
+    server.close()
+    thread.join(timeout=2)
+
+
+def test_direct_public_bind_rejected_without_security():
+    with pytest.raises(ValueError, match="Refusing insecure ZMQ bind"):
+        PolicyServer(host="0.0.0.0", port=0)
+
+
+def test_direct_insecure_override_warns(caplog: pytest.LogCaptureFixture):
+    caplog.set_level(logging.WARNING)
+    server, thread = _start_server(
+        host="0.0.0.0",
+        allow_insecure=True,
+    )
+    assert server.bound_address.startswith("tcp://0.0.0.0:")
+    assert "Allowing insecure ZMQ bind" in caplog.text
+    assert "0.0.0.0" in caplog.text
     server.close()
     thread.join(timeout=2)

--- a/tests/test_zmq_security.py
+++ b/tests/test_zmq_security.py
@@ -1,5 +1,8 @@
 """Tests for ZMQ transport security helpers."""
+
 from __future__ import annotations
+
+import logging
 
 import pytest
 
@@ -46,13 +49,20 @@ def test_validate_zmq_bind_security_rejects_partial_security() -> None:
         )
 
 
-def test_validate_zmq_bind_security_allows_explicit_insecure_override() -> None:
+def test_validate_zmq_bind_security_allows_explicit_insecure_override(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
     validate_zmq_bind_security(
         host="0.0.0.0",
         curve_enabled=False,
         control_auth_enabled=False,
         allow_insecure=True,
     )
+    assert "Allowing insecure ZMQ bind" in caplog.text
+    assert "0.0.0.0" in caplog.text
+    assert "CURVE certificates" in caplog.text
+    assert "control token" in caplog.text
 
 
 def test_load_curve_key_rejects_invalid_raw_key_length() -> None:


### PR DESCRIPTION
## Summary
- default direct SDK/factory binds to loopback and validate non-loopback security before allocating ZMQ resources
- require a configured constant-time control token for ping/kill; leave prediction/custom endpoint policy unchanged
- support an explicit warned lab-only insecure override and pass the existing CLI flag into the low-level constructor
- update focused socket tests and transport docs

## Validation
- four focused ZMQ suites: 46 passed
- Ruff check + format check: passed
- diff check: passed
- independent review verified rejection occurs before `zmq.Context` allocation

Fixes #278.