### PR TITLE
fix(snapflow): train for the requested step count

### DIFF
--- a/src/tether/finetune/backends/snapflow_backend.py
+++ b/src/tether/finetune/backends/snapflow_backend.py
@@ -67,6 +67,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+from collections.abc import Iterator
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Callable
@@ -87,6 +88,53 @@ DEFAULT_CONSISTENCY_ALPHA: float = 1.0
 # Save a student checkpoint every N steps (same convention as
 # lerobot-train). Override via cfg.extra_lerobot_args["checkpoint_every"].
 DEFAULT_CHECKPOINT_EVERY: int = 1_000
+
+
+class EmptyTrainingEpochError(RuntimeError):
+    """Raised when a finite training loader yields no batches in an epoch."""
+
+    def __init__(self, *, completed_steps: int, requested_steps: int) -> None:
+        self.completed_steps = completed_steps
+        self.requested_steps = requested_steps
+        super().__init__(
+            "SnapFlow dataloader yielded no batches before training completed "
+            f"({completed_steps}/{requested_steps} steps). Check that the dataset "
+            "contains at least batch_size samples, or disable drop_last."
+        )
+
+
+def _iter_training_batches(
+    loader: Any,
+    num_steps: int,
+) -> Iterator[tuple[int, Any]]:
+    """Yield global ``(step, batch)`` pairs across finite loader epochs.
+
+    A fresh iteration starts whenever the finite loader is exhausted. This is
+    deliberately implemented without ``itertools.cycle``: cycle retains every
+    yielded batch, which can pin large CPU or accelerator tensors in memory.
+
+    Raises:
+        EmptyTrainingEpochError: if a fresh epoch yields no batches before the
+            requested number of steps has completed.
+    """
+    if num_steps <= 0:
+        raise ValueError(f"num_steps must be positive; got {num_steps}")
+
+    step = 0
+    while step < num_steps:
+        yielded_batch = False
+        for batch in loader:
+            yielded_batch = True
+            step += 1
+            yield step, batch
+            if step == num_steps:
+                return
+
+        if not yielded_batch:
+            raise EmptyTrainingEpochError(
+                completed_steps=step,
+                requested_steps=num_steps,
+            )
 
 
 class SnapFlowBackend:
@@ -289,7 +337,7 @@ class SnapFlowBackend:
             )
             heartbeat_t0 = _time.time()
             heartbeat_step0 = 0
-            for step, batch in enumerate(loader, start=1):
+            for step, batch in _iter_training_batches(loader, cfg.num_steps):
                 # Apply lerobot's preprocessor pipeline: rename_map (image keys),
                 # tokenizer (task -> language_tokens), device transfer, normalize.
                 # v0.5 state-out: preprocess twice — teacher sees state-in-lang,
@@ -387,18 +435,47 @@ class SnapFlowBackend:
                         "on_checkpoint", ctx, step=step, ckpt_path=last_ckpt,
                     )
 
-                if step >= cfg.num_steps:
-                    break
+        except EmptyTrainingEpochError as e:
+            logger.error("[snapflow] %s", e)
+            ctx.hooks.run(
+                "on_end",
+                ctx,
+                status="training_failed",
+                steps_completed=e.completed_steps,
+            )
+            return CheckpointResult(
+                final_checkpoint_path=Path(cfg.output),
+                training_steps_completed=e.completed_steps,
+                status="training_failed",
+                error=str(e),
+            )
         finally:
             log_handle.close()
 
