### PR TITLE
fix(a2c2): keep default latency gating active

### DIFF
--- a/docs/a2c2.md
+++ b/docs/a2c2.md
@@ -1,6 +1,6 @@
 # A2C2 correction head
 
-`tether serve --a2c2-checkpoint <path>` plugs an A2C2 residual MLP onto the action chunk after the policy returns it. Auto-skips when latency is low or success is high — zero overhead when correction isn't needed.
+`tether serve --a2c2-checkpoint <path>` plugs an A2C2 residual MLP onto the action chunk after the policy returns it. By default it auto-skips at low latency and applies after cold start when latency remains high.
 
 Paper: [arxiv 2509.23224](https://arxiv.org/abs/2509.23224). Local notes: `reflex_context/02_research/papers/2509.23224-a2c2.md`.
 
@@ -30,15 +30,19 @@ The correction is bounded by the head's training distribution; it doesn't replac
 
 ## Auto-skip semantics
 
-The hook tracks two rolling windows from real /act traffic:
+The hook tracks two rolling windows from real `/act` traffic:
 
 | Tracker | Window | Default threshold | Action when threshold hit |
 |---|---|---|---|
 | `latency_p95_ms` | last 100 acts | < 40 ms | Skip — correction not needed at low latency |
-| `success_rate` | last 50 acts | > 90% | Skip — correction not needed when policy is doing fine |
+| HTTP request-success rate | last 50 acts | `1.01` sentinel (disabled) | No default skip; values from 0.0 (inclusive) to 1.0 (exclusive) opt into the advanced request-health gate |
 | `cold_start` | first 5 acts | — | Skip — insufficient signal to decide |
 
-Apply only when **both** conditions favor it: high latency AND low success. This matches the paper's guidance that A2C2 has positive marginal value only at high-latency low-success regimes; at the low end it's pure overhead.
+The default steady-state decision is latency-only: apply at or above the latency threshold. Tether currently observes whether `/act` returned an error, not whether the robot completed its task. It therefore does not treat healthy HTTP traffic as task success or suppress correction because requests returned successfully.
+
+For backward compatibility, operators may explicitly set `--a2c2-success-threshold` to a value from `0.0` (inclusive) to `1.0` (exclusive). That enables a request-health skip when the fraction of error-free `/act` responses exceeds the threshold. Values of `1.0` or greater disable this gate because request success cannot exceed 100%. Startup logs warn that this advanced signal is HTTP health, not robot task success. Keep the default `1.01` until a real task-outcome provider is wired.
+
+BID and A2C2 are mutually exclusive in Phase 1. If both are configured on a BID-capable decomposed server, BID takes precedence and the A2C2 hook is fully disabled before inference.
 
 ## /act response telemetry
 
@@ -54,7 +58,7 @@ When the hook is loaded, every `/act` response gains three fields:
 }
 ```
 
-`a2c2_reason` is a bounded enum: `applied | cold_start | low_latency | high_success`. `a2c2_correction_magnitude` is the L2 norm of the residual across the chunk (0 when skipped). Use these for observability dashboards + replay analysis.
+`a2c2_reason` is a bounded enum: `applied | cold_start | low_latency | high_success`. The compatibility label `high_success` means the optional HTTP request-health gate fired; it does not report robot task success. `a2c2_correction_magnitude` is the L2 norm of the residual across the chunk (0 when skipped). Use these for observability dashboards + replay analysis.
 
 When the hook is **not** loaded (no `--a2c2-checkpoint`), the `a2c2_*` fields are absent — back-compat for existing clients.
 
@@ -108,15 +112,15 @@ NumPy-only forward pass on the hot path. No torch import in serve runtime; CPU f
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `applied` counter is always 0 | Latency p95 stays under 40ms (good!) OR success rate stays high (also good) | Nothing to fix; A2C2 is correctly recognizing it isn't needed. |
-| `applied` counter dominates | Latency is consistently high + success low | Either real distribution shift (A2C2 is earning its keep), or the thresholds are too aggressive. Tune via `A2C2HookConfig` (CLI flag for thresholds is Phase 1.5). |
+| `applied` counter is always 0 | Latency p95 stays under 40ms, the hook is still in cold start, or an explicit request-health gate is suppressing it | Check `a2c2_reason`; keep the default request-health threshold at 1.01 unless the compatibility gate is intentional. |
+| `applied` counter dominates | Latency is consistently high | A2C2 is active as designed. Tune `--a2c2-latency-threshold-ms` if the deployment threshold differs. |
 | Correction magnitude > 1.0 sustained | A2C2 head was trained on a very different distribution | Retrain on traces from THIS deployment via `scripts/train_a2c2_customer.py`. The head learns customer-specific corrections. |
 | Bad checkpoint path → server crashes | Misconfigured `--a2c2-checkpoint` | Server handles this gracefully — logs an ERROR and continues with `a2c2_hook=None`. /act returns successful responses without `a2c2_*` fields. |
 
 ## What's not in Phase 1
 
 - **Observation encoding via VLM-prefix output.** Today the hook receives a zero-vector observation (or whatever the integration site supplies). Phase 1.5 wires the VLM prefix output through to give the head real per-image context — paper assumption.
-- **CLI flags for thresholds.** `--a2c2-latency-threshold-ms`, `--a2c2-success-threshold` are Phase 1.5. Today configure via `A2C2HookConfig` constructor.
+- **Robot task-outcome gating.** The current optional request-health gate observes `/act` errors only. A future task-outcome API can introduce real episode success without fabricating it from HTTP responses.
 - **Customer-data fine-tuning.** `scripts/train_a2c2_customer.py` warm-starts from the LeRobot checkpoint on customer traces — Phase 1.5 once we have a customer with enough recorded traces.
 - **Real-Jetson latency validation.** Today's CPU bound is 5ms; Orin Nano integration test (`scripts/test_a2c2_on_jetson.py`) runs once we have hardware.
 - **LIBERO regression on Modal.** Day 5 of the plan; runs once a customer-trained checkpoint exists.

--- a/docs/architecture_wedges.md
+++ b/docs/architecture_wedges.md
@@ -640,5 +640,5 @@ Use `mode: "reject"` only if your task cannot tolerate ANY constraint violation 
 - [Batching & throughput tuning](batching.md)
 - [CUDA Graphs & performance](cuda_graphs.md)
 - [Safety & ActionGuard](../scripts/emit_embodiment_presets.py) — code for guard initialization
-- [A2C2 Correction](self_distilling_serve.md) — post-hoc action correction based on task success rate
+- [A2C2 Correction](a2c2.md) — post-hoc action correction gated by deployment latency
 - [Policy Versioning](policy_versioning.md) — A/B testing and policy slots

--- a/scripts/modal_libero_via_reflex_serve.py
+++ b/scripts/modal_libero_via_reflex_serve.py
@@ -180,7 +180,7 @@ def libero_via_serve(
     task_indices: list[int] | None = None,
     a2c2_checkpoint: str = "",
     a2c2_latency_threshold_ms: float = 40.0,
-    a2c2_success_threshold: float = 0.90,
+    a2c2_success_threshold: float = 1.01,
     inject_latency_ms: float = 0.0,
     bid_n_candidates: int = 0,
     bid_coherence_window: int = 5,
@@ -515,7 +515,7 @@ def main(
     suite: str = "libero_10",
     a2c2_checkpoint: str = "",
     a2c2_latency_threshold_ms: float = 40.0,
-    a2c2_success_threshold: float = 0.90,
+    a2c2_success_threshold: float = 1.01,
     inject_latency_ms: float = 0.0,
     bid_n_candidates: int = 0,
     bid_coherence_window: int = 5,
@@ -529,7 +529,7 @@ def main(
     --tasks "0,1,2"      3 tasks
     --tasks "all"        full suite
     --a2c2-checkpoint /gate_out/.../a2c2_head.npz  enable A2C2
-    --a2c2-success-threshold 1.01  disable success-based skip (for measurement)
+    --a2c2-success-threshold 0.90  enable advanced HTTP request-health skip
     --a2c2-latency-threshold-ms 0  disable latency-based skip (force-apply)
     --inject-latency-ms 100  synthetic latency for A2C2 measurement (ADR 2026-04-24)
     --bid-n-candidates 8  enable BID chunk selection (mutex with a2c2_checkpoint in Phase 1)

--- a/src/tether/cli.py
+++ b/src/tether/cli.py
@@ -2479,9 +2479,9 @@ def serve(
         "--a2c2-checkpoint",
         help="Path to a trained A2C2 correction-head checkpoint (.npz). When "
              "set, the server applies per-step A2C2 corrections on the action "
-             "chunk after the policy returns it. Auto-skipped at low latency "
-             "(p95 < 40ms) or high success rate (>90%) — no overhead when not "
-             "needed. Per a2c2-correction execution plan B.5. Train with "
+             "chunk after the policy returns it. By default it auto-skips only "
+             "at low latency (p95 < 40ms); no robot task-success signal is "
+             "inferred from HTTP responses. Train with "
              "scripts/train_a2c2_lerobot.py (Modal A100; user-authorized).",
     ),
     a2c2_latency_threshold_ms: float = typer.Option(
@@ -2493,13 +2493,13 @@ def serve(
              "measurement under --inject-latency-ms).",
     ),
     a2c2_success_threshold: float = typer.Option(
-        0.90,
+        1.01,
         "--a2c2-success-threshold",
-        help="A2C2 hook auto-skips when /act success rate > this (0..1). "
-             "NOTE: 'success' here is /act error-rate (server crash) NOT "
-             "task-success — without task feedback wired in, leave at 0.90 "
-             "for default behavior or set to 1.01 to disable success-skip "
-             "for measurement runs.",
+        help="Advanced request-health gate: auto-skip when the fraction of "
+             "error-free /act responses exceeds this threshold. Default 1.01 "
+             "disables the gate, leaving latency-only behavior. Values from "
+             "0 (inclusive) to 1 (exclusive) enable it; 1.0 and above disable "
+             "it. This is HTTP request health, not robot task success.",
     ),
     bid_n_candidates: int = typer.Option(
         0,

--- a/src/tether/runtime/a2c2_hook.py
+++ b/src/tether/runtime/a2c2_hook.py
@@ -2,15 +2,17 @@
 
 Wraps the inference-time A2C2Head (kernels/a2c2_correction.py) with:
 - Latency tracker — rolling-window p95 of recent /act latencies
-- Success-rate tracker — rolling-window fraction of "good" recent acts
-- Auto-skip logic — apply correction only when latency p95 >= threshold
-  AND success rate <= threshold (correction has positive marginal value)
+- Request-health tracker — rolling-window fraction of /act responses without errors
+- Auto-skip logic — apply correction when latency p95 >= threshold by default;
+  an advanced compatibility gate can also skip on healthy HTTP traffic
 - Prometheus metrics — `tether_a2c2_applied_total` + `tether_a2c2_skipped_total`
 
 Per a2c2-correction execution plan B.5 Day 3:
-- Auto-disable: if `latency_p95 < 40 ms` OR `success_rate > 90%`, skip
-  the A2C2 forward pass — A2C2 only adds value at high-latency low-success
-  regimes; otherwise it's pure overhead.
+- Auto-disable by default when `latency_p95 < 40 ms`. The runtime has no robot
+  task-outcome signal, so ordinary successful HTTP responses must not suppress
+  correction at high latency.
+- Operators may explicitly set `success_threshold < 1.0` to restore the
+  legacy request-health skip. This measures /act errors, not task success.
 - Per-act logging via structured fields (a2c2_applied, latency_p95_ms,
   correction_magnitude) — picked up by the existing JSONL recorder.
 
@@ -35,14 +37,15 @@ logger = logging.getLogger(__name__)
 
 
 # Default thresholds per a2c2-correction execution plan B.5 acceptance
-# criteria. Customers tune these via tether.yaml or `--a2c2-*` CLI flags.
+# criteria. 1.01 disables the optional request-health skip, leaving latency as
+# the only steady-state gate until a real robot task-outcome provider exists.
 _DEFAULT_LATENCY_THRESHOLD_MS = 40.0
-_DEFAULT_SUCCESS_THRESHOLD = 0.90
+_DEFAULT_REQUEST_SUCCESS_THRESHOLD = 1.01
 
 # Rolling-window sizes — match webhooks + slo conventions (~10s of traffic
 # at 10 QPS). Longer = more stable thresholds but slower adaptation.
 _DEFAULT_LATENCY_WINDOW = 100
-_DEFAULT_SUCCESS_WINDOW = 50
+_DEFAULT_REQUEST_SUCCESS_WINDOW = 50
 
 # Cold-start: until we have N samples, skip A2C2 (insufficient signal to
 # decide whether it's needed). 5 is enough for a stable p95 in practice.
@@ -55,9 +58,9 @@ class A2C2HookConfig:
     create_app time; immutable thereafter."""
 
     latency_threshold_ms: float = _DEFAULT_LATENCY_THRESHOLD_MS
-    success_threshold: float = _DEFAULT_SUCCESS_THRESHOLD
+    success_threshold: float = _DEFAULT_REQUEST_SUCCESS_THRESHOLD
     latency_window: int = _DEFAULT_LATENCY_WINDOW
-    success_window: int = _DEFAULT_SUCCESS_WINDOW
+    success_window: int = _DEFAULT_REQUEST_SUCCESS_WINDOW
     min_samples_for_decision: int = _MIN_SAMPLES_FOR_DECISION
 
     def __post_init__(self) -> None:
@@ -66,13 +69,13 @@ class A2C2HookConfig:
                 f"latency_threshold_ms must be positive, got "
                 f"{self.latency_threshold_ms}"
             )
-        # Allow values > 1.0 as a documented "never skip due to success" sentinel
-        # (e.g., 1.01 disables success-based skip — useful for measurement runs
-        # where the success metric is /act error rate, not task success).
+        # Values >= 1.0 disable request-health skipping because a rate cannot
+        # exceed 1.0. The default 1.01 remains the explicit sentinel: this
+        # window measures /act errors, not robot task outcomes.
         # Hard cap at 2.0 to catch typos like 100 instead of 1.0.
         if not (0.0 <= self.success_threshold <= 2.0):
             raise ValueError(
-                f"success_threshold must be in [0, 2.0] (1.01+ disables skip), got "
+                f"success_threshold must be in [0, 2.0] (1.0+ disables skip), got "
                 f"{self.success_threshold}"
             )
         if self.latency_window < 1:
@@ -98,12 +101,12 @@ class A2C2Decision:
     apply: bool
     reason: str  # bounded enum: "applied" | "cold_start" | "low_latency" | "high_success"
     latency_p95_ms: float
-    success_rate: float
+    success_rate: float  # Compatibility field: HTTP request-success rate.
     samples: int
 
 
 class A2C2Hook:
-    """Stateful wrapper around A2C2Head with latency + success tracking.
+    """Stateful wrapper around A2C2Head with latency + request-health tracking.
 
     Thread-safe: trackers protected by a single lock; rare contention since
     the only writer is the /act handler (one event loop) and reads are
@@ -112,7 +115,7 @@ class A2C2Hook:
 
     __slots__ = (
         "_head", "_config",
-        "_latency_window", "_success_window", "_lock",
+        "_latency_window", "_request_success_window", "_lock",
         "_applied_total", "_skipped_total",
     )
 
@@ -126,7 +129,7 @@ class A2C2Hook:
         self._latency_window: collections.deque[float] = collections.deque(
             maxlen=self._config.latency_window
         )
-        self._success_window: collections.deque[bool] = collections.deque(
+        self._request_success_window: collections.deque[bool] = collections.deque(
             maxlen=self._config.success_window
         )
         self._lock = threading.Lock()
@@ -153,13 +156,16 @@ class A2C2Hook:
         return self._skipped_total
 
     def record_outcome(self, latency_ms: float, success: bool) -> None:
-        """Record one /act outcome. Called by the serve runtime after every
-        act completes. Updates both rolling windows."""
+        """Record one /act outcome for latency and HTTP request health.
+
+        ``success`` means the handler returned no error; it is not a robot
+        task-success observation. Called by the serve runtime after every act.
+        """
         if latency_ms <= 0 or latency_ms != latency_ms:  # rejects NaN + non-positive
             return
         with self._lock:
             self._latency_window.append(float(latency_ms))
-            self._success_window.append(bool(success))
+            self._request_success_window.append(bool(success))
 
     def latency_p95_ms(self) -> float:
         """Current p95 latency from the rolling window. Returns 0.0 when
@@ -170,38 +176,41 @@ class A2C2Hook:
             return 0.0
         return float(np.percentile(samples, 95))
 
-    def success_rate(self) -> float:
-        """Current success rate from the rolling window. Returns 1.0 when
-        no samples yet (we assume things are working until proven otherwise
-        — cold-start path is gated by min_samples in should_apply)."""
+    def request_success_rate(self) -> float:
+        """Return the fraction of /act responses that completed without errors."""
         with self._lock:
-            samples = list(self._success_window)
+            samples = list(self._request_success_window)
         if not samples:
             return 1.0
         return float(np.mean(samples))
 
+    def success_rate(self) -> float:
+        """Compatibility alias for :meth:`request_success_rate`."""
+        return self.request_success_rate()
+
     def sample_count(self) -> tuple[int, int]:
-        """Returns (n_latency, n_success). Used by cold-start gate."""
+        """Return ``(n_latency, n_request_health)`` for the cold-start gate."""
         with self._lock:
-            return len(self._latency_window), len(self._success_window)
+            return len(self._latency_window), len(self._request_success_window)
 
     def should_apply(self) -> A2C2Decision:
         """Decide whether to invoke the head this /act.
 
         Cold-start: skip until we have min_samples in BOTH windows.
-        Steady-state: apply when latency_p95 >= threshold AND
-        success_rate <= threshold (i.e., latency is high AND success is
-        not great — A2C2 has positive marginal value).
+        Steady-state defaults to latency-only: apply when latency p95 is at or
+        above the threshold. If an operator explicitly configures a request
+        success threshold below 1.0, healthy HTTP traffic may also skip
+        correction for backward compatibility.
         """
         n_lat, n_succ = self.sample_count()
         latency_p95 = self.latency_p95_ms()
-        success_rate = self.success_rate()
+        request_success_rate = self.request_success_rate()
         cfg = self._config
 
         if n_lat < cfg.min_samples_for_decision or n_succ < cfg.min_samples_for_decision:
             return A2C2Decision(
                 apply=False, reason="cold_start",
-                latency_p95_ms=latency_p95, success_rate=success_rate,
+                latency_p95_ms=latency_p95, success_rate=request_success_rate,
                 samples=min(n_lat, n_succ),
             )
 
@@ -209,21 +218,25 @@ class A2C2Hook:
         if latency_p95 < cfg.latency_threshold_ms:
             return A2C2Decision(
                 apply=False, reason="low_latency",
-                latency_p95_ms=latency_p95, success_rate=success_rate,
+                latency_p95_ms=latency_p95, success_rate=request_success_rate,
                 samples=min(n_lat, n_succ),
             )
 
-        # Skip when success is high (correction not needed)
-        if success_rate > cfg.success_threshold:
+        # Optional compatibility gate. This is HTTP request health, not robot
+        # task success; the default sentinel (1.01) makes this branch inert.
+        if (
+            cfg.success_threshold < 1.0
+            and request_success_rate > cfg.success_threshold
+        ):
             return A2C2Decision(
                 apply=False, reason="high_success",
-                latency_p95_ms=latency_p95, success_rate=success_rate,
+                latency_p95_ms=latency_p95, success_rate=request_success_rate,
                 samples=min(n_lat, n_succ),
             )
 
         return A2C2Decision(
             apply=True, reason="applied",
-            latency_p95_ms=latency_p95, success_rate=success_rate,
+            latency_p95_ms=latency_p95, success_rate=request_success_rate,
             samples=min(n_lat, n_succ),
         )
 

--- a/src/tether/runtime/decomposed_server.py
+++ b/src/tether/runtime/decomposed_server.py
@@ -112,8 +112,8 @@ class Pi05DecomposedServer:
         # BID (Bidirectional Decoding) chunk-selection config — alternative to
         # A2C2 head. Set via set_bid_config() from create_app at lifespan time.
         # None = no BID (default; single-sample inference path). Mutually
-        # exclusive with _a2c2_hook in Phase 1; create_app validates the
-        # mutex at startup.
+        # exclusive with _a2c2_hook in Phase 1; create_app and both setters
+        # enforce BID precedence.
         self._bid_config: Any = None
         # Per-server previous-chunk buffer for BID coherence scoring. Holds
         # the last emitted (post-denorm? no — pre-denorm) chunk so the next
@@ -647,7 +647,7 @@ class Pi05DecomposedServer:
             # head's residuals are in normalized units (~[-1,1]) while
             # denormalized actions have very different magnitudes (~[0.5m]).
             a2c2_decision_meta: dict[str, Any] | None = None
-            if self._a2c2_hook is not None:
+            if self._bid_config is None and self._a2c2_hook is not None:
                 a2c2_decision_meta = self._apply_a2c2_normalized(actions_padded)
 
             # 6. Postprocess -- denormalize THEN slice to action_dim.
@@ -712,6 +712,13 @@ class Pi05DecomposedServer:
 
         Returns nothing. Setting None disables internal a2c2 application.
         """
+        if hook is not None and self._bid_config is not None:
+            self._a2c2_hook = None
+            logger.warning(
+                "A2C2 hook ignored because BID is enabled; Phase 1 gives BID "
+                "precedence and does not compose the two correction paths."
+            )
+            return
         self._a2c2_hook = hook
         if hook is not None:
             logger.info(
@@ -737,9 +744,10 @@ class Pi05DecomposedServer:
             if self._a2c2_hook is not None:
                 logger.warning(
                     "BID config set while A2C2 hook is also bound — Phase 1 "
-                    "treats these as mutually exclusive; BID will run, A2C2 "
-                    "hook output will be ignored on this server."
+                    "treats these as mutually exclusive; BID wins and A2C2 "
+                    "is disabled on this server."
                 )
+                self._a2c2_hook = None
             logger.info(
                 "Pi05DecomposedServer BID enabled: n_candidates=%d, "
                 "coherence_window=%d, metric=%s",

--- a/src/tether/runtime/server.py
+++ b/src/tether/runtime/server.py
@@ -1769,7 +1769,9 @@ def create_app(
     max_similar_skips: int = 3,
     a2c2_checkpoint: str | None = None,  # path to .npz A2C2 head; None disables A2C2
     a2c2_latency_threshold_ms: float = 40.0,  # hook auto-skip when latency_p95 < this (ms)
-    a2c2_success_threshold: float = 0.90,  # hook auto-skip when /act success rate > this; set to 1.01 to disable
+    # Advanced request-health gate; 1.01 disables it so default gating is
+    # latency-only. Values < 1.0 measure /act errors, not robot task success.
+    a2c2_success_threshold: float = 1.01,
     # BID (Bidirectional Decoding) — alternative to A2C2 head per arxiv
     # 2408.17355 + 2026-04-29 a2c2-correction research-revisit Lens 4. When
     # bid_n_candidates > 0, server samples N chunks per /act + picks best
@@ -2413,7 +2415,7 @@ def create_app(
                 server.a2c2_internal = True  # type: ignore[attr-defined]
             logger.info(
                 "A2C2 hook loaded: checkpoint=%s, "
-                "latency_threshold_ms=%.1f, success_threshold=%.2f, "
+                "latency_threshold_ms=%.1f, request_success_threshold=%.2f, "
                 "applied=%s",
                 a2c2_checkpoint,
                 server.a2c2_hook.config.latency_threshold_ms,
@@ -2441,17 +2443,24 @@ def create_app(
             )
             if hasattr(server, "set_bid_config"):
                 server.set_bid_config(_bid_cfg)  # type: ignore[attr-defined]
+                if getattr(server, "a2c2_hook", None) is not None:
+                    # BID wins the Phase 1 mutex. Clear both the public hook
+                    # used by the /act handler and any server-internal binding
+                    # so correction cannot run after candidate selection.
+                    if hasattr(server, "set_a2c2_hook"):
+                        server.set_a2c2_hook(None)
+                    server.a2c2_hook = None  # type: ignore[attr-defined]
+                    server.a2c2_internal = False  # type: ignore[attr-defined]
+                    logger.warning(
+                        "Both --bid-num-candidates and --a2c2-checkpoint set; "
+                        "Phase 1 treats these as mutually exclusive. BID is "
+                        "enabled and A2C2 is disabled."
+                    )
                 logger.info(
                     "BID enabled on server: N=%d, window=%d, metric=%s",
                     _bid_cfg.n_candidates, _bid_cfg.coherence_window,
                     _bid_cfg.coherence_metric,
                 )
-                if a2c2_checkpoint:
-                    logger.warning(
-                        "Both --bid-num-candidates and --a2c2-checkpoint set; "
-                        "Phase 1 treats these as mutually exclusive. BID will "
-                        "run; A2C2 head output ignored."
-                    )
             else:
                 logger.warning(
                     "--bid-num-candidates=%d set but server type %s does not "
@@ -2464,6 +2473,21 @@ def create_app(
                 "Failed to configure BID (n=%d): %s — falling back to single-sample",
                 bid_n_candidates, exc,
             )
+
+    # Warn only when the request-health gate remains active. A successfully
+    # configured BID path clears A2C2 above, so the transient hook load should
+    # not produce a misleading gate-enabled warning.
+    if (
+        getattr(server, "a2c2_hook", None) is not None
+        and a2c2_success_threshold < 1.0
+    ):
+        logger.warning(
+            "A2C2 request-health gate enabled at %.2f: this signal only "
+            "records whether /act returned an error; it is not robot task "
+            "success. Healthy HTTP traffic can disable corrections. The "
+            "default 1.01 leaves gating latency-only.",
+            a2c2_success_threshold,
+        )
 
     # The cuda_graphs_enabled flag is consumed by Pi05DecomposedInference when
     # that backend is instantiated (scripts/modal_*_decomposed.py paths, and
@@ -3525,10 +3549,11 @@ def create_app(
 
             # A2C2 correction hook (Phase 1 a2c2-correction Day 3).
             # Applies a per-step residual correction to the action chunk
-            # when latency p95 ≥ threshold AND success rate ≤ threshold.
-            # Cold-start + no-hook → no-op. Per-act outcome recorded into
-            # the hook's rolling windows AFTER the apply call so the
-            # current request's signal joins the steady-state distribution.
+            # when latency p95 ≥ threshold. An explicitly configured legacy
+            # request-health gate may also skip on error-free HTTP traffic;
+            # it is disabled by default. Cold-start + no-hook → no-op.
+            # Per-act outcome is recorded AFTER the apply call so the current
+            # request's signal joins the steady-state distribution.
             _a2c2 = getattr(server, "a2c2_hook", None)
             _a2c2_internal = getattr(server, "a2c2_internal", False)
             if (
@@ -3753,17 +3778,20 @@ def create_app(
                 span.set_attribute("tether.injected_latency_ms", _inj)
                 await _asyncio.sleep(_inj / 1000.0)
 
-            # A2C2 outcome bookkeeping — feed the latency + success signal
-            # into the hook's rolling windows so subsequent should_apply()
-            # decisions reflect this request. Records regardless of whether
-            # we applied or skipped this time.
+            # A2C2 outcome bookkeeping — feed latency + HTTP request health
+            # into the rolling windows so subsequent should_apply() decisions
+            # reflect this request. This is not a robot task-success signal.
+            # Record regardless of whether correction applied this time.
             if _a2c2 is not None and isinstance(result, dict):
                 try:
                     _latency_ms = float(result.get("latency_ms", 0.0))
                     if _inj > 0:
                         _latency_ms += _inj  # client-perceived latency
-                    _success = "error" not in result
-                    _a2c2.record_outcome(latency_ms=_latency_ms, success=_success)
+                    _request_succeeded = "error" not in result
+                    _a2c2.record_outcome(
+                        latency_ms=_latency_ms,
+                        success=_request_succeeded,
+                    )
                 except Exception as exc:  # noqa: BLE001
                     logger.warning("a2c2_hook.record_outcome_failed: %s", exc)
 

--- a/tests/test_a2c2_runtime_hook.py
+++ b/tests/test_a2c2_runtime_hook.py
@@ -2,8 +2,8 @@
 
 Per a2c2-correction execution plan B.5 Day 3 acceptance criteria:
 - Auto-skip when latency_p95 < threshold (default 40ms)
-- Auto-skip when success_rate > threshold (default 90%)
-- Apply when both: high latency AND low success (correction has marginal value)
+- Apply at high latency by default, regardless of healthy HTTP responses
+- Optionally auto-skip on HTTP request health when explicitly configured
 - Cold-start: skip until min_samples in BOTH windows
 - Counters: applied/skipped totals correctly tracked
 - Per-action correction across the chunk (not just chunk[0])
@@ -58,9 +58,9 @@ def test_config_accepts_boundary_success_thresholds():
 
 
 def test_config_accepts_disable_skip_sentinel():
-    """Values in (1.0, 2.0] disable success-based skip — used in measurement
+    """Values in [1.0, 2.0] disable success-based skip — used in measurement
     runs where the success metric is /act error rate, not task success."""
-    h = A2C2HookConfig(success_threshold=1.01)
+    h = A2C2HookConfig()
     assert h.success_threshold == 1.01
     h2 = A2C2HookConfig(success_threshold=2.0)
     assert h2.success_threshold == 2.0
@@ -162,13 +162,34 @@ def test_should_apply_skips_when_latency_low():
     assert decision.reason == "low_latency"
 
 
-def test_should_apply_skips_when_success_high():
-    hook = _mk_hook(min_samples_for_decision=3)
+def test_explicit_request_health_gate_can_skip():
+    hook = _mk_hook(min_samples_for_decision=3, success_threshold=0.90)
     for _ in range(5):
         hook.record_outcome(latency_ms=100.0, success=True)  # high success
     decision = hook.should_apply()
     assert decision.apply is False
     assert decision.reason == "high_success"
+
+
+def test_default_high_latency_request_success_applies():
+    """Healthy HTTP responses do not suppress the latency-only default."""
+    hook = _mk_hook(min_samples_for_decision=5)
+    for _ in range(5):
+        hook.record_outcome(latency_ms=100.0, success=True)
+    decision = hook.should_apply()
+    assert decision.apply is True
+    assert decision.reason == "applied"
+    assert decision.success_rate == 1.0
+
+
+def test_threshold_one_disables_request_health_gate():
+    """A 100% threshold is inert under the strict greater-than contract."""
+    hook = _mk_hook(min_samples_for_decision=5, success_threshold=1.0)
+    for _ in range(5):
+        hook.record_outcome(latency_ms=100.0, success=True)
+    decision = hook.should_apply()
+    assert decision.apply is True
+    assert decision.reason == "applied"
 
 
 def test_should_apply_applies_when_high_latency_and_low_success():
@@ -196,8 +217,8 @@ def _bad_day_hook() -> A2C2Hook:
 
 
 def _good_day_hook() -> A2C2Hook:
-    """Hook seeded with samples that trigger should_apply()=False."""
-    hook = _mk_hook(min_samples_for_decision=3)
+    """Hook with the advanced request-health gate enabled and satisfied."""
+    hook = _mk_hook(min_samples_for_decision=3, success_threshold=0.90)
     for _ in range(5):
         hook.record_outcome(latency_ms=100.0, success=True)  # high success → skip
     return hook
@@ -287,6 +308,7 @@ def test_from_checkpoint_loads_head_and_wraps_with_default_config(tmp_path):
     hook = A2C2Hook.from_checkpoint(ckpt)
     assert hook.head.config == head.config
     assert hook.config.latency_threshold_ms == 40.0  # default
+    assert hook.config.success_threshold == 1.01  # request-health gate disabled
 
 
 def test_from_checkpoint_accepts_custom_config(tmp_path):

--- a/tests/test_a2c2_serve_integration.py
+++ b/tests/test_a2c2_serve_integration.py
@@ -9,8 +9,12 @@ from __future__ import annotations
 
 import base64
 import io
+import inspect
 import json
+import logging
 from pathlib import Path
+import sys
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -45,6 +49,23 @@ def _make_export_dir(tmp_path: Path) -> Path:
     return export_dir
 
 
+def _make_decomposed_export_dir(tmp_path: Path) -> Path:
+    export_dir = tmp_path / "decomposed_export"
+    export_dir.mkdir()
+    (export_dir / "tether_config.json").write_text(json.dumps({
+        "model_type": "pi05_decomposed_student",
+        "export_kind": "decomposed",
+        "chunk_size": 50,
+        "action_dim": 32,
+        "decomposed": {
+            "vlm_prefix_onnx": "vlm_prefix.onnx",
+            "expert_denoise_onnx": "expert_denoise.onnx",
+            "max_action_dim": 32,
+        },
+    }))
+    return export_dir
+
+
 def _tiny_jpeg_b64() -> str:
     try:
         from PIL import Image
@@ -56,14 +77,23 @@ def _tiny_jpeg_b64() -> str:
     return base64.b64encode(buf.getvalue()).decode("ascii")
 
 
-def _setup_app(tmp_path, monkeypatch, *, a2c2_ckpt: str | None = None):
+def _setup_app(
+    tmp_path,
+    monkeypatch,
+    *,
+    a2c2_ckpt: str | None = None,
+    **create_app_kwargs,
+):
     """Builds a FastAPI app via create_app with optional A2C2 checkpoint."""
     try:
         from fastapi.testclient import TestClient  # noqa: F401
     except ImportError:
         pytest.skip("fastapi/httpx not installed")
     import onnxruntime as ort
-    import transformers
+
+    transformers_stub = ModuleType("transformers")
+    transformers_stub.AutoTokenizer = MagicMock()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "transformers", transformers_stub)
 
     input_names = [
         "img_cam1", "img_cam2", "img_cam3",
@@ -79,7 +109,8 @@ def _setup_app(tmp_path, monkeypatch, *, a2c2_ckpt: str | None = None):
         "attention_mask": np.ones((1, 16), dtype=np.int64),
     }
     monkeypatch.setattr(
-        transformers.AutoTokenizer, "from_pretrained",
+        transformers_stub.AutoTokenizer,  # type: ignore[attr-defined]
+        "from_pretrained",
         lambda *a, **kw: tok_stub,
     )
 
@@ -89,6 +120,7 @@ def _setup_app(tmp_path, monkeypatch, *, a2c2_ckpt: str | None = None):
     return create_app(
         str(export_dir), device="cpu",
         a2c2_checkpoint=a2c2_ckpt,
+        **create_app_kwargs,
     )
 
 
@@ -122,6 +154,88 @@ def test_a2c2_hook_loaded_when_checkpoint_set(tmp_path, monkeypatch):
         hook = getattr(server, "a2c2_hook", None)
         assert hook is not None
         assert hook.head.config.action_dim == 32
+        assert hook.config.success_threshold == 1.01
+
+
+def test_create_app_and_cli_default_to_latency_only():
+    """Both public serve entry points disable the request-health gate."""
+    from typer.models import OptionInfo
+
+    from tether.cli import serve
+    from tether.runtime.server import create_app
+
+    create_default = inspect.signature(create_app).parameters[
+        "a2c2_success_threshold"
+    ].default
+    assert create_default == 1.01
+
+    cli_option = inspect.signature(serve).parameters[
+        "a2c2_success_threshold"
+    ].default
+    assert isinstance(cli_option, OptionInfo)
+    assert cli_option.default == 1.01
+    assert "request-health" in cli_option.help
+    assert "1 (exclusive)" in cli_option.help
+    assert "not robot task success" in cli_option.help
+
+
+def test_explicit_request_health_gate_logs_semantics_warning(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    """Compatibility thresholds warn that HTTP success is not task success."""
+    ckpt = _make_a2c2_checkpoint(tmp_path, action_dim=32)
+    with caplog.at_level(logging.WARNING):
+        _setup_app(
+            tmp_path,
+            monkeypatch,
+            a2c2_ckpt=ckpt,
+            a2c2_success_threshold=0.90,
+        )
+    assert "request-health gate enabled at 0.90" in caplog.text
+    assert "not robot task success" in caplog.text
+
+
+def test_threshold_one_disables_gate_without_enabled_warning(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    ckpt = _make_a2c2_checkpoint(tmp_path, action_dim=32)
+    with caplog.at_level(logging.WARNING):
+        app = _setup_app(
+            tmp_path,
+            monkeypatch,
+            a2c2_ckpt=ckpt,
+            a2c2_success_threshold=1.0,
+        )
+    assert app.state.tether_server.a2c2_hook.config.success_threshold == 1.0
+    assert "request-health gate enabled" not in caplog.text
+
+
+def test_bid_precedence_clears_public_and_internal_a2c2_hooks(
+    tmp_path,
+    caplog,
+):
+    """The real create_app combined path enables BID and fully disables A2C2."""
+    from tether.runtime.server import create_app
+
+    export_dir = _make_decomposed_export_dir(tmp_path)
+    ckpt = _make_a2c2_checkpoint(tmp_path, action_dim=32)
+    with caplog.at_level(logging.WARNING):
+        app = create_app(
+            str(export_dir),
+            device="cpu",
+            a2c2_checkpoint=ckpt,
+            bid_n_candidates=2,
+        )
+    server = app.state.tether_server
+    assert server._bid_config is not None
+    assert server._a2c2_hook is None
+    assert server.a2c2_hook is None
+    assert server.a2c2_internal is False
+    assert "BID is enabled and A2C2 is disabled" in caplog.text
 
 
 def test_a2c2_hook_load_failure_disables_gracefully(tmp_path, monkeypatch):
@@ -193,6 +307,37 @@ def test_a2c2_hook_records_outcomes_after_each_act(tmp_path, monkeypatch):
         n_lat, n_succ = hook.sample_count()
         assert n_lat == 3
         assert n_succ == 3
+
+
+def test_default_a2c2_applies_after_high_latency_cold_start(
+    tmp_path,
+    monkeypatch,
+):
+    """The sixth request applies after five healthy, high-latency samples."""
+    from fastapi.testclient import TestClient
+
+    ckpt = _make_a2c2_checkpoint(tmp_path, action_dim=32)
+    app = _setup_app(
+        tmp_path,
+        monkeypatch,
+        a2c2_ckpt=ckpt,
+        inject_latency_ms=50.0,
+    )
+    decisions = []
+    with TestClient(app) as client:
+        for _ in range(6):
+            resp = client.post("/act", json={
+                "image": _tiny_jpeg_b64(),
+                "instruction": "test",
+                "state": [0.0] * 6,
+            })
+            assert resp.status_code == 200
+            decisions.append(resp.json())
+
+    assert [d["a2c2_reason"] for d in decisions[:5]] == ["cold_start"] * 5
+    assert all(d["a2c2_applied"] is False for d in decisions[:5])
+    assert decisions[5]["a2c2_reason"] == "applied"
+    assert decisions[5]["a2c2_applied"] is True
 
 
 def test_metrics_endpoint_includes_a2c2_counters(tmp_path, monkeypatch):

--- a/tests/test_decomposed_server.py
+++ b/tests/test_decomposed_server.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from tether.correction.bid import BIDConfig
 from tether.runtime.decomposed_server import (
     DEFAULT_CAMERA_RESOLUTION,
     DEFAULT_LANG_SEQ_LEN,
@@ -197,6 +198,43 @@ def test_predict_from_base64_returns_actions_dict(tmp_path, monkeypatch):
     # Shape: (chunk_size, action_dim) = (50, 7)
     assert len(result["actions"]) == 50
     assert len(result["actions"][0]) == 7
+
+
+def test_bid_wins_over_a2c2_during_prediction(tmp_path, monkeypatch):
+    """BID selection must never be followed by A2C2 correction in Phase 1."""
+    server = _build_loaded_server(tmp_path, monkeypatch)
+
+    class _ExplodingA2C2Hook:
+        def __init__(self):
+            from types import SimpleNamespace
+
+            self.calls = 0
+            self.head = SimpleNamespace(
+                config=SimpleNamespace(action_dim=7, obs_dim=256),
+            )
+
+        def maybe_apply_to_chunk(self, *, actions):
+            self.calls += 1
+            raise AssertionError("A2C2 must not run when BID is enabled")
+
+    hook = _ExplodingA2C2Hook()
+    server.set_a2c2_hook(hook)
+    server.set_bid_config(BIDConfig(n_candidates=2))
+    assert server._a2c2_hook is None
+
+    # The mutex is order-independent: a later hook bind is ignored too.
+    server.set_a2c2_hook(hook)
+    assert server._a2c2_hook is None
+
+    result = server.predict_from_base64(
+        image_b64=_make_b64_image(),
+        instruction="pick up the cup",
+        state=[0.0] * 7,
+    )
+    assert "error" not in result
+    assert result["bid_n_candidates"] == 2
+    assert "a2c2_applied" not in result
+    assert hook.calls == 0
 
 
 def test_predict_from_base64_invalid_image_returns_error(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- make the default A2C2 threshold an explicit inert request-health sentinel so high-latency traffic can actually use A2C2
- preserve the optional HTTP request-health compatibility gate only for thresholds in `[0.0, 1.0)` and document its real semantics
- enforce the documented BID-wins mutex in configuration, inference, and the public `/act` path
- keep CLI and Modal defaults, warnings, docs, and runtime behavior consistent

## Validation
- 136 focused A2C2, BID, and decomposed-server tests passed
- exact threshold-boundary and both-configuration-order regressions passed
- Ruff, compile, and diff checks passed
- independent R2 review: approved with no blockers

Fixes #285.