-        # ---- 8. Ensure we have a final checkpoint -------------------------
-        if last_ckpt is None:
-            last_ckpt = _save_student_checkpoint(
-                student, checkpoint_root, step or 0,
+        # ---- 8. Require exact completion before success artifacts ----------
+        if step != cfg.num_steps:
+            error = (
+                "SnapFlow training ended before the requested step count "
+                f"({step}/{cfg.num_steps} steps); refusing to report success."
+            )
+            logger.error("[snapflow] %s", error)
+            ctx.hooks.run(
+                "on_end", ctx, status="training_failed", steps_completed=step,
+            )
+            return CheckpointResult(
+                final_checkpoint_path=Path(cfg.output),
+                training_steps_completed=step,
+                status="training_failed",
+                error=error,
             )
 
-        # ---- 9. Provenance stamp ------------------------------------------
+        # ---- 9. Ensure we have a final checkpoint -------------------------
+        if last_ckpt is None:
+            last_ckpt = _save_student_checkpoint(
+                student, checkpoint_root, step,
+            )
+
+        # ---- 10. Provenance stamp -----------------------------------------
         _write_provenance(
             last_ckpt,
             teacher_dir=loaded.checkpoint_dir,
@@ -407,7 +484,7 @@ class SnapFlowBackend:
             consistency_alpha=consistency_alpha,
         )
 
-        # ---- 10. Fire on_end + return -------------------------------------
+        # ---- 11. Fire on_end + return -------------------------------------
         ctx.hooks.run(
             "on_end", ctx, status="ok", steps_completed=step,
         )

--- a/tests/test_snapflow_backend.py
+++ b/tests/test_snapflow_backend.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -33,6 +34,7 @@ from tether.distill.teacher_loader import (
     load_teacher,
     resolve_policy_type,
 )
+from tether.distill.snapflow import SnapFlowLosses
 from tether.finetune.backends import TrainerContext
 from tether.finetune.backends.base import CheckpointResult
 from tether.finetune.backends.snapflow_backend import (
@@ -413,6 +415,103 @@ class TestWriteProvenance:
 
 
 class TestSnapFlowBackendFit:
+    @staticmethod
+    def _fit_with_loader(
+        tmp_path,
+        loader,
+        *,
+        num_steps: int,
+        checkpoint_every: int = 100,
+    ):
+        """Run the generic loop with lightweight CPU-only collaborators."""
+        teacher_dir = tmp_path / "teacher"
+        teacher_dir.mkdir()
+        (teacher_dir / "config.json").write_text(json.dumps({"type": "smolvla"}))
+
+        cfg = FinetuneConfig(
+            base="lerobot/smolvla_base",
+            dataset="lerobot/libero",
+            output=tmp_path,
+            num_steps=num_steps,
+            phase="distill",
+            teacher_export=str(teacher_dir),
+            precision="fp32",
+            extra_lerobot_args={"checkpoint_every": checkpoint_every},
+        )
+        log_path = tmp_path / "training_log.jsonl"
+        log_path.touch()
+        events = []
+        hooks = HookRegistry()
+        for name in ("on_step", "on_checkpoint", "on_end"):
+            hooks.register(
+                name,
+                lambda _ctx, _name=name, **payload: events.append(
+                    (_name, payload)
+                ),
+            )
+        ctx = TrainerContext(config=cfg, hooks=hooks, training_log_path=log_path)
+
+        teacher = torch.nn.Linear(1, 1)
+        teacher.config = SimpleNamespace(max_action_dim=None, chunk_size=None)
+        student = torch.nn.Linear(1, 1)
+        student.config = SimpleNamespace(max_action_dim=None, chunk_size=None)
+        teacher_loaded = LoadedTeacher(
+            policy=teacher,
+            config={"type": "smolvla"},
+            policy_type="smolvla",
+            checkpoint_dir=teacher_dir,
+        )
+        student_loaded = LoadedTeacher(
+            policy=student,
+            config={"type": "smolvla"},
+            policy_type="smolvla",
+            checkpoint_dir=teacher_dir,
+        )
+
+        def fake_save(_student, root, step):
+            path = root / f"{step:08d}" / "pretrained_model"
+            path.mkdir(parents=True)
+            return path
+
+        loss = torch.tensor(1.0, requires_grad=True)
+        snapshot = SnapFlowLosses(
+            flow_matching=0.5,
+            consistency=0.5,
+            total=1.0,
+        )
+        with patch(
+            "tether.distill.teacher_loader.load_teacher",
+            side_effect=[teacher_loaded, student_loaded],
+        ), patch(
+            "tether.finetune.backends.snapflow_backend._build_velocity_adapters",
+            return_value=(lambda *a, **kw: None, lambda *a, **kw: None),
+        ), patch(
+            "tether.finetune.backends.snapflow_backend._build_dataloader",
+            return_value=loader,
+        ), patch(
+            "tether.finetune.backends.snapflow_backend._build_preprocessor",
+            return_value=lambda batch: batch,
+        ), patch(
+            "tether.finetune.backends.snapflow_backend._prepare_batch",
+            return_value=(
+                torch.zeros(1, 1, 1),
+                torch.zeros(1, 1, 1),
+                torch.zeros(1),
+                {},
+            ),
+        ), patch(
+            "tether.distill.snapflow.snapflow_loss_step",
+            return_value=(loss, snapshot),
+        ), patch(
+            "tether.finetune.backends.snapflow_backend._save_student_checkpoint",
+            side_effect=fake_save,
+        ) as save_checkpoint, patch(
+            "tether.finetune.backends.snapflow_backend._write_provenance",
+        ) as write_provenance:
+            result = SnapFlowBackend().fit(ctx)
+
+        return result, events, save_checkpoint, write_provenance, log_path
+
     def test_missing_teacher_export_returns_training_failed(self, tmp_path):
         cfg = FinetuneConfig(
             base="lerobot/pi0", dataset="lerobot/libero",
@@ -469,6 +568,83 @@ class TestSnapFlowBackendFit:
             result = SnapFlowBackend().fit(ctx)
         assert result.status == "training_failed"
         assert "dataloader" in result.error.lower()
+
+    def test_short_loader_completes_requested_steps(self, tmp_path):
+        result, events, save_checkpoint, write_provenance, log_path = (
+            self._fit_with_loader(
+                tmp_path,
+                ["A", "B"],
+                num_steps=5,
+                checkpoint_every=2,
+            )
+        )
+
+        assert result.status == "ok"
+        assert result.training_steps_completed == 5
+        assert [
+            payload["step"] for name, payload in events if name == "on_step"
+        ] == [1, 2, 3, 4, 5]
+        assert [
+            json.loads(line)["step"]
+            for line in log_path.read_text().splitlines()
+        ] == [1, 2, 3, 4, 5]
+        assert [call.args[2] for call in save_checkpoint.call_args_list] == [
+            2,
+            4,
+            5,
+        ]
+        assert [
+            payload["step"]
+            for name, payload in events
+            if name == "on_checkpoint"
+        ] == [2, 4, 5]
+        write_provenance.assert_called_once()
+        assert events[-1] == (
+            "on_end",
+            {"status": "ok", "steps_completed": 5},
+        )
+
+    def test_empty_loader_fails_without_success_artifacts(self, tmp_path):
+        result, events, save_checkpoint, write_provenance, _ = (
+            self._fit_with_loader(tmp_path, [], num_steps=5)
+        )
+
+        assert result.status == "training_failed"
+        assert result.training_steps_completed == 0
+        assert "yielded no batches" in result.error
+        assert "drop_last" in result.error
+        save_checkpoint.assert_not_called()
+        write_provenance.assert_not_called()
+        assert events[-1] == (
+            "on_end",
+            {"status": "training_failed", "steps_completed": 0},
+        )
+
+    def test_one_step_saves_final_checkpoint_once(self, tmp_path):
+        result, _events, save_checkpoint, write_provenance, _ = (
+            self._fit_with_loader(tmp_path, ["A"], num_steps=1)
+        )
+
+        assert result.status == "ok"
+        assert result.training_steps_completed == 1
+        save_checkpoint.assert_called_once()
+        assert save_checkpoint.call_args.args[2] == 1
+        write_provenance.assert_called_once()
+
+    def test_non_reiterable_short_loader_cannot_report_success(self, tmp_path):
+        result, events, save_checkpoint, write_provenance, _ = (
+            self._fit_with_loader(tmp_path, iter(["A", "B"]), num_steps=5)
+        )
+
+        assert result.status == "training_failed"
+        assert result.training_steps_completed == 2
+        assert "2/5 steps" in result.error
+        save_checkpoint.assert_not_called()
+        write_provenance.assert_not_called()
+        assert events[-1] == (
+            "on_end",
+            {"status": "training_failed", "steps_completed": 2},
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_snapflow_training_iterator.py
+++ b/tests/test_snapflow_training_iterator.py
@@ -1,0 +1,39 @@
+"""CPU- and LeRobot-independent tests for SnapFlow batch iteration."""
+
+from __future__ import annotations
+
+import pytest
+
+from tether.finetune.backends.snapflow_backend import (
+    EmptyTrainingEpochError,
+    _iter_training_batches,
+)
+
+
+class TestTrainingBatchIterator:
+    def test_reiterates_loader_to_exact_step_count(self):
+        batches = list(_iter_training_batches(["A", "B"], num_steps=5))
+        assert batches == [
+            (1, "A"),
+            (2, "B"),
+            (3, "A"),
+            (4, "B"),
+            (5, "A"),
+        ]
+
+    def test_empty_loader_fails_instead_of_spinning(self):
+        with pytest.raises(EmptyTrainingEpochError) as exc_info:
+            list(_iter_training_batches([], num_steps=5))
+
+        assert exc_info.value.completed_steps == 0
+        assert exc_info.value.requested_steps == 5
+        assert "batch_size" in str(exc_info.value)
+        assert "drop_last" in str(exc_info.value)
+
+    def test_loader_exception_propagates(self):
+        class BrokenLoader:
+            def __iter__(self):
+                raise RuntimeError("dataset read failed")
+
+        with pytest.raises(RuntimeError, match="dataset read failed"):
+            list(_iter_training_batches(BrokenLoader(), num_steps=2))


### PR DESCRIPTION
## Summary
- re-iterate finite dataloaders epoch-by-epoch until exactly `num_steps` without caching yielded batches
- fail closed on an empty epoch and emit no success checkpoint/provenance
- keep global logging, checkpoint, and hook steps monotonic across epochs
- enforce that success is impossible unless completed steps equal requested steps

## Validation
- new pure iterator + backend regressions: 9 passed
- mypy, scoped Ruff, and diff checks: passed
- independent review: approved
- full local SnapFlow file retains four documented pre-existing LeRobot lazy-module failures outside this diff (33 other tests pass)

Fixes #284.