### PR TITLE
fix(export): unify tether config schema and reader dispatch

### DIFF
--- a/src/tether/_onnx_backend.py
+++ b/src/tether/_onnx_backend.py
@@ -41,7 +41,6 @@ expected to mirror this scheme; Issue 6 will add explicit parity tests.
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -52,19 +51,9 @@ logger = logging.getLogger("tether.validate.onnx")
 
 
 def _detect_model_type(config: dict[str, Any], onnx_path: Path) -> str:
-    """Return the model type from config, falling back to filename heuristics."""
-    mt = config.get("model_type")
-    if mt:
-        return str(mt).lower()
-    name = onnx_path.name.lower()
-    for candidate in ("gr00t", "pi0", "smolvla"):
-        if candidate in name:
-            return candidate
-    parent = onnx_path.parent.name.lower()
-    for candidate in ("gr00t", "pi0", "smolvla"):
-        if candidate in parent:
-            return candidate
-    return "unknown"
+    """Return the required canonical model type without filename guessing."""
+    del onnx_path
+    return str(config["model_type"]).lower()
 
 
 def _read_opset(onnx_path: Path) -> int | None:
@@ -103,9 +92,7 @@ class ONNXBackend:
         self.model_type: str = model_type
 
         expert_meta = config.get("expert", {}) or {}
-        self.action_dim: int = int(
-            config.get("action_dim", expert_meta.get("action_dim", 0))
-        )
+        self.action_dim: int = int(config.get("action_dim", expert_meta.get("action_dim", 0)))
         self.chunk_size: int = int(config.get("action_chunk_size", 50))
         # Default step counts: 4 for gr00t (per gr00t_exporter), 10 elsewhere.
         default_steps = 4 if model_type == "gr00t" else 10
@@ -127,7 +114,7 @@ class ONNXBackend:
     def forward(
         self,
         image: np.ndarray,  # noqa: ARG002 - reserved for v2 full-stack path
-        prompt: str,        # noqa: ARG002 - reserved for v2 full-stack path
+        prompt: str,  # noqa: ARG002 - reserved for v2 full-stack path
         state: np.ndarray,  # noqa: ARG002 - reserved for v2 full-stack path
         initial_noise: np.ndarray,
     ) -> np.ndarray:
@@ -142,9 +129,7 @@ class ONNXBackend:
         backend; this is the seed bridge.
         """
         if not isinstance(initial_noise, np.ndarray):
-            raise TypeError(
-                f"initial_noise must be a numpy array; got {type(initial_noise)!r}"
-            )
+            raise TypeError(f"initial_noise must be a numpy array; got {type(initial_noise)!r}")
 
         # Normalize to float32 + add batch dim if missing.
         noise = initial_noise
@@ -183,13 +168,14 @@ class ONNXBackend:
         if feed_vlm_kv:
             # Read the actual dim from the ONNX input shape (expert.vlm_kv_dim),
             # NOT the VLM hidden_size — they differ (320 vs 960 for SmolVLA).
-            vlm_kv_shape = [
-                inp.shape for inp in self.session.get_inputs()
-                if inp.name == "vlm_kv"
-            ][0]
+            vlm_kv_shape = [inp.shape for inp in self.session.get_inputs() if inp.name == "vlm_kv"][
+                0
+            ]
             vlm_kv_dim = vlm_kv_shape[-1] if isinstance(vlm_kv_shape[-1], int) else 320
             vlm_kv = np.zeros((b, 1, vlm_kv_dim), dtype=np.float32)
-            logger.debug("Expert expects vlm_kv input (dim=%d); feeding zeros for validation", vlm_kv_dim)
+            logger.debug(
+                "Expert expects vlm_kv input (dim=%d); feeding zeros for validation", vlm_kv_dim
+            )
 
         dt = -1.0 / float(self.num_steps)
         for step in range(self.num_steps):
@@ -242,31 +228,28 @@ def load_onnx_backend(export_dir: Path, device: str = "cpu") -> ONNXBackend:
 
     config_path = export_dir / "tether_config.json"
     if not config_path.exists():
-        raise FileNotFoundError(
-            f"Missing tether_config.json in export dir: {export_dir}"
-        )
-    config: dict[str, Any] = json.loads(config_path.read_text())
+        raise FileNotFoundError(f"Missing tether_config.json in export dir: {export_dir}")
+    from tether.export_config import load_tether_config, require_supported_export_kind
 
-    # Resolve ONNX path: prefer config, fall back to canonical filename.
-    onnx_path: Path | None = None
-    files = config.get("files") or {}
-    if isinstance(files, dict):
-        candidate = files.get("expert_onnx")
-        if candidate:
-            cand = Path(candidate)
-            if not cand.is_absolute():
-                cand = export_dir / cand
-            if cand.exists():
-                onnx_path = cand
-    if onnx_path is None:
-        default = export_dir / "expert_stack.onnx"
-        if default.exists():
-            onnx_path = default
-    if onnx_path is None:
-        raise FileNotFoundError(
-            f"No ONNX graph found in {export_dir}: looked for "
-            f"`expert_stack.onnx` and config.files.expert_onnx",
-        )
+    config = load_tether_config(config_path)
+    require_supported_export_kind(
+        config,
+        {"monolithic_onnx", "decomposed_onnx"},
+        "ONNX round-trip reader",
+    )
+
+    onnx_artifacts = [
+        item
+        for item in config["artifacts"]
+        if item["role"] == "model" and str(item["path"]).endswith(".onnx")
+    ]
+    if not onnx_artifacts:
+        raise FileNotFoundError(f"No model-role ONNX artifact declared in {config_path}")
+    preferred = next(
+        (item for item in onnx_artifacts if Path(item["path"]).name == "expert_stack.onnx"),
+        onnx_artifacts[0],
+    )
+    onnx_path = export_dir / preferred["path"]
 
     if device.lower() != "cpu":
         logger.info(
@@ -279,13 +262,10 @@ def load_onnx_backend(export_dir: Path, device: str = "cpu") -> ONNXBackend:
         import onnxruntime as ort  # type: ignore[import-not-found]
     except ImportError as e:
         raise ImportError(
-            "onnxruntime is required for `tether validate`. "
-            "Install with: pip install onnxruntime"
+            "onnxruntime is required for `tether validate`. Install with: pip install onnxruntime"
         ) from e
 
-    session = ort.InferenceSession(
-        str(onnx_path), providers=["CPUExecutionProvider"]
-    )
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
     active_providers = session.get_providers()
     active = active_providers[0] if active_providers else "<none>"
     if active != "CPUExecutionProvider":  # pragma: no cover - defensive

--- a/src/tether/_onnx_backend.py
+++ b/src/tether/_onnx_backend.py
@@ -92,7 +92,9 @@ class ONNXBackend:
         self.model_type: str = model_type
 
         expert_meta = config.get("expert", {}) or {}
-        self.action_dim: int = int(config.get("action_dim", expert_meta.get("action_dim", 0)))
+        self.action_dim: int = int(
+            config.get("action_dim", expert_meta.get("action_dim", 0))
+        )
         self.chunk_size: int = int(config.get("action_chunk_size", 50))
         # Default step counts: 4 for gr00t (per gr00t_exporter), 10 elsewhere.
         default_steps = 4 if model_type == "gr00t" else 10
@@ -114,7 +116,7 @@ class ONNXBackend:
     def forward(
         self,
         image: np.ndarray,  # noqa: ARG002 - reserved for v2 full-stack path
-        prompt: str,  # noqa: ARG002 - reserved for v2 full-stack path
+        prompt: str,        # noqa: ARG002 - reserved for v2 full-stack path
         state: np.ndarray,  # noqa: ARG002 - reserved for v2 full-stack path
         initial_noise: np.ndarray,
     ) -> np.ndarray:
@@ -129,7 +131,9 @@ class ONNXBackend:
         backend; this is the seed bridge.
         """
         if not isinstance(initial_noise, np.ndarray):
-            raise TypeError(f"initial_noise must be a numpy array; got {type(initial_noise)!r}")
+            raise TypeError(
+                f"initial_noise must be a numpy array; got {type(initial_noise)!r}"
+            )
 
         # Normalize to float32 + add batch dim if missing.
         noise = initial_noise
@@ -168,14 +172,13 @@ class ONNXBackend:
         if feed_vlm_kv:
             # Read the actual dim from the ONNX input shape (expert.vlm_kv_dim),
             # NOT the VLM hidden_size — they differ (320 vs 960 for SmolVLA).
-            vlm_kv_shape = [inp.shape for inp in self.session.get_inputs() if inp.name == "vlm_kv"][
-                0
-            ]
+            vlm_kv_shape = [
+                inp.shape for inp in self.session.get_inputs()
+                if inp.name == "vlm_kv"
+            ][0]
             vlm_kv_dim = vlm_kv_shape[-1] if isinstance(vlm_kv_shape[-1], int) else 320
             vlm_kv = np.zeros((b, 1, vlm_kv_dim), dtype=np.float32)
-            logger.debug(
-                "Expert expects vlm_kv input (dim=%d); feeding zeros for validation", vlm_kv_dim
-            )
+            logger.debug("Expert expects vlm_kv input (dim=%d); feeding zeros for validation", vlm_kv_dim)
 
         dt = -1.0 / float(self.num_steps)
         for step in range(self.num_steps):
@@ -229,27 +232,28 @@ def load_onnx_backend(export_dir: Path, device: str = "cpu") -> ONNXBackend:
     config_path = export_dir / "tether_config.json"
     if not config_path.exists():
         raise FileNotFoundError(f"Missing tether_config.json in export dir: {export_dir}")
-    from tether.export_config import load_tether_config, require_supported_export_kind
+    from tether.export_config import (
+        UnsupportedExportPipelineError,
+        decomposed_layout,
+        load_tether_config,
+        require_supported_export_kind,
+        require_supported_pipeline,
+    )
 
     config = load_tether_config(config_path)
     require_supported_export_kind(
         config,
-        {"monolithic_onnx", "decomposed_onnx"},
+        {"decomposed_onnx"},
         "ONNX round-trip reader",
     )
+    require_supported_pipeline(config, set(), "ONNX round-trip reader")
+    layout = decomposed_layout(config)
+    if layout not in {"expert_stack", "smolvla_full_bundle"}:
+        raise UnsupportedExportPipelineError(
+            f"ONNX round-trip reader supports only the expert_stack family, got {layout!r}"
+        )
 
-    onnx_artifacts = [
-        item
-        for item in config["artifacts"]
-        if item["role"] == "model" and str(item["path"]).endswith(".onnx")
-    ]
-    if not onnx_artifacts:
-        raise FileNotFoundError(f"No model-role ONNX artifact declared in {config_path}")
-    preferred = next(
-        (item for item in onnx_artifacts if Path(item["path"]).name == "expert_stack.onnx"),
-        onnx_artifacts[0],
-    )
-    onnx_path = export_dir / preferred["path"]
+    onnx_path = export_dir / "expert_stack.onnx"
 
     if device.lower() != "cpu":
         logger.info(
@@ -262,10 +266,13 @@ def load_onnx_backend(export_dir: Path, device: str = "cpu") -> ONNXBackend:
         import onnxruntime as ort  # type: ignore[import-not-found]
     except ImportError as e:
         raise ImportError(
-            "onnxruntime is required for `tether validate`. Install with: pip install onnxruntime"
+            "onnxruntime is required for `tether validate`. "
+            "Install with: pip install onnxruntime"
         ) from e
 
-    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    session = ort.InferenceSession(
+        str(onnx_path), providers=["CPUExecutionProvider"]
+    )
     active_providers = session.get_providers()
     active = active_providers[0] if active_providers else "<none>"
     if active != "CPUExecutionProvider":  # pragma: no cover - defensive

--- a/src/tether/_pytorch_backend.py
+++ b/src/tether/_pytorch_backend.py
@@ -45,8 +45,7 @@ from tether.checkpoint import detect_model_type, load_checkpoint
 logger = logging.getLogger("tether.validate.pytorch")
 
 UNSUPPORTED_MODEL_MESSAGE = (
-    "tether validate v1 supports smolvla, pi0, gr00t. "
-    "For pi0.5 / openvla see roadmap."
+    "tether validate v1 supports smolvla, pi0, gr00t. For pi0.5 / openvla see roadmap."
 )
 
 # Per-model default denoise step counts. Overridden by tether_config.json
@@ -91,17 +90,19 @@ def load_pytorch_backend(
     export_dir = Path(export_dir)
     config_path = export_dir / "tether_config.json"
     if not config_path.exists():
-        raise FileNotFoundError(
-            f"Missing tether_config.json in export dir: {export_dir}"
-        )
-    import json
+        raise FileNotFoundError(f"Missing tether_config.json in export dir: {export_dir}")
+    from tether.export_config import load_tether_config, require_supported_export_kind
 
-    config: dict[str, Any] = json.loads(config_path.read_text())
+    config = load_tether_config(config_path)
+    require_supported_export_kind(
+        config,
+        {"monolithic_onnx", "decomposed_onnx"},
+        "PyTorch round-trip reference",
+    )
     resolved_id = model_id or config.get("model_id")
     if resolved_id is None:
         raise ValueError(
-            "Cannot resolve checkpoint: pass model_id or include 'model_id' "
-            "in tether_config.json."
+            "Cannot resolve checkpoint: pass model_id or include 'model_id' in tether_config.json."
         )
 
     logger.info(
@@ -150,13 +151,8 @@ def _build_decomposed_model(
         try:  # pragma: no cover - defensive, mirrors smolvla_exporter
             from transformers import AutoConfig
 
-            vlm_cfg = AutoConfig.from_pretrained(
-                "HuggingFaceTB/SmolVLM2-500M-Video-Instruct"
-            )
-            head_dim = (
-                vlm_cfg.text_config.hidden_size
-                // vlm_cfg.text_config.num_attention_heads
-            )
+            vlm_cfg = AutoConfig.from_pretrained("HuggingFaceTB/SmolVLM2-500M-Video-Instruct")
+            head_dim = vlm_cfg.text_config.hidden_size // vlm_cfg.text_config.num_attention_heads
         except Exception as exc:  # pragma: no cover - defensive
             logging.getLogger(__name__).warning(
                 "Could not fetch SmolVLM2 head_dim from HF (%s); "
@@ -216,9 +212,7 @@ class PyTorchBackend:
         self.num_steps: int = int(
             self.config.get("num_denoising_steps", _DEFAULT_STEPS[model_type])
         )
-        self.chunk_size: int = int(
-            self.config.get("action_chunk_size", _DEFAULT_CHUNK_SIZE)
-        )
+        self.chunk_size: int = int(self.config.get("action_chunk_size", _DEFAULT_CHUNK_SIZE))
         # action_dim is the *input/output* feature dim the ONNX accepts. For
         # GR00T full-stack it is the raw DoF dim; for SmolVLA / pi0 it is the
         # native action dim. The exporter writes this into tether_config.json.
@@ -227,9 +221,7 @@ class PyTorchBackend:
             expert_meta = self.config.get("expert", {})
             action_dim = expert_meta.get("action_dim")
         if action_dim is None:
-            raise ValueError(
-                "tether_config.json missing 'action_dim'; cannot shape noise."
-            )
+            raise ValueError("tether_config.json missing 'action_dim'; cannot shape noise.")
         self.action_dim: int = int(action_dim)
 
     def forward(
@@ -265,9 +257,7 @@ class PyTorchBackend:
         elif initial_noise.ndim == 3:
             noise = initial_noise
         else:
-            raise ValueError(
-                f"initial_noise must be 2D or 3D, got shape {initial_noise.shape}"
-            )
+            raise ValueError(f"initial_noise must be 2D or 3D, got shape {initial_noise.shape}")
 
         if noise.shape[-2] != self.chunk_size or noise.shape[-1] != self.action_dim:
             raise ValueError(

--- a/src/tether/_pytorch_backend.py
+++ b/src/tether/_pytorch_backend.py
@@ -45,7 +45,8 @@ from tether.checkpoint import detect_model_type, load_checkpoint
 logger = logging.getLogger("tether.validate.pytorch")
 
 UNSUPPORTED_MODEL_MESSAGE = (
-    "tether validate v1 supports smolvla, pi0, gr00t. For pi0.5 / openvla see roadmap."
+    "tether validate v1 supports smolvla, pi0, gr00t. "
+    "For pi0.5 / openvla see roadmap."
 )
 
 # Per-model default denoise step counts. Overridden by tether_config.json
@@ -91,18 +92,31 @@ def load_pytorch_backend(
     config_path = export_dir / "tether_config.json"
     if not config_path.exists():
         raise FileNotFoundError(f"Missing tether_config.json in export dir: {export_dir}")
-    from tether.export_config import load_tether_config, require_supported_export_kind
+    from tether.export_config import (
+        UnsupportedExportPipelineError,
+        decomposed_layout,
+        load_tether_config,
+        require_supported_export_kind,
+        require_supported_pipeline,
+    )
 
     config = load_tether_config(config_path)
     require_supported_export_kind(
         config,
-        {"monolithic_onnx", "decomposed_onnx"},
+        {"decomposed_onnx"},
         "PyTorch round-trip reference",
     )
+    require_supported_pipeline(config, set(), "PyTorch round-trip reference")
+    layout = decomposed_layout(config)
+    if layout not in {"expert_stack", "smolvla_full_bundle"}:
+        raise UnsupportedExportPipelineError(
+            f"PyTorch round-trip reference supports only the expert_stack family, got {layout!r}"
+        )
     resolved_id = model_id or config.get("model_id")
     if resolved_id is None:
         raise ValueError(
-            "Cannot resolve checkpoint: pass model_id or include 'model_id' in tether_config.json."
+            "Cannot resolve checkpoint: pass model_id or include 'model_id' "
+            "in tether_config.json."
         )
 
     logger.info(
@@ -151,8 +165,13 @@ def _build_decomposed_model(
         try:  # pragma: no cover - defensive, mirrors smolvla_exporter
             from transformers import AutoConfig
 
-            vlm_cfg = AutoConfig.from_pretrained("HuggingFaceTB/SmolVLM2-500M-Video-Instruct")
-            head_dim = vlm_cfg.text_config.hidden_size // vlm_cfg.text_config.num_attention_heads
+            vlm_cfg = AutoConfig.from_pretrained(
+                "HuggingFaceTB/SmolVLM2-500M-Video-Instruct"
+            )
+            head_dim = (
+                vlm_cfg.text_config.hidden_size
+                // vlm_cfg.text_config.num_attention_heads
+            )
         except Exception as exc:  # pragma: no cover - defensive
             logging.getLogger(__name__).warning(
                 "Could not fetch SmolVLM2 head_dim from HF (%s); "
@@ -212,7 +231,9 @@ class PyTorchBackend:
         self.num_steps: int = int(
             self.config.get("num_denoising_steps", _DEFAULT_STEPS[model_type])
         )
-        self.chunk_size: int = int(self.config.get("action_chunk_size", _DEFAULT_CHUNK_SIZE))
+        self.chunk_size: int = int(
+            self.config.get("action_chunk_size", _DEFAULT_CHUNK_SIZE)
+        )
         # action_dim is the *input/output* feature dim the ONNX accepts. For
         # GR00T full-stack it is the raw DoF dim; for SmolVLA / pi0 it is the
         # native action dim. The exporter writes this into tether_config.json.
@@ -221,7 +242,9 @@ class PyTorchBackend:
             expert_meta = self.config.get("expert", {})
             action_dim = expert_meta.get("action_dim")
         if action_dim is None:
-            raise ValueError("tether_config.json missing 'action_dim'; cannot shape noise.")
+            raise ValueError(
+                "tether_config.json missing 'action_dim'; cannot shape noise."
+            )
         self.action_dim: int = int(action_dim)
 
     def forward(
@@ -257,7 +280,9 @@ class PyTorchBackend:
         elif initial_noise.ndim == 3:
             noise = initial_noise
         else:
-            raise ValueError(f"initial_noise must be 2D or 3D, got shape {initial_noise.shape}")
+            raise ValueError(
+                f"initial_noise must be 2D or 3D, got shape {initial_noise.shape}"
+            )
 
         if noise.shape[-2] != self.chunk_size or noise.shape[-1] != self.action_dim:
             raise ValueError(

--- a/src/tether/cli.py
+++ b/src/tether/cli.py
@@ -1027,6 +1027,47 @@ def publish_latency_cmd(
             )
 
 
+def _build_benchmark_server(
+    export_dir: str | Path, export_config: dict[str, Any], device: str
+) -> Any:
+    """Construct only a reader declared compatible with this export layout."""
+    from tether.export_config import decomposed_layout
+
+    kind = export_config.get("export_kind")
+    if kind == "monolithic_onnx":
+        model_type = export_config["model_type"]
+        if model_type == "pi0":
+            from tether.runtime.pi0_onnx_server import Pi0OnnxServer
+
+            return Pi0OnnxServer(export_dir, device=device, max_batch=1, strict_providers=False)
+        if model_type == "pi05":
+            from tether.runtime.pi05_onnx_server import Pi05OnnxServer
+
+            return Pi05OnnxServer(export_dir, device=device, max_batch=1, strict_providers=False)
+        if model_type == "smolvla":
+            from tether.runtime.smolvla_onnx_server import SmolVLAOnnxServer
+
+            return SmolVLAOnnxServer(
+                export_dir, device=device, max_batch=1, strict_providers=False
+            )
+        if model_type == "gr00t":
+            from tether.runtime.server import TetherServer
+
+            return TetherServer(export_dir, device=device, strict_providers=False)
+        raise ValueError(f"Benchmark does not support monolithic model_type={model_type!r}")
+    if kind == "decomposed_onnx":
+        layout = decomposed_layout(export_config)
+        if layout == "pi05_split":
+            from tether.runtime.decomposed_server import Pi05DecomposedServer
+
+            return Pi05DecomposedServer(export_dir, device=device, strict_providers=False)
+        if layout in {"expert_stack", "smolvla_full_bundle"}:
+            from tether.runtime.server import TetherServer
+
+            return TetherServer(export_dir, device=device, strict_providers=False)
+    raise ValueError(f"Benchmark does not support export_kind={kind!r}")
+
+
 @app.command(name="bench", hidden=True)
 def benchmark_cmd(
     export_dir: str = typer.Argument(
@@ -1252,52 +1293,15 @@ def benchmark_cmd(
     if benchmark:
         console.print(f"  Benchmark: [cyan]{benchmark}[/cyan] ({episodes_per_task} eps/task)")
 
-    config_path = export_path / "tether_config.json"
-    export_config = {}
-    if config_path.exists():
-        try:
-            export_config = json.loads(config_path.read_text())
-        except Exception:
-            export_config = {}
+    from tether.export_config import ExportConfigError, load_tether_config
 
-    server: Any
-    if export_config.get("export_kind") == "monolithic":
-        model_type = export_config.get("model_type", "smolvla")
-        if model_type == "pi0":
-            from tether.runtime.pi0_onnx_server import Pi0OnnxServer
-            server = Pi0OnnxServer(
-                export_dir,
-                device=device,
-                max_batch=1,
-                strict_providers=False,
-            )
-        elif model_type == "pi05":
-            from tether.runtime.pi05_onnx_server import Pi05OnnxServer
-            server = Pi05OnnxServer(
-                export_dir,
-                device=device,
-                max_batch=1,
-                strict_providers=False,
-            )
-        elif model_type == "smolvla":
-            from tether.runtime.smolvla_onnx_server import SmolVLAOnnxServer
-            server = SmolVLAOnnxServer(
-                export_dir,
-                device=device,
-                max_batch=1,
-                strict_providers=False,
-            )
-        elif model_type == "gr00t":
-            from tether.runtime.server import TetherServer
-            server = TetherServer(export_dir, device=device, strict_providers=False)
-        else:
-            err_console.print(
-                f"[red]Benchmark does not support monolithic model_type={model_type!r} yet.[/red]"
-            )
-            raise typer.Exit(2)
-    else:
-        from tether.runtime.server import TetherServer
-        server = TetherServer(export_dir, device=device, strict_providers=False)
+    export_config = load_tether_config(export_path)
+
+    try:
+        server = _build_benchmark_server(export_dir, export_config, device)
+    except (ExportConfigError, ValueError) as exc:
+        err_console.print(f"[red]{exc}.[/red]")
+        raise typer.Exit(2)
     console.print("[dim]Loading model...[/dim]")
     t0 = _t.perf_counter()
     server.load()

--- a/src/tether/diagnostics/check_cuda_graphs.py
+++ b/src/tether/diagnostics/check_cuda_graphs.py
@@ -17,7 +17,6 @@ Cost: loads both ORT sessions (~6.5 GB model weights) and runs one synthetic
 forward each. Typically 15-30s on GPU; skipped without CUDA. Users can skip
 explicitly via `tether doctor --skip cuda_graphs`.
 """
-
 from __future__ import annotations
 
 from pathlib import Path
@@ -50,12 +49,13 @@ def _run(*, model_path: str, embodiment_name: str, rtc: bool) -> CheckResult:
             f"no tether_config.json at {export}",
         )
 
-    from tether.export_config import ExportConfigError, load_tether_config
+    from tether.export_config import ExportConfigError, decomposed_layout, load_tether_config
 
     try:
         cfg = load_tether_config(cfg_path)
     except (ExportConfigError, FileNotFoundError) as exc:
         return CheckResult(
+            check_id=_CHECK_ID,
             name=_CHECK_NAME,
             status="fail",
             expected="valid Export Config v1",
@@ -67,6 +67,15 @@ def _run(*, model_path: str, embodiment_name: str, rtc: bool) -> CheckResult:
         return _skip(
             "cuda-graphs applies only to decomposed exports",
             f"export_kind={cfg.get('export_kind')!r}",
+        )
+    try:
+        layout = decomposed_layout(cfg)
+    except ExportConfigError as exc:
+        return _skip("supported decomposed CUDA-graphs layout", str(exc))
+    if layout != "pi05_split":
+        return _skip(
+            "pi05 split layout (vlm_prefix.onnx + expert_denoise.onnx)",
+            f"layout={layout!r}; CUDA-graphs diagnostic does not support this pipeline",
         )
 
     try:
@@ -96,8 +105,9 @@ def _run(*, model_path: str, embodiment_name: str, rtc: bool) -> CheckResult:
             duration_ms=0.0,
         )
 
-    prefix_path = export / cfg["decomposed"]["vlm_prefix_onnx"]
-    expert_path = export / cfg["decomposed"]["expert_denoise_onnx"]
+    declared_paths = {str(item["path"]) for item in cfg["artifacts"]}
+    prefix_path = export / next(path for path in declared_paths if path == "vlm_prefix.onnx")
+    expert_path = export / next(path for path in declared_paths if path == "expert_denoise.onnx")
 
     def _build_prefix(cg_enabled: bool) -> "ort.InferenceSession":
         return ort.InferenceSession(
@@ -189,12 +199,10 @@ def _run(*, model_path: str, embodiment_name: str, rtc: bool) -> CheckResult:
     )
 
 
-register(
-    Check(
-        check_id=_CHECK_ID,
-        name=_CHECK_NAME,
-        severity="warn",
-        github_issue=None,
-        run_fn=_run,
-    )
-)
+register(Check(
+    check_id=_CHECK_ID,
+    name=_CHECK_NAME,
+    severity="warn",
+    github_issue=None,
+    run_fn=_run,
+))

--- a/src/tether/diagnostics/check_cuda_graphs.py
+++ b/src/tether/diagnostics/check_cuda_graphs.py
@@ -17,9 +17,9 @@ Cost: loads both ORT sessions (~6.5 GB model weights) and runs one synthetic
 forward each. Typically 15-30s on GPU; skipped without CUDA. Users can skip
 explicitly via `tether doctor --skip cuda_graphs`.
 """
+
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from tether.diagnostics import Check, CheckResult, register
@@ -50,8 +50,20 @@ def _run(*, model_path: str, embodiment_name: str, rtc: bool) -> CheckResult:
             f"no tether_config.json at {export}",
         )
 
-    cfg = json.loads(cfg_path.read_text())
-    if cfg.get("export_kind") != "decomposed":
+    from tether.export_config import ExportConfigError, load_tether_config
+
+    try:
+        cfg = load_tether_config(cfg_path)
+    except (ExportConfigError, FileNotFoundError) as exc:
+        return CheckResult(
+            name=_CHECK_NAME,
+            status="fail",
+            expected="valid Export Config v1",
+            actual=str(exc),
+            remediation="Re-export the model with a current Tether exporter.",
+            duration_ms=0.0,
+        )
+    if cfg.get("export_kind") != "decomposed_onnx":
         return _skip(
             "cuda-graphs applies only to decomposed exports",
             f"export_kind={cfg.get('export_kind')!r}",
@@ -177,10 +189,12 @@ def _run(*, model_path: str, embodiment_name: str, rtc: bool) -> CheckResult:
     )
 
 
-register(Check(
-    check_id=_CHECK_ID,
-    name=_CHECK_NAME,
-    severity="warn",
-    github_issue=None,
-    run_fn=_run,
-))
+register(
+    Check(
+        check_id=_CHECK_ID,
+        name=_CHECK_NAME,
+        severity="warn",
+        github_issue=None,
+        run_fn=_run,
+    )
+)

--- a/src/tether/export_config.py
+++ b/src/tether/export_config.py
@@ -32,6 +32,48 @@ _LEGACY_KINDS = {
     "decomposed": "decomposed_onnx",
 }
 
+PRODUCER_LAYOUTS: dict[str, dict[str, Any]] = {
+    "monolithic": {
+        "export_kind": "monolithic_onnx",
+        "artifacts": (("model.onnx", "model"),),
+    },
+    "pi05_split": {
+        "export_kind": "decomposed_onnx",
+        "artifacts": (
+            ("vlm_prefix.onnx", "model"),
+            ("expert_denoise.onnx", "model"),
+        ),
+    },
+    "expert_stack": {
+        "export_kind": "decomposed_onnx",
+        "artifacts": (("expert_stack.onnx", "model"),),
+    },
+    "pi0_prefix": {
+        "export_kind": "decomposed_onnx",
+        "pipeline": "prefix_optimum + expert_custom",
+        "artifacts": (
+            ("vision_encoder/model.onnx", "model"),
+            ("multi_modal_projector.onnx", "model"),
+            ("text_embedder.onnx", "model"),
+            ("decoder_prefill/model.onnx", "model"),
+            ("expert_stack.onnx", "model"),
+        ),
+    },
+    "dreamzero": {
+        "export_kind": "config_only",
+        "artifacts": (),
+    },
+}
+
+SMOLVLA_VLM_MODEL_PATHS = (
+    "vision_encoder.onnx",
+    "text_embedder.onnx",
+    "decoder_prefill.onnx",
+)
+SMOLVLA_FULL_BUNDLE_MODEL_PATHS = frozenset(
+    ("expert_stack.onnx", *SMOLVLA_VLM_MODEL_PATHS)
+)
+
 
 class ExportConfigError(ValueError):
     """The export config is malformed or inconsistent with its artifacts."""
@@ -39,6 +81,10 @@ class ExportConfigError(ValueError):
 
 class UnsupportedExportKindError(ExportConfigError):
     """The config is valid but the selected operation cannot use its layout."""
+
+
+class UnsupportedExportPipelineError(ExportConfigError):
+    """The config declares a pipeline that the selected operation cannot execute."""
 
 
 def _positive_int(value: Any, field: str) -> int:
@@ -287,7 +333,9 @@ def _onnx_metadata(
     for graph_index, path in enumerate(onnx_paths):
         model = onnx.load(str(path), load_external_data=False)
         opsets.extend(int(item.version) for item in model.opset_import if not item.domain)
-        prefix = f"{path.stem}:" if len(onnx_paths) > 1 else ""
+        prefix = (
+            f"{path.relative_to(root).as_posix()}:" if len(onnx_paths) > 1 else ""
+        )
         initializers = {item.name for item in model.graph.initializer}
         for value in model.graph.input:
             if value.name not in initializers:
@@ -301,6 +349,178 @@ def _onnx_metadata(
     return (max(opsets) if opsets else None), {"inputs": inputs, "outputs": outputs}
 
 
+def _onnx_external_artifacts(root: Path, model_paths: list[str]) -> list[tuple[str, str]]:
+    """Return only external files referenced by the declared ONNX graphs."""
+    try:
+        import onnx  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise ExportConfigError("onnx is required to build a canonical ONNX manifest") from exc
+
+    discovered: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for model_path in model_paths:
+        model = onnx.load(str(root / model_path), load_external_data=False)
+        model_parent = PurePosixPath(model_path).parent
+        for tensor in model.graph.initializer:
+            if tensor.data_location != onnx.TensorProto.EXTERNAL:
+                continue
+            location = next(
+                (entry.value for entry in tensor.external_data if entry.key == "location"),
+                None,
+            )
+            if not location:
+                raise ExportConfigError(
+                    f"ONNX initializer {tensor.name!r} has no external-data location"
+                )
+            candidate = (root / model_parent / PurePosixPath(location)).resolve()
+            try:
+                relative = candidate.relative_to(root.resolve()).as_posix()
+            except ValueError as exc:
+                raise ExportConfigError(
+                    f"external data for {model_path} resolves outside the export directory"
+                ) from exc
+            relative = _artifact_path(relative, f"external data for {model_path}")
+            if relative not in seen:
+                discovered.append((relative, "weights"))
+                seen.add(relative)
+    return discovered
+
+
+def build_onnx_artifacts(
+    output_dir: str | Path,
+    model_paths: list[str] | tuple[str, ...],
+) -> list[dict[str, str]]:
+    """Build an exact manifest for declared ONNX graphs and their external data."""
+    root = Path(output_dir)
+    normalized = [_artifact_path(path, "declared ONNX artifact") for path in model_paths]
+    if len(normalized) != len(set(normalized)):
+        raise ExportConfigError("declared ONNX artifact paths must be unique")
+    for path in normalized:
+        if not (root / path).is_file():
+            raise ExportConfigError(f"declared ONNX artifact is missing: {path}")
+    artifacts = [{"path": path, "role": "model"} for path in normalized]
+    artifacts.extend(
+        {"path": path, "role": role}
+        for path, role in _onnx_external_artifacts(root, normalized)
+    )
+    return artifacts
+
+
+def replace_owned_onnx_artifacts(
+    output_dir: str | Path,
+    artifacts: list[Mapping[str, Any]],
+    *,
+    model_paths: list[str] | tuple[str, ...],
+    previously_owned_paths: list[str] | tuple[str, ...] = (),
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Replace one producer component's manifest entries declaratively.
+
+    ``previously_owned_paths`` is persisted by the producer, so rerunning an
+    export removes external-data files that a newly written graph no longer
+    references. Other producers' entries are preserved verbatim.
+    """
+    current = build_onnx_artifacts(output_dir, model_paths)
+    owned = {
+        _artifact_path(path, "previously owned artifact")
+        for path in (*previously_owned_paths, *model_paths)
+    }
+    owned.update(item["path"] for item in current)
+    retained = [dict(item) for item in artifacts if item.get("path") not in owned]
+    current_paths = [item["path"] for item in current]
+    return retained + current, current_paths
+
+
+def build_producer_config(
+    output_dir: str | Path,
+    *,
+    producer: str,
+    model_id: str,
+    model_type: str,
+    action_dim: int,
+    num_denoising_steps: int,
+    opset: int,
+    optional_artifacts: list[tuple[str, str]] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a canonical config from one producer's declared layout.
+
+    Unlike legacy normalization, this function never scans ``output_dir``.
+    External weights are included only when a declared ONNX graph references
+    them, and optional assets must be passed explicitly by the producer.
+    """
+    if producer not in PRODUCER_LAYOUTS:
+        raise ExportConfigError(f"unknown config producer {producer!r}")
+    root = Path(output_dir)
+    layout = PRODUCER_LAYOUTS[producer]
+    declared = list(layout["artifacts"])
+    model_paths = [path for path, role in declared if role == "model" and path.endswith(".onnx")]
+    if model_paths:
+        onnx_artifacts = build_onnx_artifacts(root, model_paths)
+        declared = [(item["path"], item["role"]) for item in onnx_artifacts]
+        inspected_opset, io_contract = _onnx_metadata(
+            root,
+            [{"path": path, "role": role} for path, role in declared if role == "model"],
+        )
+        if io_contract is None:
+            raise ExportConfigError("could not inspect the declared ONNX I/O contract")
+        if inspected_opset is not None and inspected_opset != opset:
+            raise ExportConfigError(
+                f"declared opset {opset} does not match ONNX opset {inspected_opset}"
+            )
+    else:
+        io_contract = {"inputs": [], "outputs": []}
+
+    for artifact in optional_artifacts or []:
+        if artifact not in declared:
+            declared.append(artifact)
+
+    config: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "model_id": model_id,
+        "model_type": model_type,
+        "action_dim": action_dim,
+        "num_denoising_steps": num_denoising_steps,
+        "opset": opset,
+        "export_kind": layout["export_kind"],
+        "artifacts": [{"path": path, "role": role} for path, role in declared],
+        "io_contract": io_contract,
+    }
+    if "pipeline" in layout:
+        config["pipeline"] = layout["pipeline"]
+    if metadata:
+        for key, value in metadata.items():
+            if key not in config:
+                config[key] = value
+    return validate_tether_config(config, root=root, inspect_artifacts=True)
+
+
+def decomposed_layout(config: Mapping[str, Any]) -> str:
+    """Classify a canonical decomposed layout without guessing compatibility."""
+    if config.get("export_kind") != "decomposed_onnx":
+        raise UnsupportedExportKindError(
+            f"decomposed layout requires export_kind='decomposed_onnx', "
+            f"got {config.get('export_kind')!r}"
+        )
+    if config.get("pipeline") is not None:
+        raise UnsupportedExportPipelineError(
+            f"unsupported decomposed pipeline {config.get('pipeline')!r}"
+        )
+    paths = {
+        str(item["path"])
+        for item in config.get("artifacts", [])
+        if item.get("role") == "model" and str(item.get("path", "")).endswith(".onnx")
+    }
+    if paths == {"vlm_prefix.onnx", "expert_denoise.onnx"}:
+        return "pi05_split"
+    if paths == {"expert_stack.onnx"}:
+        return "expert_stack"
+    if config.get("model_type") == "smolvla" and paths == SMOLVLA_FULL_BUNDLE_MODEL_PATHS:
+        return "smolvla_full_bundle"
+    raise UnsupportedExportPipelineError(
+        f"unsupported decomposed artifact layout: {sorted(paths)}"
+    )
+
+
 def normalize_legacy_tether_config(payload: Mapping[str, Any], root: str | Path) -> dict[str, Any]:
     """Normalize a legacy config using only present metadata/artifact inspection."""
     config = dict(payload)
@@ -309,6 +529,11 @@ def normalize_legacy_tether_config(payload: Mapping[str, Any], root: str | Path)
         return config
     config["schema_version"] = SCHEMA_VERSION
     config["export_kind"] = _LEGACY_KINDS.get(config.get("export_kind"), config.get("export_kind"))
+    if (
+        not config.get("export_kind")
+        and config.get("export_format") == "dreamzero_decomposed"
+    ):
+        config["export_kind"] = "config_only"
     if not config.get("model_id"):
         for key in ("checkpoint_path", "checkpoint", "source_model"):
             if isinstance(config.get(key), str) and config[key]:
@@ -321,15 +546,44 @@ def normalize_legacy_tether_config(payload: Mapping[str, Any], root: str | Path)
         if isinstance(expert, Mapping) and expert.get("action_dim"):
             config["action_dim"] = expert["action_dim"]
     if not config.get("num_denoising_steps"):
+        if config.get("num_inference_steps"):
+            config["num_denoising_steps"] = config["num_inference_steps"]
         for container_name in ("expert", "decomposed"):
+            if config.get("num_denoising_steps"):
+                break
             container = config.get(container_name)
             if isinstance(container, Mapping) and container.get("num_denoising_steps"):
                 config["num_denoising_steps"] = container["num_denoising_steps"]
                 break
+    if config.get("opset") is None and config.get("opset_version") is not None:
+        config["opset"] = config["opset_version"]
     artifacts = config.get("artifacts")
     if not isinstance(artifacts, list):
-        artifacts = _legacy_artifacts(config, root_path)
+        artifacts = (
+            []
+            if config.get("export_kind") == "config_only"
+            else _legacy_artifacts(config, root_path)
+        )
         config["artifacts"] = artifacts
+    if not config.get("export_kind"):
+        model_paths = {
+            str(item.get("path"))
+            for item in artifacts
+            if isinstance(item, Mapping)
+            and item.get("role") == "model"
+            and str(item.get("path", "")).endswith(".onnx")
+        }
+        if model_paths == {"model.onnx"}:
+            config["export_kind"] = "monolithic_onnx"
+        elif model_paths == {"expert_stack.onnx"} or model_paths == {
+            "vlm_prefix.onnx",
+            "expert_denoise.onnx",
+        }:
+            config["export_kind"] = "decomposed_onnx"
+    if config.get("export_kind") == "config_only" and not isinstance(
+        config.get("io_contract"), Mapping
+    ):
+        config["io_contract"] = {"inputs": [], "outputs": []}
     if config.get("opset") is None or not isinstance(config.get("io_contract"), Mapping):
         inspected_opset, inspected_io = _onnx_metadata(root_path, artifacts)
         if config.get("opset") is None and inspected_opset is not None:
@@ -396,17 +650,47 @@ def require_supported_export_kind(
     return kind
 
 
+def require_supported_pipeline(
+    config: Mapping[str, Any], supported: set[str], operation: str
+) -> str | None:
+    """Reject a declared component pipeline unless the operation supports it.
+
+    A missing pipeline denotes the canonical layout for ``export_kind``.  A
+    producer that declares a custom component pipeline must be opted into by
+    name so readers never guess that it is compatible from one shared file.
+    """
+    pipeline = config.get("pipeline")
+    if pipeline is None:
+        return None
+    pipeline_name = _nonempty_string(pipeline, "pipeline")
+    if pipeline_name not in supported:
+        raise UnsupportedExportPipelineError(
+            f"{operation} does not support pipeline={pipeline_name!r}; "
+            f"supported: {sorted(supported)}"
+        )
+    return pipeline_name
+
+
 __all__ = [
     "ARTIFACT_ROLES",
     "CONFIG_FILENAME",
     "DTYPES",
     "EXPORT_KINDS",
+    "PRODUCER_LAYOUTS",
+    "SMOLVLA_FULL_BUNDLE_MODEL_PATHS",
+    "SMOLVLA_VLM_MODEL_PATHS",
     "ExportConfigError",
     "SCHEMA_VERSION",
     "UnsupportedExportKindError",
+    "UnsupportedExportPipelineError",
+    "build_producer_config",
+    "build_onnx_artifacts",
+    "decomposed_layout",
     "load_tether_config",
     "normalize_legacy_tether_config",
     "require_supported_export_kind",
+    "require_supported_pipeline",
+    "replace_owned_onnx_artifacts",
     "validate_tether_config",
     "write_tether_config",
 ]

--- a/src/tether/export_config.py
+++ b/src/tether/export_config.py
@@ -1,0 +1,412 @@
+"""Canonical loading and validation for ``tether_config.json``.
+
+Export Config v1 is deliberately strict at trust boundaries.  Legacy files
+are normalized only from fields or artifacts that are actually present; this
+module never guesses a model family, action width, or denoising step count.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import tempfile
+from typing import Any, Mapping
+
+
+CONFIG_FILENAME = "tether_config.json"
+SCHEMA_VERSION = 1
+EXPORT_KINDS = frozenset(
+    {"monolithic_onnx", "decomposed_onnx", "trt_engine", "triton_bundle", "config_only"}
+)
+ARTIFACT_ROLES = frozenset({"model", "weights", "engine", "tokenizer", "config", "auxiliary"})
+DTYPES = frozenset(
+    {"float16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "bool", "string"}
+)
+_SYMBOLIC_DIM = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_LEGACY_KINDS = {
+    "monolithic": "monolithic_onnx",
+    "decomposed": "decomposed_onnx",
+}
+
+
+class ExportConfigError(ValueError):
+    """The export config is malformed or inconsistent with its artifacts."""
+
+
+class UnsupportedExportKindError(ExportConfigError):
+    """The config is valid but the selected operation cannot use its layout."""
+
+
+def _positive_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ExportConfigError(f"{field} must be a positive integer, got {value!r}")
+    return value
+
+
+def _nonempty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ExportConfigError(f"{field} must be a non-empty string")
+    return value
+
+
+def _artifact_path(value: Any, field: str) -> str:
+    path = _nonempty_string(value, field)
+    if "\\" in path:
+        raise ExportConfigError(f"{field} must use POSIX separators")
+    pure = PurePosixPath(path)
+    if pure.is_absolute() or ".." in pure.parts:
+        raise ExportConfigError(f"{field} must be a relative path without '..'")
+    if path != pure.as_posix() or path in {".", ""}:
+        raise ExportConfigError(f"{field} must be a normalized relative POSIX path")
+    return path
+
+
+def _validate_tensor(tensor: Any, field: str) -> None:
+    if not isinstance(tensor, Mapping):
+        raise ExportConfigError(f"{field} must be an object")
+    _nonempty_string(tensor.get("name"), f"{field}.name")
+    dtype = tensor.get("dtype")
+    if dtype not in DTYPES:
+        raise ExportConfigError(f"{field}.dtype must be one of {sorted(DTYPES)}, got {dtype!r}")
+    shape = tensor.get("shape")
+    if not isinstance(shape, list):
+        raise ExportConfigError(f"{field}.shape must be an array")
+    for index, dim in enumerate(shape):
+        if dim is None:
+            continue
+        if isinstance(dim, bool):
+            raise ExportConfigError(f"{field}.shape[{index}] is not a valid dimension")
+        if isinstance(dim, int):
+            if dim <= 0:
+                raise ExportConfigError(f"{field}.shape[{index}] must be positive")
+            continue
+        if isinstance(dim, str) and _SYMBOLIC_DIM.fullmatch(dim):
+            continue
+        raise ExportConfigError(
+            f"{field}.shape[{index}] must be a positive integer, symbolic name, or null"
+        )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_tether_config(
+    payload: Mapping[str, Any],
+    root: str | Path | None = None,
+    *,
+    inspect_artifacts: bool = True,
+) -> dict[str, Any]:
+    """Validate and return a shallow copy of a canonical Export Config v1."""
+    if not isinstance(payload, Mapping):
+        raise ExportConfigError("tether_config.json must contain a JSON object")
+    config = dict(payload)
+    if config.get("schema_version") != SCHEMA_VERSION:
+        raise ExportConfigError(
+            f"schema_version must be {SCHEMA_VERSION}, got {config.get('schema_version')!r}"
+        )
+    _nonempty_string(config.get("model_id"), "model_id")
+    _nonempty_string(config.get("model_type"), "model_type")
+    _positive_int(config.get("action_dim"), "action_dim")
+    _positive_int(config.get("num_denoising_steps"), "num_denoising_steps")
+    _positive_int(config.get("opset"), "opset")
+    export_kind = config.get("export_kind")
+    if export_kind not in EXPORT_KINDS:
+        raise ExportConfigError(
+            f"export_kind must be one of {sorted(EXPORT_KINDS)}, got {export_kind!r}"
+        )
+
+    artifacts = config.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ExportConfigError("artifacts must be an array")
+    if export_kind != "config_only" and not artifacts:
+        raise ExportConfigError(f"artifacts must not be empty for export_kind={export_kind!r}")
+    seen_paths: set[str] = set()
+    resolved_root = Path(root).resolve() if root is not None else None
+    for index, artifact in enumerate(artifacts):
+        field = f"artifacts[{index}]"
+        if not isinstance(artifact, Mapping):
+            raise ExportConfigError(f"{field} must be an object")
+        relative = _artifact_path(artifact.get("path"), f"{field}.path")
+        if relative in seen_paths:
+            raise ExportConfigError(f"{field}.path duplicates {relative!r}")
+        seen_paths.add(relative)
+        role = artifact.get("role")
+        if role not in ARTIFACT_ROLES:
+            raise ExportConfigError(
+                f"{field}.role must be one of {sorted(ARTIFACT_ROLES)}, got {role!r}"
+            )
+        expected_digest = artifact.get("sha256")
+        if expected_digest is not None and (
+            not isinstance(expected_digest, str) or not _SHA256.fullmatch(expected_digest)
+        ):
+            raise ExportConfigError(f"{field}.sha256 must be lowercase 64-hex")
+        if resolved_root is not None and inspect_artifacts:
+            resolved = (resolved_root / relative).resolve()
+            try:
+                resolved.relative_to(resolved_root)
+            except ValueError as exc:
+                raise ExportConfigError(
+                    f"{field}.path resolves outside the export directory"
+                ) from exc
+            if not resolved.is_file():
+                raise ExportConfigError(f"{field}.path is missing: {relative}")
+            if expected_digest is not None:
+                actual = _sha256_file(resolved)
+                if actual != expected_digest:
+                    raise ExportConfigError(
+                        f"{field}.sha256 mismatch for {relative}: expected {expected_digest}, got {actual}"
+                    )
+
+    io_contract = config.get("io_contract")
+    if not isinstance(io_contract, Mapping):
+        raise ExportConfigError("io_contract must be an object")
+    for direction in ("inputs", "outputs"):
+        tensors = io_contract.get(direction)
+        if not isinstance(tensors, list):
+            raise ExportConfigError(f"io_contract.{direction} must be an array")
+        names: set[str] = set()
+        for index, tensor in enumerate(tensors):
+            field = f"io_contract.{direction}[{index}]"
+            _validate_tensor(tensor, field)
+            name = str(tensor["name"])
+            if name in names:
+                raise ExportConfigError(f"{field}.name duplicates {name!r}")
+            names.add(name)
+    return config
+
+
+def _legacy_artifacts(config: Mapping[str, Any], root: Path) -> list[dict[str, str]]:
+    artifacts: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    def add(candidate: Any, role: str) -> None:
+        if not isinstance(candidate, str) or not candidate:
+            return
+        raw = Path(candidate)
+        if raw.is_absolute():
+            try:
+                candidate = raw.resolve().relative_to(root.resolve()).as_posix()
+            except ValueError:
+                return
+        try:
+            relative = _artifact_path(candidate, "legacy artifact path")
+        except ExportConfigError:
+            return
+        if relative not in seen and (root / relative).is_file():
+            artifacts.append({"path": relative, "role": role})
+            seen.add(relative)
+
+    for container_name in ("files", "components"):
+        container = config.get(container_name)
+        if not isinstance(container, Mapping):
+            continue
+        for key, value in container.items():
+            role = "weights" if "weight" in str(key) else "engine" if "trt" in str(key) else "model"
+            add(value, role)
+    for filename, role in (
+        ("model.onnx", "model"),
+        ("expert_stack.onnx", "model"),
+        ("vlm_prefix.onnx", "model"),
+        ("expert_denoise.onnx", "model"),
+        ("expert_stack.trt", "engine"),
+    ):
+        add(filename, role)
+    for candidate in sorted(root.rglob("*")):
+        if not candidate.is_file() or candidate.name == CONFIG_FILENAME:
+            continue
+        role: str | None = None
+        if candidate.suffix == ".onnx":
+            role = "model"
+        elif candidate.suffix in {".data", ".bin", ".safetensors"}:
+            role = "weights"
+        elif candidate.suffix in {".trt", ".engine"}:
+            role = "engine"
+        elif "tokenizer" in candidate.name or candidate.name in {
+            "merges.txt",
+            "vocab.json",
+            "special_tokens_map.json",
+        }:
+            role = "tokenizer"
+        if role is not None:
+            add(candidate.resolve().relative_to(root.resolve()).as_posix(), role)
+    return artifacts
+
+
+def _onnx_metadata(
+    root: Path, artifacts: list[dict[str, Any]]
+) -> tuple[int | None, dict[str, list[dict[str, Any]]] | None]:
+    onnx_paths = [root / item["path"] for item in artifacts if str(item["path"]).endswith(".onnx")]
+    if not onnx_paths:
+        return None, None
+    try:
+        import onnx  # type: ignore[import-not-found]
+    except ImportError:
+        return None, None
+
+    opsets: list[int] = []
+    inputs: list[dict[str, Any]] = []
+    outputs: list[dict[str, Any]] = []
+    dtype_names = {
+        1: "float32",
+        2: "uint8",
+        3: "int8",
+        4: "uint16",
+        5: "int16",
+        6: "int32",
+        7: "int64",
+        8: "string",
+        9: "bool",
+        10: "float16",
+        11: "float64",
+    }
+
+    def tensor_descriptor(value: Any) -> dict[str, Any]:
+        tensor_type = value.type.tensor_type
+        dtype = dtype_names.get(int(tensor_type.elem_type))
+        if dtype not in DTYPES:
+            raise ExportConfigError(f"ONNX tensor {value.name!r} uses unsupported dtype")
+        shape: list[int | str | None] = []
+        for dim in tensor_type.shape.dim:
+            if dim.HasField("dim_value"):
+                shape.append(int(dim.dim_value) if int(dim.dim_value) > 0 else None)
+            elif dim.HasField("dim_param") and dim.dim_param:
+                shape.append(str(dim.dim_param))
+            else:
+                shape.append(None)
+        return {"name": value.name, "dtype": dtype, "shape": shape}
+
+    for graph_index, path in enumerate(onnx_paths):
+        model = onnx.load(str(path), load_external_data=False)
+        opsets.extend(int(item.version) for item in model.opset_import if not item.domain)
+        prefix = f"{path.stem}:" if len(onnx_paths) > 1 else ""
+        initializers = {item.name for item in model.graph.initializer}
+        for value in model.graph.input:
+            if value.name not in initializers:
+                desc = tensor_descriptor(value)
+                desc["name"] = prefix + desc["name"]
+                inputs.append(desc)
+        for value in model.graph.output:
+            desc = tensor_descriptor(value)
+            desc["name"] = prefix + desc["name"]
+            outputs.append(desc)
+    return (max(opsets) if opsets else None), {"inputs": inputs, "outputs": outputs}
+
+
+def normalize_legacy_tether_config(payload: Mapping[str, Any], root: str | Path) -> dict[str, Any]:
+    """Normalize a legacy config using only present metadata/artifact inspection."""
+    config = dict(payload)
+    root_path = Path(root)
+    if config.get("schema_version") == SCHEMA_VERSION:
+        return config
+    config["schema_version"] = SCHEMA_VERSION
+    config["export_kind"] = _LEGACY_KINDS.get(config.get("export_kind"), config.get("export_kind"))
+    if not config.get("model_id"):
+        for key in ("checkpoint_path", "checkpoint", "source_model"):
+            if isinstance(config.get(key), str) and config[key]:
+                config["model_id"] = config[key]
+                break
+    if not config.get("model_type") and isinstance(config.get("model_family"), str):
+        config["model_type"] = config["model_family"]
+    if not config.get("action_dim"):
+        expert = config.get("expert")
+        if isinstance(expert, Mapping) and expert.get("action_dim"):
+            config["action_dim"] = expert["action_dim"]
+    if not config.get("num_denoising_steps"):
+        for container_name in ("expert", "decomposed"):
+            container = config.get(container_name)
+            if isinstance(container, Mapping) and container.get("num_denoising_steps"):
+                config["num_denoising_steps"] = container["num_denoising_steps"]
+                break
+    artifacts = config.get("artifacts")
+    if not isinstance(artifacts, list):
+        artifacts = _legacy_artifacts(config, root_path)
+        config["artifacts"] = artifacts
+    if config.get("opset") is None or not isinstance(config.get("io_contract"), Mapping):
+        inspected_opset, inspected_io = _onnx_metadata(root_path, artifacts)
+        if config.get("opset") is None and inspected_opset is not None:
+            config["opset"] = inspected_opset
+        if not isinstance(config.get("io_contract"), Mapping) and inspected_io is not None:
+            config["io_contract"] = inspected_io
+    return config
+
+
+def load_tether_config(
+    path: str | Path,
+    *,
+    inspect_artifacts: bool = True,
+) -> dict[str, Any]:
+    """Load, legacy-normalize, and validate an export config."""
+    requested = Path(path)
+    config_path = requested / CONFIG_FILENAME if requested.is_dir() else requested
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Missing {CONFIG_FILENAME}: {config_path}")
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ExportConfigError(f"Malformed {CONFIG_FILENAME} at {config_path}: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise ExportConfigError(f"{CONFIG_FILENAME} must contain a JSON object")
+    normalized = normalize_legacy_tether_config(payload, config_path.parent)
+    return validate_tether_config(
+        normalized,
+        root=config_path.parent,
+        inspect_artifacts=inspect_artifacts,
+    )
+
+
+def write_tether_config(output_dir: str | Path, payload: Mapping[str, Any]) -> Path:
+    """Validate then atomically write a canonical config."""
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    config = validate_tether_config(payload, root=root, inspect_artifacts=True)
+    target = root / CONFIG_FILENAME
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{CONFIG_FILENAME}.", dir=root)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(config, stream, indent=2, sort_keys=True, ensure_ascii=False)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, target)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    return target
+
+
+def require_supported_export_kind(
+    config: Mapping[str, Any], supported: set[str], operation: str
+) -> str:
+    """Return the canonical kind or raise an explicit unsupported-layout error."""
+    kind = str(config.get("export_kind", ""))
+    if kind not in supported:
+        raise UnsupportedExportKindError(
+            f"{operation} does not support export_kind={kind!r}; supported: {sorted(supported)}"
+        )
+    return kind
+
+
+__all__ = [
+    "ARTIFACT_ROLES",
+    "CONFIG_FILENAME",
+    "DTYPES",
+    "EXPORT_KINDS",
+    "ExportConfigError",
+    "SCHEMA_VERSION",
+    "UnsupportedExportKindError",
+    "load_tether_config",
+    "normalize_legacy_tether_config",
+    "require_supported_export_kind",
+    "validate_tether_config",
+    "write_tether_config",
+]

--- a/src/tether/exporters/decomposed.py
+++ b/src/tether/exporters/decomposed.py
@@ -52,10 +52,10 @@ is invoked here to get the shared denoise-step + cache-freeze patches.
 - Does NOT handle pi0 (the non-.5 variant). pi0 decomposed export is
   a separate future goal (pi0 has state_proj, different suffix shape).
 """
+
 from __future__ import annotations
 
 from concurrent.futures import ProcessPoolExecutor
-import json
 import logging
 import multiprocessing as mp
 import time
@@ -85,7 +85,7 @@ _PI05_VISION_PATCHES_PER_VIEW: int = 256
 # pi0.5 path has historically produced roughly 13 GiB of ONNX/external data.
 # Using that estimate keeps auto on the sequential baseline for most hardware,
 # while still allowing explicit or truly high-VRAM parallel runs.
-_PI05_ESTIMATED_ONNX_BYTES: int = int(13.0 * 1024 ** 3)
+_PI05_ESTIMATED_ONNX_BYTES: int = int(13.0 * 1024**3)
 
 
 def export_pi05_decomposed(
@@ -183,6 +183,7 @@ def _export_pi05_decomposed_sequential(
     # Free the prefix wrapper before building the expert — on A100-80GB we
     # OOM'd with both loaded + a second prefix forward for dummy inputs.
     import gc
+
     gc.collect()
 
     expert_meta = _export_pi05_expert_pass(
@@ -356,6 +357,7 @@ def _load_pi05_policy(
                 f"got num_steps={num_steps}"
             )
         from tether.distill.snapflow_pi0_model import load_snapflow_student
+
         logger.info("[decomposed] Loading SnapFlow student from %s", student_checkpoint)
         policy = load_snapflow_student(student_checkpoint)
         if variant == "state_out":
@@ -364,16 +366,18 @@ def _load_pi05_policy(
             # SnapFlowPI05Pytorch; reset class then upgrade.
             from lerobot.policies.pi05.modeling_pi05 import PI05Pytorch
             from tether.distill.snapflow_pi0_model import enable_snapflow_state_out
+
             policy.model.__class__ = PI05Pytorch
             enable_snapflow_state_out(policy.model)
             logger.info("[decomposed] enabled state-out variant on student")
     else:
         from lerobot.policies.pi05.modeling_pi05 import PI05Policy
+
         logger.info("[decomposed] Loading %s", model_id)
         # Apply the same torch.compile suppression as monolithic export
         # — LIBERO-finetuned pi0.5 configs set compile_model=True.
         _orig_compile = torch.compile
-        torch.compile = lambda fn=None, *a, **kw: (fn if fn is not None else (lambda f: f))
+        torch.compile = lambda fn=None, *a, **kw: fn if fn is not None else (lambda f: f)
         try:
             policy = PI05Policy.from_pretrained(model_id)
         finally:
@@ -427,14 +431,18 @@ def _export_pi05_prefix_pass(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep_prefix = torch.export.export(
-            prefix_wrapper, tuple(prefix_dummy.values()),
-            dynamic_shapes=None, strict=False,
+            prefix_wrapper,
+            tuple(prefix_dummy.values()),
+            dynamic_shapes=None,
+            strict=False,
         )
     logger.info("[decomposed] prefix torch.export: %.1fs", time.time() - t0)
 
     t0 = time.time()
     torch.onnx.export(
-        ep_prefix, tuple(prefix_dummy.values()), str(prefix_path),
+        ep_prefix,
+        tuple(prefix_dummy.values()),
+        str(prefix_path),
         input_names=list(prefix_dummy.keys()),
         output_names=prefix_output_names,
         opset_version=19,
@@ -494,8 +502,7 @@ def _export_pi05_expert_pass(
     # torch.export Dim — deferred until parity is green.)
     past_kv_shape = (B, PI05_KV_HEADS, prefix_seq_len, PI05_HEAD_DIM)
     past_kv_dummies = [
-        torch.randn(past_kv_shape, dtype=torch.float32)
-        for _ in range(PI05_PALIGEMMA_LAYERS * 2)
+        torch.randn(past_kv_shape, dtype=torch.float32) for _ in range(PI05_PALIGEMMA_LAYERS * 2)
     ]
     prefix_pad_masks_dummy = torch.ones(B, prefix_seq_len, dtype=torch.bool)
 
@@ -528,13 +535,17 @@ def _export_pi05_expert_pass(
     expert_path = output_dir / "expert_denoise.onnx"
     shape_label = "per-step" if per_step_expert else f"baked num_steps={num_steps}"
     logger.info(
-        "[decomposed] Exporting expert (%s) → %s", shape_label, expert_path,
+        "[decomposed] Exporting expert (%s) → %s",
+        shape_label,
+        expert_path,
     )
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep_expert = torch.export.export(
-            expert_wrapper, tuple(expert_dummy.values()),
-            dynamic_shapes=None, strict=False,
+            expert_wrapper,
+            tuple(expert_dummy.values()),
+            dynamic_shapes=None,
+            strict=False,
         )
     logger.info("[decomposed] expert torch.export: %.1fs", time.time() - t0)
 
@@ -554,7 +565,9 @@ def _export_pi05_expert_pass(
     # Reproduced + isolated 2026-04-30; see
     # 03_experiments/2026-04-30-per-step-parity-modal-a100.md.
     torch.onnx.export(
-        ep_expert, tuple(expert_dummy.values()), str(expert_path),
+        ep_expert,
+        tuple(expert_dummy.values()),
+        str(expert_path),
         input_names=list(expert_dummy.keys()),
         output_names=output_names,
         opset_version=19,
@@ -602,7 +615,7 @@ def _write_decomposed_export_result(
         "action_chunk_size": chunk_size,
         "action_dim": action_dim,
         "opset": 19,
-        "export_kind": "decomposed",
+        "export_kind": "decomposed_onnx",
         "export_mode": export_mode.value,
         "export_mode_reason": export_mode_reason,
         "decomposed": {
@@ -621,9 +634,12 @@ def _write_decomposed_export_result(
             "per_step_expert": bool(per_step_expert),
         },
     }
-    (output_dir / "tether_config.json").write_text(json.dumps(tether_cfg, indent=2))
+    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+
+    write_tether_config(output_dir, normalize_legacy_tether_config(tether_cfg, output_dir))
     try:
         from tether.verification_report import write_verification_report
+
         write_verification_report(output_dir, parity=None)
     except Exception:
         pass
@@ -679,6 +695,7 @@ class Pi05PrefixWrapper:
     Defined as a lazy class built on first instantiation so we don't
     force lerobot import at module load. See ``_build_prefix_class``.
     """
+
     def __new__(cls, pi05_model):
         impl = _build_prefix_class()
         return impl(pi05_model)
@@ -689,6 +706,7 @@ class Pi05ExpertWrapper:
     + prefix_pad_masks + noise, runs the Euler loop (num_steps iterations;
     1 for SnapFlow students with target_time=1), returns actions.
     """
+
     def __new__(cls, pi05_model, num_steps):
         impl = _build_expert_class()
         return impl(pi05_model, num_steps)
@@ -711,6 +729,7 @@ class Pi05ExpertPerStepWrapper:
     See features/03_export/per-step-expert-export.md for the spec.
     Used when ``export_pi05_decomposed(..., per_step_expert=True)``.
     """
+
     def __new__(cls, pi05_model):
         impl = _build_expert_per_step_class()
         return impl(pi05_model)
@@ -737,15 +756,23 @@ def _build_prefix_class():
 
         def forward(
             self,
-            img_base, img_wrist_l, img_wrist_r,
-            mask_base, mask_wrist_l, mask_wrist_r,
-            lang_tokens, lang_masks,
+            img_base,
+            img_wrist_l,
+            img_wrist_r,
+            mask_base,
+            mask_wrist_l,
+            mask_wrist_r,
+            lang_tokens,
+            lang_masks,
         ):
             images = [img_base, img_wrist_l, img_wrist_r]
             img_masks = [mask_base, mask_wrist_l, mask_wrist_r]
 
             prefix_embs, prefix_pad_masks, prefix_att_masks = self.model.embed_prefix(
-                images, img_masks, lang_tokens, lang_masks,
+                images,
+                img_masks,
+                lang_tokens,
+                lang_masks,
             )
             prefix_att_2d = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
             prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
@@ -817,7 +844,7 @@ def _build_expert_class():
         def forward(self, *args):
             # args layout (default): 36 past_kv tensors + prefix_pad_masks + noise.
             # args layout (state_out): same + state tensor (last position).
-            past_flat = args[:PI05_PALIGEMMA_LAYERS * 2]
+            past_flat = args[: PI05_PALIGEMMA_LAYERS * 2]
             prefix_pad_masks = args[PI05_PALIGEMMA_LAYERS * 2]
             noise = args[PI05_PALIGEMMA_LAYERS * 2 + 1]
             state = args[PI05_PALIGEMMA_LAYERS * 2 + 2] if self._is_state_out else None
@@ -830,6 +857,7 @@ def _build_expert_class():
             # real DynamicCache (isinstance check) so we can't pass a
             # shim.
             from transformers.cache_utils import DynamicCache
+
             past_kv = DynamicCache()
             for i in range(PI05_PALIGEMMA_LAYERS):
                 past_kv.update(
@@ -848,8 +876,10 @@ def _build_expert_class():
             for step in range(self.n_steps):
                 time_val = 1.0 + step * dt
                 time_tensor = torch.full(
-                    (x_t.shape[0],), time_val,
-                    dtype=torch.float32, device=x_t.device,
+                    (x_t.shape[0],),
+                    time_val,
+                    dtype=torch.float32,
+                    device=x_t.device,
                 )
                 # State-out variant: pass state= to denoise_step. Default
                 # path leaves it unset.
@@ -918,7 +948,7 @@ def _build_expert_per_step_class():
         def forward(self, *args):
             # args layout (default):    36 past_kv + prefix_pad_masks + x_t + t.
             # args layout (state_out):  same + state tensor (last position).
-            past_flat = args[:PI05_PALIGEMMA_LAYERS * 2]
+            past_flat = args[: PI05_PALIGEMMA_LAYERS * 2]
             prefix_pad_masks = args[PI05_PALIGEMMA_LAYERS * 2]
             x_t = args[PI05_PALIGEMMA_LAYERS * 2 + 1]
             t = args[PI05_PALIGEMMA_LAYERS * 2 + 2]
@@ -928,6 +958,7 @@ def _build_expert_per_step_class():
             # (see _Pi05ExpertWrapper above) — same source of past_kv, same
             # layer-by-layer .update() pattern. Bit-for-bit equivalent.
             from transformers.cache_utils import DynamicCache
+
             past_kv = DynamicCache()
             for i in range(PI05_PALIGEMMA_LAYERS):
                 past_kv.update(
@@ -976,6 +1007,7 @@ class _FlatCache:
     — the only attributes pi_gemma's forward path reads from past_kv
     under our denoise_step patch.
     """
+
     def __init__(self, flat: tuple, num_layers: int):
         self.key_cache = [flat[2 * i] for i in range(num_layers)]
         self.value_cache = [flat[2 * i + 1] for i in range(num_layers)]
@@ -993,6 +1025,7 @@ class _FlatCache:
 def _require_decomposed_deps() -> None:
     """Decomposed export shares the monolithic ``[monolithic]`` extra."""
     from tether.exporters.monolithic import _require_monolithic_deps
+
     _require_monolithic_deps()
 
 

--- a/src/tether/exporters/decomposed.py
+++ b/src/tether/exporters/decomposed.py
@@ -52,7 +52,6 @@ is invoked here to get the shared denoise-step + cache-freeze patches.
 - Does NOT handle pi0 (the non-.5 variant). pi0 decomposed export is
   a separate future goal (pi0 has state_proj, different suffix shape).
 """
-
 from __future__ import annotations
 
 from concurrent.futures import ProcessPoolExecutor
@@ -85,7 +84,7 @@ _PI05_VISION_PATCHES_PER_VIEW: int = 256
 # pi0.5 path has historically produced roughly 13 GiB of ONNX/external data.
 # Using that estimate keeps auto on the sequential baseline for most hardware,
 # while still allowing explicit or truly high-VRAM parallel runs.
-_PI05_ESTIMATED_ONNX_BYTES: int = int(13.0 * 1024**3)
+_PI05_ESTIMATED_ONNX_BYTES: int = int(13.0 * 1024 ** 3)
 
 
 def export_pi05_decomposed(
@@ -183,7 +182,6 @@ def _export_pi05_decomposed_sequential(
     # Free the prefix wrapper before building the expert — on A100-80GB we
     # OOM'd with both loaded + a second prefix forward for dummy inputs.
     import gc
-
     gc.collect()
 
     expert_meta = _export_pi05_expert_pass(
@@ -357,7 +355,6 @@ def _load_pi05_policy(
                 f"got num_steps={num_steps}"
             )
         from tether.distill.snapflow_pi0_model import load_snapflow_student
-
         logger.info("[decomposed] Loading SnapFlow student from %s", student_checkpoint)
         policy = load_snapflow_student(student_checkpoint)
         if variant == "state_out":
@@ -366,18 +363,16 @@ def _load_pi05_policy(
             # SnapFlowPI05Pytorch; reset class then upgrade.
             from lerobot.policies.pi05.modeling_pi05 import PI05Pytorch
             from tether.distill.snapflow_pi0_model import enable_snapflow_state_out
-
             policy.model.__class__ = PI05Pytorch
             enable_snapflow_state_out(policy.model)
             logger.info("[decomposed] enabled state-out variant on student")
     else:
         from lerobot.policies.pi05.modeling_pi05 import PI05Policy
-
         logger.info("[decomposed] Loading %s", model_id)
         # Apply the same torch.compile suppression as monolithic export
         # — LIBERO-finetuned pi0.5 configs set compile_model=True.
         _orig_compile = torch.compile
-        torch.compile = lambda fn=None, *a, **kw: fn if fn is not None else (lambda f: f)
+        torch.compile = lambda fn=None, *a, **kw: (fn if fn is not None else (lambda f: f))
         try:
             policy = PI05Policy.from_pretrained(model_id)
         finally:
@@ -431,18 +426,14 @@ def _export_pi05_prefix_pass(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep_prefix = torch.export.export(
-            prefix_wrapper,
-            tuple(prefix_dummy.values()),
-            dynamic_shapes=None,
-            strict=False,
+            prefix_wrapper, tuple(prefix_dummy.values()),
+            dynamic_shapes=None, strict=False,
         )
     logger.info("[decomposed] prefix torch.export: %.1fs", time.time() - t0)
 
     t0 = time.time()
     torch.onnx.export(
-        ep_prefix,
-        tuple(prefix_dummy.values()),
-        str(prefix_path),
+        ep_prefix, tuple(prefix_dummy.values()), str(prefix_path),
         input_names=list(prefix_dummy.keys()),
         output_names=prefix_output_names,
         opset_version=19,
@@ -502,7 +493,8 @@ def _export_pi05_expert_pass(
     # torch.export Dim — deferred until parity is green.)
     past_kv_shape = (B, PI05_KV_HEADS, prefix_seq_len, PI05_HEAD_DIM)
     past_kv_dummies = [
-        torch.randn(past_kv_shape, dtype=torch.float32) for _ in range(PI05_PALIGEMMA_LAYERS * 2)
+        torch.randn(past_kv_shape, dtype=torch.float32)
+        for _ in range(PI05_PALIGEMMA_LAYERS * 2)
     ]
     prefix_pad_masks_dummy = torch.ones(B, prefix_seq_len, dtype=torch.bool)
 
@@ -535,17 +527,13 @@ def _export_pi05_expert_pass(
     expert_path = output_dir / "expert_denoise.onnx"
     shape_label = "per-step" if per_step_expert else f"baked num_steps={num_steps}"
     logger.info(
-        "[decomposed] Exporting expert (%s) → %s",
-        shape_label,
-        expert_path,
+        "[decomposed] Exporting expert (%s) → %s", shape_label, expert_path,
     )
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep_expert = torch.export.export(
-            expert_wrapper,
-            tuple(expert_dummy.values()),
-            dynamic_shapes=None,
-            strict=False,
+            expert_wrapper, tuple(expert_dummy.values()),
+            dynamic_shapes=None, strict=False,
         )
     logger.info("[decomposed] expert torch.export: %.1fs", time.time() - t0)
 
@@ -565,9 +553,7 @@ def _export_pi05_expert_pass(
     # Reproduced + isolated 2026-04-30; see
     # 03_experiments/2026-04-30-per-step-parity-modal-a100.md.
     torch.onnx.export(
-        ep_expert,
-        tuple(expert_dummy.values()),
-        str(expert_path),
+        ep_expert, tuple(expert_dummy.values()), str(expert_path),
         input_names=list(expert_dummy.keys()),
         output_names=output_names,
         opset_version=19,
@@ -634,12 +620,23 @@ def _write_decomposed_export_result(
             "per_step_expert": bool(per_step_expert),
         },
     }
-    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+    from tether.export_config import build_producer_config, write_tether_config
 
-    write_tether_config(output_dir, normalize_legacy_tether_config(tether_cfg, output_dir))
+    canonical = build_producer_config(
+        output_dir,
+        producer="pi05_split",
+        model_id=tether_cfg["model_id"],
+        model_type=tether_cfg["model_type"],
+        action_dim=action_dim,
+        num_denoising_steps=num_steps,
+        opset=19,
+        metadata={key: value for key, value in tether_cfg.items() if key not in {
+            "model_id", "model_type", "action_dim", "num_denoising_steps", "opset", "export_kind"
+        }},
+    )
+    write_tether_config(output_dir, canonical)
     try:
         from tether.verification_report import write_verification_report
-
         write_verification_report(output_dir, parity=None)
     except Exception:
         pass
@@ -695,7 +692,6 @@ class Pi05PrefixWrapper:
     Defined as a lazy class built on first instantiation so we don't
     force lerobot import at module load. See ``_build_prefix_class``.
     """
-
     def __new__(cls, pi05_model):
         impl = _build_prefix_class()
         return impl(pi05_model)
@@ -706,7 +702,6 @@ class Pi05ExpertWrapper:
     + prefix_pad_masks + noise, runs the Euler loop (num_steps iterations;
     1 for SnapFlow students with target_time=1), returns actions.
     """
-
     def __new__(cls, pi05_model, num_steps):
         impl = _build_expert_class()
         return impl(pi05_model, num_steps)
@@ -729,7 +724,6 @@ class Pi05ExpertPerStepWrapper:
     See features/03_export/per-step-expert-export.md for the spec.
     Used when ``export_pi05_decomposed(..., per_step_expert=True)``.
     """
-
     def __new__(cls, pi05_model):
         impl = _build_expert_per_step_class()
         return impl(pi05_model)
@@ -756,23 +750,15 @@ def _build_prefix_class():
 
         def forward(
             self,
-            img_base,
-            img_wrist_l,
-            img_wrist_r,
-            mask_base,
-            mask_wrist_l,
-            mask_wrist_r,
-            lang_tokens,
-            lang_masks,
+            img_base, img_wrist_l, img_wrist_r,
+            mask_base, mask_wrist_l, mask_wrist_r,
+            lang_tokens, lang_masks,
         ):
             images = [img_base, img_wrist_l, img_wrist_r]
             img_masks = [mask_base, mask_wrist_l, mask_wrist_r]
 
             prefix_embs, prefix_pad_masks, prefix_att_masks = self.model.embed_prefix(
-                images,
-                img_masks,
-                lang_tokens,
-                lang_masks,
+                images, img_masks, lang_tokens, lang_masks,
             )
             prefix_att_2d = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
             prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
@@ -844,7 +830,7 @@ def _build_expert_class():
         def forward(self, *args):
             # args layout (default): 36 past_kv tensors + prefix_pad_masks + noise.
             # args layout (state_out): same + state tensor (last position).
-            past_flat = args[: PI05_PALIGEMMA_LAYERS * 2]
+            past_flat = args[:PI05_PALIGEMMA_LAYERS * 2]
             prefix_pad_masks = args[PI05_PALIGEMMA_LAYERS * 2]
             noise = args[PI05_PALIGEMMA_LAYERS * 2 + 1]
             state = args[PI05_PALIGEMMA_LAYERS * 2 + 2] if self._is_state_out else None
@@ -857,7 +843,6 @@ def _build_expert_class():
             # real DynamicCache (isinstance check) so we can't pass a
             # shim.
             from transformers.cache_utils import DynamicCache
-
             past_kv = DynamicCache()
             for i in range(PI05_PALIGEMMA_LAYERS):
                 past_kv.update(
@@ -876,10 +861,8 @@ def _build_expert_class():
             for step in range(self.n_steps):
                 time_val = 1.0 + step * dt
                 time_tensor = torch.full(
-                    (x_t.shape[0],),
-                    time_val,
-                    dtype=torch.float32,
-                    device=x_t.device,
+                    (x_t.shape[0],), time_val,
+                    dtype=torch.float32, device=x_t.device,
                 )
                 # State-out variant: pass state= to denoise_step. Default
                 # path leaves it unset.
@@ -948,7 +931,7 @@ def _build_expert_per_step_class():
         def forward(self, *args):
             # args layout (default):    36 past_kv + prefix_pad_masks + x_t + t.
             # args layout (state_out):  same + state tensor (last position).
-            past_flat = args[: PI05_PALIGEMMA_LAYERS * 2]
+            past_flat = args[:PI05_PALIGEMMA_LAYERS * 2]
             prefix_pad_masks = args[PI05_PALIGEMMA_LAYERS * 2]
             x_t = args[PI05_PALIGEMMA_LAYERS * 2 + 1]
             t = args[PI05_PALIGEMMA_LAYERS * 2 + 2]
@@ -958,7 +941,6 @@ def _build_expert_per_step_class():
             # (see _Pi05ExpertWrapper above) — same source of past_kv, same
             # layer-by-layer .update() pattern. Bit-for-bit equivalent.
             from transformers.cache_utils import DynamicCache
-
             past_kv = DynamicCache()
             for i in range(PI05_PALIGEMMA_LAYERS):
                 past_kv.update(
@@ -1007,7 +989,6 @@ class _FlatCache:
     — the only attributes pi_gemma's forward path reads from past_kv
     under our denoise_step patch.
     """
-
     def __init__(self, flat: tuple, num_layers: int):
         self.key_cache = [flat[2 * i] for i in range(num_layers)]
         self.value_cache = [flat[2 * i + 1] for i in range(num_layers)]
@@ -1025,7 +1006,6 @@ class _FlatCache:
 def _require_decomposed_deps() -> None:
     """Decomposed export shares the monolithic ``[monolithic]`` extra."""
     from tether.exporters.monolithic import _require_monolithic_deps
-
     _require_monolithic_deps()
 
 

--- a/src/tether/exporters/dreamzero.py
+++ b/src/tether/exporters/dreamzero.py
@@ -16,7 +16,6 @@ Usage::
         output_dir="./dreamzero_export/",
     )
 """
-
 from __future__ import annotations
 
 import logging
@@ -60,23 +59,14 @@ def export_dreamzero(
     logger.info("DreamZero export — checkpoint=%s, output=%s", checkpoint_path, output_dir)
 
     # Build the tether_config.json (describes the export for `tether serve`)
-    config = {
-        "schema_version": 1,
-        "model_id": str(checkpoint_path),
-        "model_type": "dreamzero",
-        "export_kind": "config_only",
+    metadata = {
         "model_family": "dreamzero",
         "architecture": "world_action_model",
-        "action_dim": action_dim,
         "max_action_dim": max_action_dim,
         "action_horizon": action_horizon,
         "num_frames": num_frames,
         "image_size": image_size,
         "num_inference_steps": 4,
-        "num_denoising_steps": 4,
-        "opset": opset_version,
-        "artifacts": [],
-        "io_contract": {"inputs": [], "outputs": []},
         "components": {
             "vlm_backbone": "wan_backbone",
             "vla_head": "dreamzero_head",
@@ -85,7 +75,18 @@ def export_dreamzero(
         "requires_video_input": True,
     }
 
-    from tether.export_config import write_tether_config
+    from tether.export_config import build_producer_config, write_tether_config
+
+    config = build_producer_config(
+        output_dir,
+        producer="dreamzero",
+        model_id=str(checkpoint_path),
+        model_type="dreamzero",
+        action_dim=action_dim,
+        num_denoising_steps=4,
+        opset=opset_version,
+        metadata=metadata,
+    )
 
     config_path = write_tether_config(output_dir, config)
     logger.info("Wrote tether_config.json")
@@ -121,7 +122,6 @@ def export_dreamzero(
 def validate_dreamzero_registry() -> bool:
     """Check that the DreamZero registry entry resolves."""
     from tether.registry.data import REGISTRY
-
     for entry in REGISTRY:
         if entry.model_id == "pi05-libero10-fluxvla":
             return True

--- a/src/tether/exporters/dreamzero.py
+++ b/src/tether/exporters/dreamzero.py
@@ -16,15 +16,12 @@ Usage::
         output_dir="./dreamzero_export/",
     )
 """
+
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any
-
-import torch
-import torch.nn as nn
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +61,10 @@ def export_dreamzero(
 
     # Build the tether_config.json (describes the export for `tether serve`)
     config = {
+        "schema_version": 1,
+        "model_id": str(checkpoint_path),
+        "model_type": "dreamzero",
+        "export_kind": "config_only",
         "model_family": "dreamzero",
         "architecture": "world_action_model",
         "action_dim": action_dim,
@@ -72,6 +73,10 @@ def export_dreamzero(
         "num_frames": num_frames,
         "image_size": image_size,
         "num_inference_steps": 4,
+        "num_denoising_steps": 4,
+        "opset": opset_version,
+        "artifacts": [],
+        "io_contract": {"inputs": [], "outputs": []},
         "components": {
             "vlm_backbone": "wan_backbone",
             "vla_head": "dreamzero_head",
@@ -80,9 +85,9 @@ def export_dreamzero(
         "requires_video_input": True,
     }
 
-    config_path = output_dir / "tether_config.json"
-    with open(config_path, "w") as f:
-        json.dump(config, f, indent=2)
+    from tether.export_config import write_tether_config
+
+    config_path = write_tether_config(output_dir, config)
     logger.info("Wrote tether_config.json")
 
     result = {
@@ -116,6 +121,7 @@ def export_dreamzero(
 def validate_dreamzero_registry() -> bool:
     """Check that the DreamZero registry entry resolves."""
     from tether.registry.data import REGISTRY
+
     for entry in REGISTRY:
         if entry.model_id == "pi05-libero10-fluxvla":
             return True

--- a/src/tether/exporters/gr00t.py
+++ b/src/tether/exporters/gr00t.py
@@ -17,7 +17,6 @@ lands the export refactor in the same PR as the spine composition.
 
 from __future__ import annotations
 
-import json
 import logging
 import math
 from pathlib import Path
@@ -94,17 +93,27 @@ def export_gr00t(
         try:
             import onnxruntime as ort
             import numpy as np
+
             sess = ort.InferenceSession(str(expert_onnx))
-            ort_out = sess.run(None, {
-                "noisy_actions": dummy_action_tokens.numpy(),
-                "timestep": dummy_time.numpy(),
-                "position_ids": dummy_pos.numpy().astype(np.int64),
-            })[0]
+            ort_out = sess.run(
+                None,
+                {
+                    "noisy_actions": dummy_action_tokens.numpy(),
+                    "timestep": dummy_time.numpy(),
+                    "position_ids": dummy_pos.numpy().astype(np.int64),
+                },
+            )[0]
             torch_out = dit_stack(dummy_action_tokens, dummy_time, dummy_pos).detach().numpy()
             max_diff = float(np.abs(ort_out - torch_out).max())
-            result["metadata"]["onnx_validation"] = {"max_diff": max_diff, "passed": max_diff < 0.01}
-            logger.info("ONNX validation: max_diff=%.2e (%s)",
-                        max_diff, "PASS" if max_diff < 0.01 else "FAIL")
+            result["metadata"]["onnx_validation"] = {
+                "max_diff": max_diff,
+                "passed": max_diff < 0.01,
+            }
+            logger.info(
+                "ONNX validation: max_diff=%.2e (%s)",
+                max_diff,
+                "PASS" if max_diff < 0.01 else "FAIL",
+            )
         except ImportError:
             logger.warning("onnxruntime not installed, skipping validation")
 
@@ -117,20 +126,21 @@ def export_gr00t(
             logger.warning("TRT build failed: %s", e)
 
     meta_with_action_dim = dict(meta)
-    meta_with_action_dim["action_dim"] = hidden
+    meta_with_action_dim["action_dim"] = meta["output_dim"]
     export_config = {
         "model_id": config.model_id,
         "model_type": "gr00t",
+        "export_kind": "decomposed_onnx",
         "target": config.target,
         "precision": config.precision,
         "opset": config.opset,
         "num_denoising_steps": 4,
         "action_chunk_size": chunk_size,
-        "action_dim": hidden,
+        "action_dim": meta["output_dim"],
         "hidden": hidden,
         "output_dim": meta["output_dim"],
         "note": "expert accepts action tokens (hidden-dim), emits velocity tokens (output_dim). "
-                "action_decoder (per-embodiment) needed downstream to recover native actions.",
+        "action_decoder (per-embodiment) needed downstream to recover native actions.",
         "hardware": {
             "name": hardware.name,
             "memory_gb": hardware.memory_gb,
@@ -140,8 +150,11 @@ def export_gr00t(
         "expert": meta_with_action_dim,
         "spine_path": True,
     }
-    config_path = output_dir / "tether_config.json"
-    config_path.write_text(json.dumps(export_config, indent=2))
+    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+
+    config_path = write_tether_config(
+        output_dir, normalize_legacy_tether_config(export_config, output_dir)
+    )
     result["files"]["config"] = str(config_path)
     return result
 
@@ -201,17 +214,27 @@ def export_gr00t_full(
         try:
             import onnxruntime as ort
             import numpy as np
+
             sess = ort.InferenceSession(str(expert_onnx))
-            ort_out = sess.run(None, {
-                "noisy_actions": dummy_actions.numpy(),
-                "timestep": dummy_time.numpy(),
-                "position_ids": dummy_pos.numpy().astype(np.int64),
-            })[0]
+            ort_out = sess.run(
+                None,
+                {
+                    "noisy_actions": dummy_actions.numpy(),
+                    "timestep": dummy_time.numpy(),
+                    "position_ids": dummy_pos.numpy().astype(np.int64),
+                },
+            )[0]
             torch_out = full(dummy_actions, dummy_time, dummy_pos).detach().numpy()
             max_diff = float(np.abs(ort_out - torch_out).max())
-            result["metadata"]["onnx_validation"] = {"max_diff": max_diff, "passed": max_diff < 0.01}
-            logger.info("ONNX validation: max_diff=%.2e (%s)",
-                        max_diff, "PASS" if max_diff < 0.01 else "FAIL")
+            result["metadata"]["onnx_validation"] = {
+                "max_diff": max_diff,
+                "passed": max_diff < 0.01,
+            }
+            logger.info(
+                "ONNX validation: max_diff=%.2e (%s)",
+                max_diff,
+                "PASS" if max_diff < 0.01 else "FAIL",
+            )
         except ImportError:
             logger.warning("onnxruntime not installed, skipping validation")
 
@@ -228,6 +251,7 @@ def export_gr00t_full(
     export_config = {
         "model_id": config.model_id,
         "model_type": "gr00t",
+        "export_kind": "decomposed_onnx",
         "full_stack": True,
         "embodiment_id": embodiment_id,
         "target": config.target,
@@ -247,8 +271,11 @@ def export_gr00t_full(
         "expert": meta_with_action_dim,
         "spine_path": True,
     }
-    config_path = output_dir / "tether_config.json"
-    config_path.write_text(json.dumps(export_config, indent=2))
+    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+
+    config_path = write_tether_config(
+        output_dir, normalize_legacy_tether_config(export_config, output_dir)
+    )
     result["files"]["config"] = str(config_path)
     return result
 
@@ -276,7 +303,6 @@ __all__ = [
 # preserved verbatim; the only change is the home address. Per the lift #1
 # plan, the spine is now the single source of truth for these classes.
 # ════════════════════════════════════════════════════════════════════════
-
 
 
 GR00T_BLOCK_PREFIX = "action_head.model.transformer_blocks."
@@ -323,6 +349,7 @@ def _sinusoidal_timestep(t: torch.Tensor, dim: int = 256) -> torch.Tensor:
     args = t.float().unsqueeze(-1) * freqs.unsqueeze(0)
     return torch.cat([torch.cos(args), torch.sin(args)], dim=-1).to(t.dtype)
 
+
 class GR00TDiTBlock(nn.Module):
     """One DiT block: AdaLN → (cross-attn or self-attn) → residual →
     LayerNorm(non-affine) → GEGLU-FF → residual.
@@ -331,8 +358,9 @@ class GR00TDiTBlock(nn.Module):
     self-attn blocks always use kv_in == hidden.
     """
 
-    def __init__(self, hidden: int, num_heads: int, head_dim: int, ff_inner: int,
-                 kv_in: int, is_cross: bool):
+    def __init__(
+        self, hidden: int, num_heads: int, head_dim: int, ff_inner: int, kv_in: int, is_cross: bool
+    ):
         super().__init__()
         self.hidden = hidden
         self.num_heads = num_heads
@@ -352,8 +380,9 @@ class GR00TDiTBlock(nn.Module):
         self.ff_net_0_proj = nn.Linear(hidden, ff_inner, bias=True)
         self.ff_net_2 = nn.Linear(ff_inner, hidden, bias=True)
 
-    def forward(self, x: torch.Tensor, temb: torch.Tensor,
-                encoder_kv: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, temb: torch.Tensor, encoder_kv: torch.Tensor | None = None
+    ) -> torch.Tensor:
         b, s, _ = x.shape
 
         # AdaLN pre-attn modulation
@@ -378,9 +407,7 @@ class GR00TDiTBlock(nn.Module):
         k = k.view(b, seq_kv, self.num_heads, self.head_dim).transpose(1, 2)
         v = v.view(b, seq_kv, self.num_heads, self.head_dim).transpose(1, 2)
 
-        attn = F.softmax(
-            torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.head_dim), dim=-1
-        )
+        attn = F.softmax(torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.head_dim), dim=-1)
         attn_out = torch.matmul(attn, v).transpose(1, 2).contiguous().view(b, s, -1)
         x = x + self.to_out_0(attn_out)
 
@@ -407,13 +434,17 @@ class GR00TExpertStack(nn.Module):
     emit velocities in the same space via the per-embodiment encoder/decoder.
     """
 
-    def __init__(self, blocks: list[GR00TDiTBlock], hidden: int,
-                 pos_embed_weight: torch.Tensor,
-                 timestep_mlp_weights: dict,
-                 proj_out_weights: dict,
-                 vlln_weights: dict,
-                 vlm_kv_dim: int = 2048,
-                 output_dim: int = 1024):
+    def __init__(
+        self,
+        blocks: list[GR00TDiTBlock],
+        hidden: int,
+        pos_embed_weight: torch.Tensor,
+        timestep_mlp_weights: dict,
+        proj_out_weights: dict,
+        vlln_weights: dict,
+        vlm_kv_dim: int = 2048,
+        output_dim: int = 1024,
+    ):
         super().__init__()
         self.blocks = nn.ModuleList(blocks)
         self.hidden = hidden
@@ -425,10 +456,14 @@ class GR00TExpertStack(nn.Module):
         # Timestep MLP (256-dim sinusoidal → linear_1 → silu → linear_2)
         self.sinusoidal_dim = timestep_mlp_weights["in_dim"]
         self.timestep_linear_1 = nn.Linear(
-            timestep_mlp_weights["in_dim"], timestep_mlp_weights["mid_dim"], bias=True,
+            timestep_mlp_weights["in_dim"],
+            timestep_mlp_weights["mid_dim"],
+            bias=True,
         )
         self.timestep_linear_2 = nn.Linear(
-            timestep_mlp_weights["mid_dim"], hidden, bias=True,
+            timestep_mlp_weights["mid_dim"],
+            hidden,
+            bias=True,
         )
         self.timestep_linear_1.weight = nn.Parameter(timestep_mlp_weights["l1_w"])
         self.timestep_linear_1.bias = nn.Parameter(timestep_mlp_weights["l1_b"])
@@ -449,10 +484,14 @@ class GR00TExpertStack(nn.Module):
         self.vlln.weight = nn.Parameter(vlln_weights["w"])
         self.vlln.bias = nn.Parameter(vlln_weights["b"])
 
-    def forward(self, action_tokens: torch.Tensor, timestep: torch.Tensor,
-                position_ids: torch.Tensor,
-                vlm_kv: torch.Tensor | None = None,
-                add_pos_embed: bool = True) -> torch.Tensor:
+    def forward(
+        self,
+        action_tokens: torch.Tensor,
+        timestep: torch.Tensor,
+        position_ids: torch.Tensor,
+        vlm_kv: torch.Tensor | None = None,
+        add_pos_embed: bool = True,
+    ) -> torch.Tensor:
         b, s, _ = action_tokens.shape
 
         # Add position embeddings when caller hasn't pre-added them.
@@ -491,6 +530,8 @@ class GR00TExpertStack(nn.Module):
 
         # Output projection
         return self.proj_out_2(x)
+
+
 def build_gr00t_expert_stack(
     state_dict: dict[str, torch.Tensor],
     embodiment_id: int = 0,
@@ -508,7 +549,7 @@ def build_gr00t_expert_stack(
     for k in state_dict.keys():
         if not k.startswith(GR00T_BLOCK_PREFIX):
             continue
-        rest = k[len(GR00T_BLOCK_PREFIX):]
+        rest = k[len(GR00T_BLOCK_PREFIX) :]
         parts = rest.split(".")
         if parts and parts[0].isdigit():
             layer_indices.add(int(parts[0]))
@@ -519,16 +560,13 @@ def build_gr00t_expert_stack(
     # 2. Infer shapes from block 0
     q_w = state_dict[f"{GR00T_BLOCK_PREFIX}0.attn1.to_q.weight"]
     hidden = q_w.shape[1]  # input dim of to_q = hidden
-    num_q = q_w.shape[0]   # output = num_heads * head_dim
+    num_q = q_w.shape[0]  # output = num_heads * head_dim
 
     # Block 0 is a cross-attn block (even idx); its to_k kv_in reveals vlm_kv_dim
     k_w_0 = state_dict[f"{GR00T_BLOCK_PREFIX}0.attn1.to_k.weight"]
     vlm_kv_dim = k_w_0.shape[1]  # for cross-attn block
 
     # Block 1 is self-attn (odd idx); kv_in == hidden
-    k_w_1 = state_dict[f"{GR00T_BLOCK_PREFIX}1.attn1.to_k.weight"]
-    self_kv_in = k_w_1.shape[1]
-
     # Infer num_heads by factoring num_q; head_dim=48 is the convention from config
     head_dim = 48
     num_heads = num_q // head_dim
@@ -545,13 +583,18 @@ def build_gr00t_expert_stack(
 
     logger.info(
         "GR00T DiT: %d blocks, hidden=%d, heads=%d × hd=%d, ff_inner=%d, vlm_kv_dim=%d",
-        num_layers, hidden, num_heads, head_dim, ff_inner, vlm_kv_dim,
+        num_layers,
+        hidden,
+        num_heads,
+        head_dim,
+        ff_inner,
+        vlm_kv_dim,
     )
 
     # 3. Build blocks with proper kv_in per block
     blocks = []
     for i in range(num_layers):
-        is_cross = (i % 2 == 0)  # even = cross-attn
+        is_cross = i % 2 == 0  # even = cross-attn
         kv_in = vlm_kv_dim if is_cross else hidden
         block = GR00TDiTBlock(hidden, num_heads, head_dim, ff_inner, kv_in, is_cross)
         prefix = f"{GR00T_BLOCK_PREFIX}{i}"
@@ -637,6 +680,8 @@ def build_gr00t_expert_stack(
         "total_params_m": sum(p.numel() for p in stack.parameters()) / 1e6,
     }
     return stack, metadata
+
+
 class GR00TActionEncoder(nn.Module):
     """3-linear action token encoder, pinned to one embodiment.
 
@@ -649,8 +694,7 @@ class GR00TActionEncoder(nn.Module):
     F.linear needs transpose at call time.
     """
 
-    def __init__(self, raw_action_dim: int, hidden: int, weights: dict,
-                 embodiment_id: int = 0):
+    def __init__(self, raw_action_dim: int, hidden: int, weights: dict, embodiment_id: int = 0):
         super().__init__()
         self.raw_action_dim = raw_action_dim
         self.hidden = hidden
@@ -670,10 +714,10 @@ class GR00TActionEncoder(nn.Module):
         h1 = F.silu(F.linear(actions, self.W1_w, self.W1_b))  # [b, chunk, hidden]
 
         t = time_emb.unsqueeze(1).expand(-1, chunk, -1)  # [b, chunk, hidden]
-        cat = torch.cat([h1, t], dim=-1)                 # [b, chunk, 2*hidden]
-        h2 = F.silu(F.linear(cat, self.W2_w, self.W2_b)) # [b, chunk, hidden]
+        cat = torch.cat([h1, t], dim=-1)  # [b, chunk, 2*hidden]
+        h2 = F.silu(F.linear(cat, self.W2_w, self.W2_b))  # [b, chunk, hidden]
 
-        out = F.linear(h2 + h1, self.W3_w, self.W3_b)    # residual + projection
+        out = F.linear(h2 + h1, self.W3_w, self.W3_b)  # residual + projection
         return out
 
 
@@ -695,8 +739,14 @@ class GR00TStateEncoder(nn.Module):
     with no state awareness. This class closes that gap.
     """
 
-    def __init__(self, raw_state_dim: int, hidden_mid: int, hidden_out: int,
-                 weights: dict, embodiment_id: int = 0):
+    def __init__(
+        self,
+        raw_state_dim: int,
+        hidden_mid: int,
+        hidden_out: int,
+        weights: dict,
+        embodiment_id: int = 0,
+    ):
         super().__init__()
         self.raw_state_dim = raw_state_dim
         self.hidden_mid = hidden_mid
@@ -711,7 +761,7 @@ class GR00TStateEncoder(nn.Module):
     def forward(self, state: torch.Tensor) -> torch.Tensor:
         # state: [b, raw_state_dim] → state_token [b, 1, hidden_out]
         h = F.silu(F.linear(state, self.L1_w, self.L1_b))  # [b, hidden_mid]
-        out = F.linear(h, self.L2_w, self.L2_b)            # [b, hidden_out]
+        out = F.linear(h, self.L2_w, self.L2_b)  # [b, hidden_out]
         return out.unsqueeze(1)  # [b, 1, hidden_out] — one state token
 
 
@@ -723,8 +773,7 @@ class GR00TActionDecoder(nn.Module):
         layer2.W [32, 1024, 128]   -- final → raw action dim
     """
 
-    def __init__(self, in_dim: int, raw_action_dim: int, weights: dict,
-                 embodiment_id: int = 0):
+    def __init__(self, in_dim: int, raw_action_dim: int, weights: dict, embodiment_id: int = 0):
         super().__init__()
         self.in_dim = in_dim
         self.raw_action_dim = raw_action_dim
@@ -737,7 +786,7 @@ class GR00TActionDecoder(nn.Module):
     def forward(self, tokens: torch.Tensor) -> torch.Tensor:
         # tokens: [b, chunk, in_dim=1024]
         h = F.silu(F.linear(tokens, self.L1_w, self.L1_b))  # [b, chunk, 1024]
-        return F.linear(h, self.L2_w, self.L2_b)            # [b, chunk, raw_action_dim]
+        return F.linear(h, self.L2_w, self.L2_b)  # [b, chunk, raw_action_dim]
 
 
 class GR00TFullStack(nn.Module):
@@ -792,7 +841,7 @@ class GR00TFullStack(nn.Module):
             action_pos = self.dit.pos_embed[action_pos_ids].unsqueeze(0)
             action_tokens = action_tokens + action_pos
 
-            state_token = self.state_encoder(state)                  # [b, 1, 1536]
+            state_token = self.state_encoder(state)  # [b, 1, 1536]
             tokens = torch.cat([state_token, action_tokens], dim=1)  # [b, chunk+1, 1536]
             action_start = 1
             # Pass a position_ids tensor that — combined with the DiT's
@@ -813,7 +862,10 @@ class GR00TFullStack(nn.Module):
             # Skip DiT's internal pos_embed by passing `add_pos_embed=False`.
             # (The DiT.forward signature was extended to accept this flag.)
             velocity_tokens = self.dit(
-                tokens, timestep, position_ids, vlm_kv=vlm_kv,
+                tokens,
+                timestep,
+                position_ids,
+                vlm_kv=vlm_kv,
                 add_pos_embed=False,
             )
 
@@ -821,8 +873,10 @@ class GR00TFullStack(nn.Module):
         if action_start > 0:
             velocity_tokens = velocity_tokens[:, action_start:, :]
 
-        velocity_raw = self.action_decoder(velocity_tokens)    # [b, chunk, raw_action_dim]
+        velocity_raw = self.action_decoder(velocity_tokens)  # [b, chunk, raw_action_dim]
         return velocity_raw
+
+
 def build_gr00t_full_stack(
     state_dict: dict[str, torch.Tensor],
     embodiment_id: int = 0,
@@ -839,7 +893,7 @@ def build_gr00t_full_stack(
         "W3_W": state_dict[GR00T_META_KEYS["action_enc_W3_W"]].float(),
         "W3_b": state_dict[GR00T_META_KEYS["action_enc_W3_b"]].float(),
     }
-    raw_action_dim = enc_weights["W1_W"].shape[1]   # [32, 128, 1536] → 128
+    raw_action_dim = enc_weights["W1_W"].shape[1]  # [32, 128, 1536] → 128
     hidden = enc_weights["W1_W"].shape[2]
 
     action_encoder = GR00TActionEncoder(
@@ -856,7 +910,7 @@ def build_gr00t_full_stack(
         "L2_W": state_dict[GR00T_META_KEYS["action_dec_2_W"]].float(),
         "L2_b": state_dict[GR00T_META_KEYS["action_dec_2_b"]].float(),
     }
-    output_token_dim = dec_weights["L1_W"].shape[1]   # [32, 1024, 1024] → 1024
+    output_token_dim = dec_weights["L1_W"].shape[1]  # [32, 1024, 1024] → 1024
 
     action_decoder = GR00TActionDecoder(
         in_dim=output_token_dim,
@@ -876,7 +930,7 @@ def build_gr00t_full_stack(
             "L2_W": state_dict[GR00T_META_KEYS["state_enc_2_W"]].float(),
             "L2_b": state_dict[GR00T_META_KEYS["state_enc_2_b"]].float(),
         }
-        raw_state_dim = state_enc_weights["L1_W"].shape[1]    # (32, 128, 1024) → 128
+        raw_state_dim = state_enc_weights["L1_W"].shape[1]  # (32, 128, 1024) → 128
         state_hidden_mid = state_enc_weights["L1_W"].shape[2]  # → 1024
         state_hidden_out = state_enc_weights["L2_W"].shape[2]  # (32, 1024, 1536) → 1536
         state_encoder = GR00TStateEncoder(
@@ -890,8 +944,7 @@ def build_gr00t_full_stack(
         raw_state_dim = None
         state_hidden_out = None
 
-    full = GR00TFullStack(dit, action_encoder, action_decoder,
-                           state_encoder=state_encoder)
+    full = GR00TFullStack(dit, action_encoder, action_decoder, state_encoder=state_encoder)
     full = full.float()
     full.eval()
 

--- a/src/tether/exporters/gr00t.py
+++ b/src/tether/exporters/gr00t.py
@@ -35,6 +35,18 @@ from tether.exporters.trt_build import build_engine, check_trtexec
 logger = logging.getLogger(__name__)
 
 
+def _raw_action_dim_from_checkpoint(
+    state_dict: dict[str, torch.Tensor], embodiment_id: int = 0
+) -> int:
+    """Derive neutral robot action width from the checkpoint action encoder."""
+    weights = state_dict[GR00T_META_KEYS["action_enc_W1_W"]]
+    if weights.ndim != 3 or embodiment_id < 0 or embodiment_id >= weights.shape[0]:
+        raise ValueError(
+            "GR00T action encoder W1 must have shape [embodiment, raw_action_dim, hidden]"
+        )
+    return int(weights.shape[1])
+
+
 def export_gr00t(
     config: ExportConfig,
     state_dict: dict[str, torch.Tensor] | None = None,
@@ -93,27 +105,17 @@ def export_gr00t(
         try:
             import onnxruntime as ort
             import numpy as np
-
             sess = ort.InferenceSession(str(expert_onnx))
-            ort_out = sess.run(
-                None,
-                {
-                    "noisy_actions": dummy_action_tokens.numpy(),
-                    "timestep": dummy_time.numpy(),
-                    "position_ids": dummy_pos.numpy().astype(np.int64),
-                },
-            )[0]
+            ort_out = sess.run(None, {
+                "noisy_actions": dummy_action_tokens.numpy(),
+                "timestep": dummy_time.numpy(),
+                "position_ids": dummy_pos.numpy().astype(np.int64),
+            })[0]
             torch_out = dit_stack(dummy_action_tokens, dummy_time, dummy_pos).detach().numpy()
             max_diff = float(np.abs(ort_out - torch_out).max())
-            result["metadata"]["onnx_validation"] = {
-                "max_diff": max_diff,
-                "passed": max_diff < 0.01,
-            }
-            logger.info(
-                "ONNX validation: max_diff=%.2e (%s)",
-                max_diff,
-                "PASS" if max_diff < 0.01 else "FAIL",
-            )
+            result["metadata"]["onnx_validation"] = {"max_diff": max_diff, "passed": max_diff < 0.01}
+            logger.info("ONNX validation: max_diff=%.2e (%s)",
+                        max_diff, "PASS" if max_diff < 0.01 else "FAIL")
         except ImportError:
             logger.warning("onnxruntime not installed, skipping validation")
 
@@ -125,8 +127,9 @@ def export_gr00t(
         except RuntimeError as e:
             logger.warning("TRT build failed: %s", e)
 
+    raw_action_dim = _raw_action_dim_from_checkpoint(state_dict)
     meta_with_action_dim = dict(meta)
-    meta_with_action_dim["action_dim"] = meta["output_dim"]
+    meta_with_action_dim["action_dim"] = raw_action_dim
     export_config = {
         "model_id": config.model_id,
         "model_type": "gr00t",
@@ -136,11 +139,12 @@ def export_gr00t(
         "opset": config.opset,
         "num_denoising_steps": 4,
         "action_chunk_size": chunk_size,
-        "action_dim": meta["output_dim"],
+        "action_dim": raw_action_dim,
         "hidden": hidden,
         "output_dim": meta["output_dim"],
+        "pipeline": "gr00t_token_expert",
         "note": "expert accepts action tokens (hidden-dim), emits velocity tokens (output_dim). "
-        "action_decoder (per-embodiment) needed downstream to recover native actions.",
+                "action_decoder (per-embodiment) needed downstream to recover native actions.",
         "hardware": {
             "name": hardware.name,
             "memory_gb": hardware.memory_gb,
@@ -150,11 +154,29 @@ def export_gr00t(
         "expert": meta_with_action_dim,
         "spine_path": True,
     }
-    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+    from tether.export_config import build_producer_config, write_tether_config
 
-    config_path = write_tether_config(
-        output_dir, normalize_legacy_tether_config(export_config, output_dir)
+    optional_artifacts = []
+    if "expert_trt" in result["files"]:
+        optional_artifacts.append(("expert_stack.trt", "engine"))
+    canonical = build_producer_config(
+        output_dir,
+        producer="expert_stack",
+        model_id=config.model_id,
+        model_type="gr00t",
+        action_dim=raw_action_dim,
+        num_denoising_steps=4,
+        opset=config.opset,
+        optional_artifacts=optional_artifacts,
+        metadata={
+            **export_config,
+            "extensions": {
+                "token_input_dim": hidden,
+                "token_output_dim": meta["output_dim"],
+            },
+        },
     )
+    config_path = write_tether_config(output_dir, canonical)
     result["files"]["config"] = str(config_path)
     return result
 
@@ -214,27 +236,17 @@ def export_gr00t_full(
         try:
             import onnxruntime as ort
             import numpy as np
-
             sess = ort.InferenceSession(str(expert_onnx))
-            ort_out = sess.run(
-                None,
-                {
-                    "noisy_actions": dummy_actions.numpy(),
-                    "timestep": dummy_time.numpy(),
-                    "position_ids": dummy_pos.numpy().astype(np.int64),
-                },
-            )[0]
+            ort_out = sess.run(None, {
+                "noisy_actions": dummy_actions.numpy(),
+                "timestep": dummy_time.numpy(),
+                "position_ids": dummy_pos.numpy().astype(np.int64),
+            })[0]
             torch_out = full(dummy_actions, dummy_time, dummy_pos).detach().numpy()
             max_diff = float(np.abs(ort_out - torch_out).max())
-            result["metadata"]["onnx_validation"] = {
-                "max_diff": max_diff,
-                "passed": max_diff < 0.01,
-            }
-            logger.info(
-                "ONNX validation: max_diff=%.2e (%s)",
-                max_diff,
-                "PASS" if max_diff < 0.01 else "FAIL",
-            )
+            result["metadata"]["onnx_validation"] = {"max_diff": max_diff, "passed": max_diff < 0.01}
+            logger.info("ONNX validation: max_diff=%.2e (%s)",
+                        max_diff, "PASS" if max_diff < 0.01 else "FAIL")
         except ImportError:
             logger.warning("onnxruntime not installed, skipping validation")
 
@@ -271,11 +283,23 @@ def export_gr00t_full(
         "expert": meta_with_action_dim,
         "spine_path": True,
     }
-    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+    from tether.export_config import build_producer_config, write_tether_config
 
-    config_path = write_tether_config(
-        output_dir, normalize_legacy_tether_config(export_config, output_dir)
+    optional_artifacts = []
+    if "expert_trt" in result["files"]:
+        optional_artifacts.append(("expert_stack.trt", "engine"))
+    canonical = build_producer_config(
+        output_dir,
+        producer="expert_stack",
+        model_id=config.model_id,
+        model_type="gr00t",
+        action_dim=raw_action_dim,
+        num_denoising_steps=4,
+        opset=config.opset,
+        optional_artifacts=optional_artifacts,
+        metadata=export_config,
     )
+    config_path = write_tether_config(output_dir, canonical)
     result["files"]["config"] = str(config_path)
     return result
 
@@ -303,6 +327,7 @@ __all__ = [
 # preserved verbatim; the only change is the home address. Per the lift #1
 # plan, the spine is now the single source of truth for these classes.
 # ════════════════════════════════════════════════════════════════════════
+
 
 
 GR00T_BLOCK_PREFIX = "action_head.model.transformer_blocks."
@@ -349,7 +374,6 @@ def _sinusoidal_timestep(t: torch.Tensor, dim: int = 256) -> torch.Tensor:
     args = t.float().unsqueeze(-1) * freqs.unsqueeze(0)
     return torch.cat([torch.cos(args), torch.sin(args)], dim=-1).to(t.dtype)
 
-
 class GR00TDiTBlock(nn.Module):
     """One DiT block: AdaLN → (cross-attn or self-attn) → residual →
     LayerNorm(non-affine) → GEGLU-FF → residual.
@@ -358,9 +382,8 @@ class GR00TDiTBlock(nn.Module):
     self-attn blocks always use kv_in == hidden.
     """
 
-    def __init__(
-        self, hidden: int, num_heads: int, head_dim: int, ff_inner: int, kv_in: int, is_cross: bool
-    ):
+    def __init__(self, hidden: int, num_heads: int, head_dim: int, ff_inner: int,
+                 kv_in: int, is_cross: bool):
         super().__init__()
         self.hidden = hidden
         self.num_heads = num_heads
@@ -380,9 +403,8 @@ class GR00TDiTBlock(nn.Module):
         self.ff_net_0_proj = nn.Linear(hidden, ff_inner, bias=True)
         self.ff_net_2 = nn.Linear(ff_inner, hidden, bias=True)
 
-    def forward(
-        self, x: torch.Tensor, temb: torch.Tensor, encoder_kv: torch.Tensor | None = None
-    ) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, temb: torch.Tensor,
+                encoder_kv: torch.Tensor | None = None) -> torch.Tensor:
         b, s, _ = x.shape
 
         # AdaLN pre-attn modulation
@@ -407,7 +429,9 @@ class GR00TDiTBlock(nn.Module):
         k = k.view(b, seq_kv, self.num_heads, self.head_dim).transpose(1, 2)
         v = v.view(b, seq_kv, self.num_heads, self.head_dim).transpose(1, 2)
 
-        attn = F.softmax(torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.head_dim), dim=-1)
+        attn = F.softmax(
+            torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.head_dim), dim=-1
+        )
         attn_out = torch.matmul(attn, v).transpose(1, 2).contiguous().view(b, s, -1)
         x = x + self.to_out_0(attn_out)
 
@@ -434,17 +458,13 @@ class GR00TExpertStack(nn.Module):
     emit velocities in the same space via the per-embodiment encoder/decoder.
     """
 
-    def __init__(
-        self,
-        blocks: list[GR00TDiTBlock],
-        hidden: int,
-        pos_embed_weight: torch.Tensor,
-        timestep_mlp_weights: dict,
-        proj_out_weights: dict,
-        vlln_weights: dict,
-        vlm_kv_dim: int = 2048,
-        output_dim: int = 1024,
-    ):
+    def __init__(self, blocks: list[GR00TDiTBlock], hidden: int,
+                 pos_embed_weight: torch.Tensor,
+                 timestep_mlp_weights: dict,
+                 proj_out_weights: dict,
+                 vlln_weights: dict,
+                 vlm_kv_dim: int = 2048,
+                 output_dim: int = 1024):
         super().__init__()
         self.blocks = nn.ModuleList(blocks)
         self.hidden = hidden
@@ -456,14 +476,10 @@ class GR00TExpertStack(nn.Module):
         # Timestep MLP (256-dim sinusoidal → linear_1 → silu → linear_2)
         self.sinusoidal_dim = timestep_mlp_weights["in_dim"]
         self.timestep_linear_1 = nn.Linear(
-            timestep_mlp_weights["in_dim"],
-            timestep_mlp_weights["mid_dim"],
-            bias=True,
+            timestep_mlp_weights["in_dim"], timestep_mlp_weights["mid_dim"], bias=True,
         )
         self.timestep_linear_2 = nn.Linear(
-            timestep_mlp_weights["mid_dim"],
-            hidden,
-            bias=True,
+            timestep_mlp_weights["mid_dim"], hidden, bias=True,
         )
         self.timestep_linear_1.weight = nn.Parameter(timestep_mlp_weights["l1_w"])
         self.timestep_linear_1.bias = nn.Parameter(timestep_mlp_weights["l1_b"])
@@ -484,14 +500,10 @@ class GR00TExpertStack(nn.Module):
         self.vlln.weight = nn.Parameter(vlln_weights["w"])
         self.vlln.bias = nn.Parameter(vlln_weights["b"])
 
-    def forward(
-        self,
-        action_tokens: torch.Tensor,
-        timestep: torch.Tensor,
-        position_ids: torch.Tensor,
-        vlm_kv: torch.Tensor | None = None,
-        add_pos_embed: bool = True,
-    ) -> torch.Tensor:
+    def forward(self, action_tokens: torch.Tensor, timestep: torch.Tensor,
+                position_ids: torch.Tensor,
+                vlm_kv: torch.Tensor | None = None,
+                add_pos_embed: bool = True) -> torch.Tensor:
         b, s, _ = action_tokens.shape
 
         # Add position embeddings when caller hasn't pre-added them.
@@ -530,8 +542,6 @@ class GR00TExpertStack(nn.Module):
 
         # Output projection
         return self.proj_out_2(x)
-
-
 def build_gr00t_expert_stack(
     state_dict: dict[str, torch.Tensor],
     embodiment_id: int = 0,
@@ -549,7 +559,7 @@ def build_gr00t_expert_stack(
     for k in state_dict.keys():
         if not k.startswith(GR00T_BLOCK_PREFIX):
             continue
-        rest = k[len(GR00T_BLOCK_PREFIX) :]
+        rest = k[len(GR00T_BLOCK_PREFIX):]
         parts = rest.split(".")
         if parts and parts[0].isdigit():
             layer_indices.add(int(parts[0]))
@@ -560,7 +570,7 @@ def build_gr00t_expert_stack(
     # 2. Infer shapes from block 0
     q_w = state_dict[f"{GR00T_BLOCK_PREFIX}0.attn1.to_q.weight"]
     hidden = q_w.shape[1]  # input dim of to_q = hidden
-    num_q = q_w.shape[0]  # output = num_heads * head_dim
+    num_q = q_w.shape[0]   # output = num_heads * head_dim
 
     # Block 0 is a cross-attn block (even idx); its to_k kv_in reveals vlm_kv_dim
     k_w_0 = state_dict[f"{GR00T_BLOCK_PREFIX}0.attn1.to_k.weight"]
@@ -583,18 +593,13 @@ def build_gr00t_expert_stack(
 
     logger.info(
         "GR00T DiT: %d blocks, hidden=%d, heads=%d × hd=%d, ff_inner=%d, vlm_kv_dim=%d",
-        num_layers,
-        hidden,
-        num_heads,
-        head_dim,
-        ff_inner,
-        vlm_kv_dim,
+        num_layers, hidden, num_heads, head_dim, ff_inner, vlm_kv_dim,
     )
 
     # 3. Build blocks with proper kv_in per block
     blocks = []
     for i in range(num_layers):
-        is_cross = i % 2 == 0  # even = cross-attn
+        is_cross = (i % 2 == 0)  # even = cross-attn
         kv_in = vlm_kv_dim if is_cross else hidden
         block = GR00TDiTBlock(hidden, num_heads, head_dim, ff_inner, kv_in, is_cross)
         prefix = f"{GR00T_BLOCK_PREFIX}{i}"
@@ -680,8 +685,6 @@ def build_gr00t_expert_stack(
         "total_params_m": sum(p.numel() for p in stack.parameters()) / 1e6,
     }
     return stack, metadata
-
-
 class GR00TActionEncoder(nn.Module):
     """3-linear action token encoder, pinned to one embodiment.
 
@@ -694,7 +697,8 @@ class GR00TActionEncoder(nn.Module):
     F.linear needs transpose at call time.
     """
 
-    def __init__(self, raw_action_dim: int, hidden: int, weights: dict, embodiment_id: int = 0):
+    def __init__(self, raw_action_dim: int, hidden: int, weights: dict,
+                 embodiment_id: int = 0):
         super().__init__()
         self.raw_action_dim = raw_action_dim
         self.hidden = hidden
@@ -714,10 +718,10 @@ class GR00TActionEncoder(nn.Module):
         h1 = F.silu(F.linear(actions, self.W1_w, self.W1_b))  # [b, chunk, hidden]
 
         t = time_emb.unsqueeze(1).expand(-1, chunk, -1)  # [b, chunk, hidden]
-        cat = torch.cat([h1, t], dim=-1)  # [b, chunk, 2*hidden]
-        h2 = F.silu(F.linear(cat, self.W2_w, self.W2_b))  # [b, chunk, hidden]
+        cat = torch.cat([h1, t], dim=-1)                 # [b, chunk, 2*hidden]
+        h2 = F.silu(F.linear(cat, self.W2_w, self.W2_b)) # [b, chunk, hidden]
 
-        out = F.linear(h2 + h1, self.W3_w, self.W3_b)  # residual + projection
+        out = F.linear(h2 + h1, self.W3_w, self.W3_b)    # residual + projection
         return out
 
 
@@ -739,14 +743,8 @@ class GR00TStateEncoder(nn.Module):
     with no state awareness. This class closes that gap.
     """
 
-    def __init__(
-        self,
-        raw_state_dim: int,
-        hidden_mid: int,
-        hidden_out: int,
-        weights: dict,
-        embodiment_id: int = 0,
-    ):
+    def __init__(self, raw_state_dim: int, hidden_mid: int, hidden_out: int,
+                 weights: dict, embodiment_id: int = 0):
         super().__init__()
         self.raw_state_dim = raw_state_dim
         self.hidden_mid = hidden_mid
@@ -761,7 +759,7 @@ class GR00TStateEncoder(nn.Module):
     def forward(self, state: torch.Tensor) -> torch.Tensor:
         # state: [b, raw_state_dim] → state_token [b, 1, hidden_out]
         h = F.silu(F.linear(state, self.L1_w, self.L1_b))  # [b, hidden_mid]
-        out = F.linear(h, self.L2_w, self.L2_b)  # [b, hidden_out]
+        out = F.linear(h, self.L2_w, self.L2_b)            # [b, hidden_out]
         return out.unsqueeze(1)  # [b, 1, hidden_out] — one state token
 
 
@@ -773,7 +771,8 @@ class GR00TActionDecoder(nn.Module):
         layer2.W [32, 1024, 128]   -- final → raw action dim
     """
 
-    def __init__(self, in_dim: int, raw_action_dim: int, weights: dict, embodiment_id: int = 0):
+    def __init__(self, in_dim: int, raw_action_dim: int, weights: dict,
+                 embodiment_id: int = 0):
         super().__init__()
         self.in_dim = in_dim
         self.raw_action_dim = raw_action_dim
@@ -786,7 +785,7 @@ class GR00TActionDecoder(nn.Module):
     def forward(self, tokens: torch.Tensor) -> torch.Tensor:
         # tokens: [b, chunk, in_dim=1024]
         h = F.silu(F.linear(tokens, self.L1_w, self.L1_b))  # [b, chunk, 1024]
-        return F.linear(h, self.L2_w, self.L2_b)  # [b, chunk, raw_action_dim]
+        return F.linear(h, self.L2_w, self.L2_b)            # [b, chunk, raw_action_dim]
 
 
 class GR00TFullStack(nn.Module):
@@ -841,7 +840,7 @@ class GR00TFullStack(nn.Module):
             action_pos = self.dit.pos_embed[action_pos_ids].unsqueeze(0)
             action_tokens = action_tokens + action_pos
 
-            state_token = self.state_encoder(state)  # [b, 1, 1536]
+            state_token = self.state_encoder(state)                  # [b, 1, 1536]
             tokens = torch.cat([state_token, action_tokens], dim=1)  # [b, chunk+1, 1536]
             action_start = 1
             # Pass a position_ids tensor that — combined with the DiT's
@@ -862,10 +861,7 @@ class GR00TFullStack(nn.Module):
             # Skip DiT's internal pos_embed by passing `add_pos_embed=False`.
             # (The DiT.forward signature was extended to accept this flag.)
             velocity_tokens = self.dit(
-                tokens,
-                timestep,
-                position_ids,
-                vlm_kv=vlm_kv,
+                tokens, timestep, position_ids, vlm_kv=vlm_kv,
                 add_pos_embed=False,
             )
 
@@ -873,10 +869,8 @@ class GR00TFullStack(nn.Module):
         if action_start > 0:
             velocity_tokens = velocity_tokens[:, action_start:, :]
 
-        velocity_raw = self.action_decoder(velocity_tokens)  # [b, chunk, raw_action_dim]
+        velocity_raw = self.action_decoder(velocity_tokens)    # [b, chunk, raw_action_dim]
         return velocity_raw
-
-
 def build_gr00t_full_stack(
     state_dict: dict[str, torch.Tensor],
     embodiment_id: int = 0,
@@ -893,7 +887,7 @@ def build_gr00t_full_stack(
         "W3_W": state_dict[GR00T_META_KEYS["action_enc_W3_W"]].float(),
         "W3_b": state_dict[GR00T_META_KEYS["action_enc_W3_b"]].float(),
     }
-    raw_action_dim = enc_weights["W1_W"].shape[1]  # [32, 128, 1536] → 128
+    raw_action_dim = _raw_action_dim_from_checkpoint(state_dict, embodiment_id)
     hidden = enc_weights["W1_W"].shape[2]
 
     action_encoder = GR00TActionEncoder(
@@ -910,7 +904,7 @@ def build_gr00t_full_stack(
         "L2_W": state_dict[GR00T_META_KEYS["action_dec_2_W"]].float(),
         "L2_b": state_dict[GR00T_META_KEYS["action_dec_2_b"]].float(),
     }
-    output_token_dim = dec_weights["L1_W"].shape[1]  # [32, 1024, 1024] → 1024
+    output_token_dim = dec_weights["L1_W"].shape[1]   # [32, 1024, 1024] → 1024
 
     action_decoder = GR00TActionDecoder(
         in_dim=output_token_dim,
@@ -930,7 +924,7 @@ def build_gr00t_full_stack(
             "L2_W": state_dict[GR00T_META_KEYS["state_enc_2_W"]].float(),
             "L2_b": state_dict[GR00T_META_KEYS["state_enc_2_b"]].float(),
         }
-        raw_state_dim = state_enc_weights["L1_W"].shape[1]  # (32, 128, 1024) → 128
+        raw_state_dim = state_enc_weights["L1_W"].shape[1]    # (32, 128, 1024) → 128
         state_hidden_mid = state_enc_weights["L1_W"].shape[2]  # → 1024
         state_hidden_out = state_enc_weights["L2_W"].shape[2]  # (32, 1024, 1536) → 1536
         state_encoder = GR00TStateEncoder(
@@ -944,7 +938,8 @@ def build_gr00t_full_stack(
         raw_state_dim = None
         state_hidden_out = None
 
-    full = GR00TFullStack(dit, action_encoder, action_decoder, state_encoder=state_encoder)
+    full = GR00TFullStack(dit, action_encoder, action_decoder,
+                           state_encoder=state_encoder)
     full = full.float()
     full.eval()
 

--- a/src/tether/exporters/monolithic.py
+++ b/src/tether/exporters/monolithic.py
@@ -21,7 +21,6 @@ scripts produce. See
 https://github.com/FastCrest/reflex-vault/blob/main/reflex_vla/measured_numbers.md
 for the parity rows this export is responsible for.
 """
-
 from __future__ import annotations
 
 import logging
@@ -94,7 +93,6 @@ def _bundle_tokenizer(output_dir: Path, model_type: str) -> dict[str, Any]:
     try:
         from transformers import AutoTokenizer
         from tether.runtime.tokenizers import tokenizer_offline_enabled
-
         tok = AutoTokenizer.from_pretrained(
             tokenizer_ref,
             local_files_only=tokenizer_offline_enabled(),
@@ -102,11 +100,15 @@ def _bundle_tokenizer(output_dir: Path, model_type: str) -> dict[str, Any]:
         if getattr(tok, "pad_token", None) is None and getattr(tok, "eos_token", None) is not None:
             tok.pad_token = tok.eos_token
         tok_dir = output_dir / "tokenizer"
-        tok.save_pretrained(tok_dir)
+        saved_paths = tok.save_pretrained(tok_dir)
         meta.update(
             {
                 "tokenizer_path": "tokenizer",
                 "tokenizer_bundled": True,
+                "_artifact_paths": [
+                    Path(path).resolve().relative_to(output_dir.resolve()).as_posix()
+                    for path in saved_paths
+                ],
             }
         )
     except Exception as exc:
@@ -130,7 +132,6 @@ def _require_monolithic_deps() -> None:
     missing = []
     try:
         import transformers
-
         if transformers.__version__ != "5.3.0":
             raise ImportError(
                 f"transformers {transformers.__version__} detected; the "
@@ -196,7 +197,8 @@ def _raise_if_smolvla_export_patches_failed() -> None:
         "SmolVLA monolithic export patches failed to install. This usually "
         "means the lerobot/transformers export stack does not match the pinned "
         "monolithic environment; install with: pip install "
-        "'fastcrest-tether[monolithic]'.\n  - " + details
+        "'fastcrest-tether[monolithic]'.\n  - "
+        + details
     )
 
 
@@ -227,16 +229,12 @@ def apply_export_patches() -> None:
         from transformers.models.mamba.modeling_mamba import MambaCache  # noqa
     except ImportError:
         import transformers.cache_utils as _cu
-
         if not hasattr(_cu, "MambaCache"):
-
             class _MambaCacheStub:
                 pass
-
             _cu.MambaCache = _MambaCacheStub
             try:
                 import transformers.models.mamba.modeling_mamba as _mm
-
                 if not hasattr(_mm, "MambaCache"):
                     _mm.MambaCache = _MambaCacheStub
             except ImportError:
@@ -265,7 +263,6 @@ def apply_export_patches() -> None:
     masking_utils.create_causal_mask = _ccm_shim
     try:
         from lerobot.policies import pi_gemma as _pg
-
         if hasattr(_pg, "create_causal_mask"):
             _pg.create_causal_mask = _ccm_shim
     except ImportError:
@@ -282,7 +279,6 @@ def apply_export_patches() -> None:
         from lerobot.policies.smolvla import modeling_smolvla as _smolvla
 
         if not getattr(_smolvla.SmolVLMWithExpertModel.embed_image, "_tether_patched", False):
-
             def _embed_image_with_explicit_patch_mask(self, image):
                 patch_size = self.get_vlm_model().vision_model.patch_size
                 patch_attention_mask = torch.ones(
@@ -316,25 +312,16 @@ def apply_export_patches() -> None:
         from transformers.models.smolvlm import modeling_smolvlm as _smolvlm
 
         if not getattr(_smolvlm.SmolVLMVisionAttention.forward, "_tether_patched", False):
-
-            def _vision_attention_forward_no_dense_mask(
-                self, hidden_states, attention_mask=None, **kwargs
-            ):
+            def _vision_attention_forward_no_dense_mask(self, hidden_states, attention_mask=None, **kwargs):
                 batch_size, seq_length, embed_dim = hidden_states.shape
 
                 queries = self.q_proj(hidden_states)
                 keys = self.k_proj(hidden_states)
                 values = self.v_proj(hidden_states)
 
-                queries = queries.view(
-                    batch_size, seq_length, self.num_heads, self.head_dim
-                ).transpose(1, 2)
-                keys = keys.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(
-                    1, 2
-                )
-                values = values.view(
-                    batch_size, seq_length, self.num_heads, self.head_dim
-                ).transpose(1, 2)
+                queries = queries.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(1, 2)
+                keys = keys.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(1, 2)
+                values = values.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(1, 2)
 
                 attention_interface = _smolvlm.ALL_ATTENTION_FUNCTIONS.get_interface(
                     self.config._attn_implementation,
@@ -368,11 +355,9 @@ def apply_export_patches() -> None:
 
     def _safe_deepcopy(obj, *args, **kwargs):
         from transformers.cache_utils import DynamicCache
-
         if isinstance(obj, DynamicCache):
             return obj
         return _orig_deepcopy(obj, *args, **kwargs)
-
     copy.deepcopy = _safe_deepcopy
 
     # SmolVLA pad_tensor/pad_vector: replace slice-assign with torch.cat so
@@ -386,13 +371,10 @@ def apply_export_patches() -> None:
                 return tensor[:, :max_len]
             pad_shape = (b, max_len - d, *tensor.shape[2:])
             pad = torch.full(
-                pad_shape,
-                float(pad_value),
-                dtype=tensor.dtype,
-                device=tensor.device,
+                pad_shape, float(pad_value),
+                dtype=tensor.dtype, device=tensor.device,
             )
             return torch.cat([tensor, pad], dim=1)
-
         _smv.pad_tensor = _safe_pad_tensor
 
         def _safe_pad_vector(vector, new_dim):
@@ -402,7 +384,6 @@ def apply_export_patches() -> None:
             pad_shape = (*vector.shape[:-1], new_dim - current_dim)
             pad = torch.zeros(pad_shape, dtype=vector.dtype, device=vector.device)
             return torch.cat([vector, pad], dim=-1)
-
         _smv.pad_vector = _safe_pad_vector
     except ImportError:
         pass
@@ -413,10 +394,8 @@ def apply_export_patches() -> None:
 
     def _safe_where(condition, x=None, y=None, *args, **kwargs):
         if (
-            x is not None
-            and y is not None
-            and hasattr(x, "dtype")
-            and hasattr(y, "dtype")
+            x is not None and y is not None
+            and hasattr(x, "dtype") and hasattr(y, "dtype")
             and x.dtype != y.dtype
         ):
             common = torch.promote_types(x.dtype, y.dtype)
@@ -425,7 +404,6 @@ def apply_export_patches() -> None:
             if y.dtype != common:
                 y = y.to(common)
         return _orig_where(condition, x, y, *args, **kwargs)
-
     torch.where = _safe_where
 
     # pi0-specific: PaliGemmaWithExpertModel.embed_image image_outputs extraction
@@ -439,11 +417,10 @@ def apply_export_patches() -> None:
                 image = image.to(_t.float32)
             out = self.paligemma.model.get_image_features(image)
             features = out.pooler_output if hasattr(out, "pooler_output") else out
-            features = features * self.paligemma.config.text_config.hidden_size**0.5
+            features = features * self.paligemma.config.text_config.hidden_size ** 0.5
             if features.dtype != out_dtype:
                 features = features.to(out_dtype)
             return features
-
         modeling_pi0.PaliGemmaWithExpertModel.embed_image = _patched_embed_image
     except ImportError:
         pass
@@ -494,20 +471,15 @@ def apply_export_patches() -> None:
                     new_v = torch.cat([past_v, value_states], dim=-2)
                     return new_k, new_v
             return _orig_layer_update(self, key_states, value_states, cache_kwargs)
-
         _DL.update = _frozen_layer_update
 
         def _patched_denoise_step(self, state, prefix_pad_masks, past_key_values, x_t, timestep):
             suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
-                state,
-                x_t,
-                timestep,
+                state, x_t, timestep,
             )
             suffix_len = suffix_pad_masks.shape[1]
             batch_size = prefix_pad_masks.shape[0]
-            cached_prefix_len = (
-                past_key_values.get_seq_length() if past_key_values is not None else 0
-            )
+            cached_prefix_len = past_key_values.get_seq_length() if past_key_values is not None else 0
             prefix_len = max(cached_prefix_len, prefix_pad_masks.shape[1])
 
             pad_deficit = prefix_len - prefix_pad_masks.shape[1]
@@ -515,9 +487,7 @@ def apply_export_patches() -> None:
             if pad_deficit > 0:
                 prefix_pad_masks_extended = _F.pad(prefix_pad_masks, (0, pad_deficit), value=True)
 
-            prefix_pad_2d_masks = prefix_pad_masks_extended[:, None, :].expand(
-                batch_size, suffix_len, prefix_len
-            )
+            prefix_pad_2d_masks = prefix_pad_masks_extended[:, None, :].expand(batch_size, suffix_len, prefix_len)
             suffix_att_2d_masks = _make_att_2d_masks(suffix_pad_masks, suffix_att_masks)
 
             prefix_allowed = _F.pad(prefix_pad_2d_masks, (0, suffix_len), value=True)
@@ -539,7 +509,7 @@ def apply_export_patches() -> None:
                 adarms_cond=[None, adarms_cond],
             )
             suffix_out = outputs_embeds[1]
-            suffix_out = suffix_out[:, -self.config.chunk_size :]
+            suffix_out = suffix_out[:, -self.config.chunk_size:]
             suffix_out = suffix_out.to(dtype=torch.float32)
             return self.action_out_proj(suffix_out)
 
@@ -579,14 +549,12 @@ def _fix_onnx_where_dtype_mismatches(onnx_path: Path) -> int:
     from onnx import helper, TensorProto
 
     model = onnx.load(str(onnx_path), load_external_data=False)
-    shape_info = onnx.shape_inference.infer_shapes(model, check_type=False, strict_mode=False)
+    shape_info = onnx.shape_inference.infer_shapes(
+        model, check_type=False, strict_mode=False
+    )
 
     name_dtype: dict[str, int] = {}
-    for vi in (
-        list(shape_info.graph.value_info)
-        + list(shape_info.graph.input)
-        + list(shape_info.graph.output)
-    ):
+    for vi in list(shape_info.graph.value_info) + list(shape_info.graph.input) + list(shape_info.graph.output):
         if vi.type.tensor_type.elem_type:
             name_dtype[vi.name] = vi.type.tensor_type.elem_type
     for init in shape_info.graph.initializer:
@@ -616,22 +584,16 @@ def _fix_onnx_where_dtype_mismatches(onnx_path: Path) -> int:
         if x_dt != target_dt:
             cast_out = f"{node.name}__cast_x"
             cast_node = helper.make_node(
-                "Cast",
-                [x_name],
-                [cast_out],
-                name=f"{node.name}__cast_x_node",
-                to=target_dt,
+                "Cast", [x_name], [cast_out],
+                name=f"{node.name}__cast_x_node", to=target_dt,
             )
             fixes_this.append(cast_node)
             node.input[1] = cast_out
         if y_dt != target_dt:
             cast_out = f"{node.name}__cast_y"
             cast_node = helper.make_node(
-                "Cast",
-                [y_name],
-                [cast_out],
-                name=f"{node.name}__cast_y_node",
-                to=target_dt,
+                "Cast", [y_name], [cast_out],
+                name=f"{node.name}__cast_y_node", to=target_dt,
             )
             fixes_this.append(cast_node)
             node.input[2] = cast_out
@@ -640,11 +602,7 @@ def _fix_onnx_where_dtype_mismatches(onnx_path: Path) -> int:
         fixes += 1
         logger.info(
             "fixed Where node %s (X=%s, Y=%s, out_decl=%s -> target=%s)",
-            node.name,
-            x_dt,
-            y_dt,
-            out_dt,
-            target_dt,
+            node.name, x_dt, y_dt, out_dt, target_dt,
         )
 
     if fixes > 0:
@@ -688,7 +646,6 @@ def export_smolvla_monolithic(
 
     logger.info("[smolvla] Loading %s", model_id)
     from lerobot.policies.smolvla.modeling_smolvla import SmolVLAPolicy
-
     t0 = time.time()
     policy = SmolVLAPolicy.from_pretrained(model_id)
     policy.eval().to("cpu").to(torch.float32)
@@ -703,26 +660,15 @@ def export_smolvla_monolithic(
 
         def forward(
             self,
-            img_cam1,
-            img_cam2,
-            img_cam3,
-            mask_cam1,
-            mask_cam2,
-            mask_cam3,
-            lang_tokens,
-            lang_masks,
-            state,
-            noise,
+            img_cam1, img_cam2, img_cam3,
+            mask_cam1, mask_cam2, mask_cam3,
+            lang_tokens, lang_masks,
+            state, noise,
         ):
             images = [img_cam1, img_cam2, img_cam3]
             img_masks = [mask_cam1, mask_cam2, mask_cam3]
             return self.model.sample_actions(
-                images,
-                img_masks,
-                lang_tokens,
-                lang_masks,
-                state,
-                noise=noise,
+                images, img_masks, lang_tokens, lang_masks, state, noise=noise,
             )
 
     wrapper = SmolVLAMonolithicWrapper(policy.model).eval()
@@ -753,21 +699,16 @@ def export_smolvla_monolithic(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep = torch.export.export(
-            wrapper,
-            tuple(dummy.values()),
-            dynamic_shapes=None,
-            strict=False,
+            wrapper, tuple(dummy.values()),
+            dynamic_shapes=None, strict=False,
         )
     logger.info("[smolvla] torch.export: %.1fs", time.time() - t0)
 
     logger.info("[smolvla] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
-        ep,
-        tuple(dummy.values()),
-        str(onnx_path),
-        input_names=list(dummy.keys()),
-        output_names=["actions"],
+        ep, tuple(dummy.values()), str(onnx_path),
+        input_names=list(dummy.keys()), output_names=["actions"],
         opset_version=19,
     )
     logger.info("[smolvla] ONNX conversion: %.1fs", time.time() - t0)
@@ -776,12 +717,8 @@ def export_smolvla_monolithic(
     logger.info("[smolvla] post-export Cast fixes: %d", fixes)
 
     _write_tether_config(
-        output_dir,
-        policy.config,
-        num_steps=num_steps,
-        model_id=model_id,
-        model_type="smolvla",
-        target=target,
+        output_dir, policy.config, num_steps=num_steps,
+        model_id=model_id, model_type="smolvla", target=target,
     )
 
     size_mb = onnx_path.stat().st_size / 1e6
@@ -819,14 +756,13 @@ def export_pi0_monolithic(
 
     logger.info("[pi0] Loading %s", model_id)
     from lerobot.policies.pi0.modeling_pi0 import PI0Policy
-
     t0 = time.time()
     # Block torch.compile during from_pretrained — see pi05 branch for the
     # "Guard failed on same frame" bug. pi0_base defaults to False so this
     # is a no-op for canonical exports, but any fine-tuned pi0 config with
     # compile_model=True (common pattern) would otherwise break the trace.
     _orig_compile = torch.compile
-    torch.compile = lambda fn=None, *a, **kw: fn if fn is not None else (lambda f: f)
+    torch.compile = lambda fn=None, *a, **kw: (fn if fn is not None else (lambda f: f))
     try:
         policy = PI0Policy.from_pretrained(model_id)
     finally:
@@ -846,27 +782,16 @@ def export_pi0_monolithic(
 
         def forward(
             self,
-            img_base,
-            img_wrist_l,
-            img_wrist_r,
-            mask_base,
-            mask_wrist_l,
-            mask_wrist_r,
-            lang_tokens,
-            lang_masks,
-            state,
-            noise,
+            img_base, img_wrist_l, img_wrist_r,
+            mask_base, mask_wrist_l, mask_wrist_r,
+            lang_tokens, lang_masks,
+            state, noise,
         ):
             images = [img_base, img_wrist_l, img_wrist_r]
             img_masks = [mask_base, mask_wrist_l, mask_wrist_r]
             return self.model.sample_actions(
-                images,
-                img_masks,
-                lang_tokens,
-                lang_masks,
-                state,
-                noise=noise,
-                num_steps=self.n_steps,
+                images, img_masks, lang_tokens, lang_masks, state,
+                noise=noise, num_steps=self.n_steps,
             )
 
     wrapper = Pi0MonolithicWrapper(policy.model, num_steps).eval()
@@ -897,21 +822,16 @@ def export_pi0_monolithic(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep = torch.export.export(
-            wrapper,
-            tuple(dummy.values()),
-            dynamic_shapes=None,
-            strict=False,
+            wrapper, tuple(dummy.values()),
+            dynamic_shapes=None, strict=False,
         )
     logger.info("[pi0] torch.export: %.1fs", time.time() - t0)
 
     logger.info("[pi0] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
-        ep,
-        tuple(dummy.values()),
-        str(onnx_path),
-        input_names=list(dummy.keys()),
-        output_names=["actions"],
+        ep, tuple(dummy.values()), str(onnx_path),
+        input_names=list(dummy.keys()), output_names=["actions"],
         opset_version=19,
     )
     logger.info("[pi0] ONNX conversion: %.1fs", time.time() - t0)
@@ -920,12 +840,8 @@ def export_pi0_monolithic(
     logger.info("[pi0] post-export Cast fixes: %d", fixes)
 
     _write_tether_config(
-        output_dir,
-        policy.config,
-        num_steps=num_steps,
-        model_id=model_id,
-        model_type="pi0",
-        target=target,
+        output_dir, policy.config, num_steps=num_steps,
+        model_id=model_id, model_type="pi0", target=target,
     )
 
     size_mb = onnx_path.stat().st_size / 1e6
@@ -950,6 +866,9 @@ def _write_tether_config(
 ) -> None:
     """Write `tether_config.json` + seed a VERIFICATION.md receipt."""
     tokenizer_meta = _bundle_tokenizer(output_dir, model_type)
+    tokenizer_artifacts = [
+        (path, "tokenizer") for path in tokenizer_meta.pop("_artifact_paths", [])
+    ]
     cfg_dict = {
         "model_id": model_id,
         "model_type": model_type,
@@ -964,9 +883,20 @@ def _write_tether_config(
         "notes": _CCM_NONE_RATIONALE if num_steps > 1 else None,
         **tokenizer_meta,
     }
-    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+    from tether.export_config import build_producer_config, write_tether_config
 
-    write_tether_config(output_dir, normalize_legacy_tether_config(cfg_dict, output_dir))
+    canonical = build_producer_config(
+        output_dir,
+        producer="monolithic",
+        model_id=model_id,
+        model_type=model_type,
+        action_dim=cfg_dict["action_dim"],
+        num_denoising_steps=num_steps,
+        opset=19,
+        optional_artifacts=tokenizer_artifacts,
+        metadata=cfg_dict,
+    )
+    write_tether_config(output_dir, canonical)
 
     # Seed VERIFICATION.md at export time — every export ships a receipt,
     # even before `tether validate` fills in the parity numbers. Callers
@@ -975,7 +905,6 @@ def _write_tether_config(
     # actual export (the ONNX is already on disk by this point).
     try:
         from tether.verification_report import write_verification_report
-
         write_verification_report(output_dir, parity=None)
     except Exception:
         pass
@@ -1009,7 +938,6 @@ def export_pi05_monolithic(
 
     logger.info("[pi05] Loading %s", model_id)
     from lerobot.policies.pi05.modeling_pi05 import PI05Policy
-
     t0 = time.time()
     # Block torch.compile during from_pretrained: LIBERO-finetuned configs
     # (e.g. lerobot/pi05_libero_finetuned_v044) ship with compile_model=True,
@@ -1018,7 +946,7 @@ def export_pi05_monolithic(
     # raise "Guard failed on same frame it was created" during export. Disable
     # the compile step for the duration of the load.
     _orig_compile = torch.compile
-    torch.compile = lambda fn=None, *a, **kw: fn if fn is not None else (lambda f: f)
+    torch.compile = lambda fn=None, *a, **kw: (fn if fn is not None else (lambda f: f))
     try:
         policy = PI05Policy.from_pretrained(model_id)
     finally:
@@ -1048,26 +976,17 @@ def export_pi05_monolithic(
 
         def forward(
             self,
-            img_base,
-            img_wrist_l,
-            img_wrist_r,
-            mask_base,
-            mask_wrist_l,
-            mask_wrist_r,
-            lang_tokens,
-            lang_masks,
+            img_base, img_wrist_l, img_wrist_r,
+            mask_base, mask_wrist_l, mask_wrist_r,
+            lang_tokens, lang_masks,
             noise,
         ):
             # pi0.5: no state arg (state is in lang_tokens).
             images = [img_base, img_wrist_l, img_wrist_r]
             img_masks = [mask_base, mask_wrist_l, mask_wrist_r]
             return self.model.sample_actions(
-                images,
-                img_masks,
-                lang_tokens,
-                lang_masks,
-                noise=noise,
-                num_steps=self.n_steps,
+                images, img_masks, lang_tokens, lang_masks,
+                noise=noise, num_steps=self.n_steps,
             )
 
     wrapper = Pi05MonolithicWrapper(policy.model, num_steps).eval()
@@ -1096,21 +1015,16 @@ def export_pi05_monolithic(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep = torch.export.export(
-            wrapper,
-            tuple(dummy.values()),
-            dynamic_shapes=None,
-            strict=False,
+            wrapper, tuple(dummy.values()),
+            dynamic_shapes=None, strict=False,
         )
     logger.info("[pi05] torch.export: %.1fs", time.time() - t0)
 
     logger.info("[pi05] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
-        ep,
-        tuple(dummy.values()),
-        str(onnx_path),
-        input_names=list(dummy.keys()),
-        output_names=["actions"],
+        ep, tuple(dummy.values()), str(onnx_path),
+        input_names=list(dummy.keys()), output_names=["actions"],
         opset_version=19,
     )
     logger.info("[pi05] ONNX conversion: %.1fs", time.time() - t0)
@@ -1119,12 +1033,8 @@ def export_pi05_monolithic(
     logger.info("[pi05] post-export Cast fixes: %d", fixes)
 
     _write_tether_config(
-        output_dir,
-        policy.config,
-        num_steps=num_steps,
-        model_id=model_id,
-        model_type="pi05",
-        target=target,
+        output_dir, policy.config, num_steps=num_steps,
+        model_id=model_id, model_type="pi05", target=target,
     )
 
     size_mb = onnx_path.stat().st_size / 1e6
@@ -1161,14 +1071,11 @@ def _apply_pi05_denoise_step_patch() -> None:
         def _patched(self, prefix_pad_masks, past_key_values, x_t, timestep):
             # pi0.5: NO state arg (tokenized into language upstream).
             suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
-                x_t,
-                timestep,
+                x_t, timestep,
             )
             suffix_len = suffix_pad_masks.shape[1]
             batch_size = prefix_pad_masks.shape[0]
-            cached_prefix_len = (
-                past_key_values.get_seq_length() if past_key_values is not None else 0
-            )
+            cached_prefix_len = past_key_values.get_seq_length() if past_key_values is not None else 0
             prefix_len = max(cached_prefix_len, prefix_pad_masks.shape[1])
 
             pad_deficit = prefix_len - prefix_pad_masks.shape[1]
@@ -1176,9 +1083,7 @@ def _apply_pi05_denoise_step_patch() -> None:
             if pad_deficit > 0:
                 prefix_pad_masks_extended = _F.pad(prefix_pad_masks, (0, pad_deficit), value=True)
 
-            prefix_pad_2d_masks = prefix_pad_masks_extended[:, None, :].expand(
-                batch_size, suffix_len, prefix_len
-            )
+            prefix_pad_2d_masks = prefix_pad_masks_extended[:, None, :].expand(batch_size, suffix_len, prefix_len)
             suffix_att_2d_masks = _make(suffix_pad_masks, suffix_att_masks)
 
             prefix_allowed = _F.pad(prefix_pad_2d_masks, (0, suffix_len), value=True)
@@ -1200,7 +1105,7 @@ def _apply_pi05_denoise_step_patch() -> None:
                 adarms_cond=[None, adarms_cond],
             )
             suffix_out = outputs_embeds[1]
-            suffix_out = suffix_out[:, -self.config.chunk_size :]
+            suffix_out = suffix_out[:, -self.config.chunk_size:]
             suffix_out = suffix_out.to(dtype=torch.float32)
             return self.action_out_proj(suffix_out)
 
@@ -1271,7 +1176,8 @@ def export_snapflow_student_monolithic(
 
     if not (is_pi05 or is_pi0):
         raise TypeError(
-            f"SnapFlow export supports pi0 / pi0.5 students only; got {type(policy.model).__name__}"
+            f"SnapFlow export supports pi0 / pi0.5 students only; got "
+            f"{type(policy.model).__name__}"
         )
 
     # Monkey-patch the SnapFlow denoise_step to drop detach+deepcopy for
@@ -1285,7 +1191,6 @@ def export_snapflow_student_monolithic(
     logger.info("[snapflow-export] Family=%s, wrapping for export", family)
 
     if is_pi05:
-
         class SnapFlowStudentWrapper(nn.Module):
             def __init__(self, model):
                 super().__init__()
@@ -1293,25 +1198,17 @@ def export_snapflow_student_monolithic(
 
             def forward(
                 self,
-                img_base,
-                img_wrist_l,
-                img_wrist_r,
-                mask_base,
-                mask_wrist_l,
-                mask_wrist_r,
-                lang_tokens,
-                lang_masks,
+                img_base, img_wrist_l, img_wrist_r,
+                mask_base, mask_wrist_l, mask_wrist_r,
+                lang_tokens, lang_masks,
                 noise,
             ):
                 return self.model.sample_actions_1step(
                     [img_base, img_wrist_l, img_wrist_r],
                     [mask_base, mask_wrist_l, mask_wrist_r],
-                    lang_tokens,
-                    lang_masks,
-                    noise=noise,
+                    lang_tokens, lang_masks, noise=noise,
                 )
     else:
-
         class SnapFlowStudentWrapper(nn.Module):
             def __init__(self, model):
                 super().__init__()
@@ -1319,24 +1216,15 @@ def export_snapflow_student_monolithic(
 
             def forward(
                 self,
-                img_cam1,
-                img_cam2,
-                img_cam3,
-                mask_cam1,
-                mask_cam2,
-                mask_cam3,
-                lang_tokens,
-                lang_masks,
-                state,
-                noise,
+                img_cam1, img_cam2, img_cam3,
+                mask_cam1, mask_cam2, mask_cam3,
+                lang_tokens, lang_masks,
+                state, noise,
             ):
                 return self.model.sample_actions_1step(
                     [img_cam1, img_cam2, img_cam3],
                     [mask_cam1, mask_cam2, mask_cam3],
-                    lang_tokens,
-                    lang_masks,
-                    state,
-                    noise=noise,
+                    lang_tokens, lang_masks, state, noise=noise,
                 )
 
     wrapper = SnapFlowStudentWrapper(policy.model).eval()
@@ -1380,21 +1268,16 @@ def export_snapflow_student_monolithic(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep = torch.export.export(
-            wrapper,
-            tuple(dummy.values()),
-            dynamic_shapes=None,
-            strict=False,
+            wrapper, tuple(dummy.values()),
+            dynamic_shapes=None, strict=False,
         )
     logger.info("[snapflow-export] torch.export: %.1fs", time.time() - t0)
 
     logger.info("[snapflow-export] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
-        ep,
-        tuple(dummy.values()),
-        str(onnx_path),
-        input_names=list(dummy.keys()),
-        output_names=["actions"],
+        ep, tuple(dummy.values()), str(onnx_path),
+        input_names=list(dummy.keys()), output_names=["actions"],
         opset_version=19,
     )
     logger.info("[snapflow-export] ONNX conversion: %.1fs", time.time() - t0)
@@ -1403,11 +1286,8 @@ def export_snapflow_student_monolithic(
     logger.info("[snapflow-export] post-export Cast fixes: %d", fixes)
 
     _write_tether_config(
-        output_dir,
-        policy.config,
-        num_steps=1,
-        model_id=str(checkpoint_path),
-        model_type=f"{family}_snapflow",
+        output_dir, policy.config, num_steps=1,
+        model_id=str(checkpoint_path), model_type=f"{family}_snapflow",
         target=target,
     )
 
@@ -1440,23 +1320,17 @@ def _install_snapflow_export_denoise_step(model: Any, *, is_pi05: bool) -> None:
         from lerobot.policies.pi0.modeling_pi0 import make_att_2d_masks
 
     if is_pi05:
-
-        def _export_denoise_step(
-            self, prefix_pad_masks, past_key_values, x_t, timestep, target_time=None, state=None
-        ):
+        def _export_denoise_step(self, prefix_pad_masks, past_key_values, x_t,
+                                 timestep, target_time=None, state=None):
             suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
-                x_t,
-                timestep,
-                target_time=target_time,
+                x_t, timestep, target_time=target_time,
             )
             suffix_len = suffix_pad_masks.shape[1]
             batch_size = prefix_pad_masks.shape[0]
             prefix_len = prefix_pad_masks.shape[1]
 
             prefix_pad_2d_masks = prefix_pad_masks[:, None, :].expand(
-                batch_size,
-                suffix_len,
-                prefix_len,
+                batch_size, suffix_len, prefix_len,
             )
             suffix_att_2d_masks = make_att_2d_masks(suffix_pad_masks, suffix_att_masks)
             prefix_allowed = _F.pad(prefix_pad_2d_masks, (0, suffix_len), value=True)
@@ -1476,28 +1350,21 @@ def _install_snapflow_export_denoise_step(model: Any, *, is_pi05: bool) -> None:
                 use_cache=False,
                 adarms_cond=[None, adarms_cond],
             )
-            suffix_out = outputs_embeds[1][:, -self.config.chunk_size :]
+            suffix_out = outputs_embeds[1][:, -self.config.chunk_size:]
             suffix_out = suffix_out.to(dtype=self.action_out_proj.weight.dtype)
             return self.action_out_proj(suffix_out)
     else:
-
-        def _export_denoise_step(
-            self, state, prefix_pad_masks, past_key_values, x_t, timestep, target_time=None
-        ):
+        def _export_denoise_step(self, state, prefix_pad_masks, past_key_values,
+                                 x_t, timestep, target_time=None):
             suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
-                state,
-                x_t,
-                timestep,
-                target_time=target_time,
+                state, x_t, timestep, target_time=target_time,
             )
             suffix_len = suffix_pad_masks.shape[1]
             batch_size = prefix_pad_masks.shape[0]
             prefix_len = prefix_pad_masks.shape[1]
 
             prefix_pad_2d_masks = prefix_pad_masks[:, None, :].expand(
-                batch_size,
-                suffix_len,
-                prefix_len,
+                batch_size, suffix_len, prefix_len,
             )
             suffix_att_2d_masks = make_att_2d_masks(suffix_pad_masks, suffix_att_masks)
             prefix_allowed = _F.pad(prefix_pad_2d_masks, (0, suffix_len), value=True)
@@ -1517,7 +1384,7 @@ def _install_snapflow_export_denoise_step(model: Any, *, is_pi05: bool) -> None:
                 use_cache=False,
                 adarms_cond=[None, adarms_cond],
             )
-            suffix_out = outputs_embeds[1][:, -self.config.chunk_size :]
+            suffix_out = outputs_embeds[1][:, -self.config.chunk_size:]
             suffix_out = suffix_out.to(dtype=self.action_out_proj.weight.dtype)
             return self.action_out_proj(suffix_out)
 
@@ -1565,12 +1432,9 @@ def export_gr00t_monolithic(
     t0 = time.time()
     full, meta = build_gr00t_full_stack(state_dict, embodiment_id=embodiment_id)
     full.eval()
-    logger.info(
-        "[gr00t] Built in %.1fs — raw_action_dim=%d, params=%.1fM",
-        time.time() - t0,
-        meta["raw_action_dim"],
-        meta["full_stack_params_m"],
-    )
+    logger.info("[gr00t] Built in %.1fs — raw_action_dim=%d, params=%.1fM",
+                time.time() - t0, meta["raw_action_dim"],
+                meta["full_stack_params_m"])
 
     raw_action_dim = meta["raw_action_dim"]
     chunk = 50
@@ -1603,15 +1467,11 @@ def export_gr00t_monolithic(
 
     _write_tether_config(
         output_dir,
-        type(
-            "GR00TConfig",
-            (),
-            {
-                "chunk_size": chunk,
-                "max_action_dim": raw_action_dim,
-                "num_steps": num_steps,
-            },
-        )(),
+        type("GR00TConfig", (), {
+            "chunk_size": chunk,
+            "max_action_dim": raw_action_dim,
+            "num_steps": num_steps,
+        })(),
         num_steps=num_steps,
         model_id=model_id,
         model_type="gr00t",
@@ -1666,7 +1526,11 @@ def _model_type_from_local_config(model_id: str) -> str | None:
     # lerobot policy convention: 'policy_type' field.
     # SnapFlow checkpoint convention: 'type' field
     # (e.g., 'pi05', 'smolvla'). Caught by 2026-04-25 distill smoke v2.
-    raw = cfg.get("model_type") or cfg.get("policy_type") or cfg.get("type")
+    raw = (
+        cfg.get("model_type")
+        or cfg.get("policy_type")
+        or cfg.get("type")
+    )
     if not isinstance(raw, str):
         return None
     raw = raw.lower()
@@ -1735,7 +1599,9 @@ def export_monolithic(
         gr00t_steps = 4 if num_steps == 10 else num_steps
         result = export_gr00t_monolithic(model_id, output_dir, num_steps=gr00t_steps, target=target)
     else:
-        raise ValueError(f"Monolithic export for model_type={model_type!r} not yet supported.")
+        raise ValueError(
+            f"Monolithic export for model_type={model_type!r} not yet supported."
+        )
 
     # Post-export weight fusion pass (lifted from dexmal/realtime-vla MIT).
     # Fuses RMSNorm scales into MatMul weights, folds Euler dt into output
@@ -1744,7 +1610,6 @@ def export_monolithic(
     if onnx_path:
         try:
             from tether.exporters.weight_fusion import fuse_weights
-
             fused_path = fuse_weights(onnx_path, num_steps=num_steps)
             logger.info("Weight fusion pass complete: %s", fused_path)
         except Exception as e:

--- a/src/tether/exporters/monolithic.py
+++ b/src/tether/exporters/monolithic.py
@@ -21,9 +21,9 @@ scripts produce. See
 https://github.com/FastCrest/reflex-vault/blob/main/reflex_vla/measured_numbers.md
 for the parity rows this export is responsible for.
 """
+
 from __future__ import annotations
 
-import json
 import logging
 import time
 from importlib.metadata import PackageNotFoundError, version as _dist_version
@@ -94,6 +94,7 @@ def _bundle_tokenizer(output_dir: Path, model_type: str) -> dict[str, Any]:
     try:
         from transformers import AutoTokenizer
         from tether.runtime.tokenizers import tokenizer_offline_enabled
+
         tok = AutoTokenizer.from_pretrained(
             tokenizer_ref,
             local_files_only=tokenizer_offline_enabled(),
@@ -129,6 +130,7 @@ def _require_monolithic_deps() -> None:
     missing = []
     try:
         import transformers
+
         if transformers.__version__ != "5.3.0":
             raise ImportError(
                 f"transformers {transformers.__version__} detected; the "
@@ -194,8 +196,7 @@ def _raise_if_smolvla_export_patches_failed() -> None:
         "SmolVLA monolithic export patches failed to install. This usually "
         "means the lerobot/transformers export stack does not match the pinned "
         "monolithic environment; install with: pip install "
-        "'fastcrest-tether[monolithic]'.\n  - "
-        + details
+        "'fastcrest-tether[monolithic]'.\n  - " + details
     )
 
 
@@ -226,12 +227,16 @@ def apply_export_patches() -> None:
         from transformers.models.mamba.modeling_mamba import MambaCache  # noqa
     except ImportError:
         import transformers.cache_utils as _cu
+
         if not hasattr(_cu, "MambaCache"):
+
             class _MambaCacheStub:
                 pass
+
             _cu.MambaCache = _MambaCacheStub
             try:
                 import transformers.models.mamba.modeling_mamba as _mm
+
                 if not hasattr(_mm, "MambaCache"):
                     _mm.MambaCache = _MambaCacheStub
             except ImportError:
@@ -260,6 +265,7 @@ def apply_export_patches() -> None:
     masking_utils.create_causal_mask = _ccm_shim
     try:
         from lerobot.policies import pi_gemma as _pg
+
         if hasattr(_pg, "create_causal_mask"):
             _pg.create_causal_mask = _ccm_shim
     except ImportError:
@@ -276,6 +282,7 @@ def apply_export_patches() -> None:
         from lerobot.policies.smolvla import modeling_smolvla as _smolvla
 
         if not getattr(_smolvla.SmolVLMWithExpertModel.embed_image, "_tether_patched", False):
+
             def _embed_image_with_explicit_patch_mask(self, image):
                 patch_size = self.get_vlm_model().vision_model.patch_size
                 patch_attention_mask = torch.ones(
@@ -309,16 +316,25 @@ def apply_export_patches() -> None:
         from transformers.models.smolvlm import modeling_smolvlm as _smolvlm
 
         if not getattr(_smolvlm.SmolVLMVisionAttention.forward, "_tether_patched", False):
-            def _vision_attention_forward_no_dense_mask(self, hidden_states, attention_mask=None, **kwargs):
+
+            def _vision_attention_forward_no_dense_mask(
+                self, hidden_states, attention_mask=None, **kwargs
+            ):
                 batch_size, seq_length, embed_dim = hidden_states.shape
 
                 queries = self.q_proj(hidden_states)
                 keys = self.k_proj(hidden_states)
                 values = self.v_proj(hidden_states)
 
-                queries = queries.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(1, 2)
-                keys = keys.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(1, 2)
-                values = values.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(1, 2)
+                queries = queries.view(
+                    batch_size, seq_length, self.num_heads, self.head_dim
+                ).transpose(1, 2)
+                keys = keys.view(batch_size, seq_length, self.num_heads, self.head_dim).transpose(
+                    1, 2
+                )
+                values = values.view(
+                    batch_size, seq_length, self.num_heads, self.head_dim
+                ).transpose(1, 2)
 
                 attention_interface = _smolvlm.ALL_ATTENTION_FUNCTIONS.get_interface(
                     self.config._attn_implementation,
@@ -352,9 +368,11 @@ def apply_export_patches() -> None:
 
     def _safe_deepcopy(obj, *args, **kwargs):
         from transformers.cache_utils import DynamicCache
+
         if isinstance(obj, DynamicCache):
             return obj
         return _orig_deepcopy(obj, *args, **kwargs)
+
     copy.deepcopy = _safe_deepcopy
 
     # SmolVLA pad_tensor/pad_vector: replace slice-assign with torch.cat so
@@ -368,10 +386,13 @@ def apply_export_patches() -> None:
                 return tensor[:, :max_len]
             pad_shape = (b, max_len - d, *tensor.shape[2:])
             pad = torch.full(
-                pad_shape, float(pad_value),
-                dtype=tensor.dtype, device=tensor.device,
+                pad_shape,
+                float(pad_value),
+                dtype=tensor.dtype,
+                device=tensor.device,
             )
             return torch.cat([tensor, pad], dim=1)
+
         _smv.pad_tensor = _safe_pad_tensor
 
         def _safe_pad_vector(vector, new_dim):
@@ -381,6 +402,7 @@ def apply_export_patches() -> None:
             pad_shape = (*vector.shape[:-1], new_dim - current_dim)
             pad = torch.zeros(pad_shape, dtype=vector.dtype, device=vector.device)
             return torch.cat([vector, pad], dim=-1)
+
         _smv.pad_vector = _safe_pad_vector
     except ImportError:
         pass
@@ -391,8 +413,10 @@ def apply_export_patches() -> None:
 
     def _safe_where(condition, x=None, y=None, *args, **kwargs):
         if (
-            x is not None and y is not None
-            and hasattr(x, "dtype") and hasattr(y, "dtype")
+            x is not None
+            and y is not None
+            and hasattr(x, "dtype")
+            and hasattr(y, "dtype")
             and x.dtype != y.dtype
         ):
             common = torch.promote_types(x.dtype, y.dtype)
@@ -401,6 +425,7 @@ def apply_export_patches() -> None:
             if y.dtype != common:
                 y = y.to(common)
         return _orig_where(condition, x, y, *args, **kwargs)
+
     torch.where = _safe_where
 
     # pi0-specific: PaliGemmaWithExpertModel.embed_image image_outputs extraction
@@ -414,10 +439,11 @@ def apply_export_patches() -> None:
                 image = image.to(_t.float32)
             out = self.paligemma.model.get_image_features(image)
             features = out.pooler_output if hasattr(out, "pooler_output") else out
-            features = features * self.paligemma.config.text_config.hidden_size ** 0.5
+            features = features * self.paligemma.config.text_config.hidden_size**0.5
             if features.dtype != out_dtype:
                 features = features.to(out_dtype)
             return features
+
         modeling_pi0.PaliGemmaWithExpertModel.embed_image = _patched_embed_image
     except ImportError:
         pass
@@ -468,15 +494,20 @@ def apply_export_patches() -> None:
                     new_v = torch.cat([past_v, value_states], dim=-2)
                     return new_k, new_v
             return _orig_layer_update(self, key_states, value_states, cache_kwargs)
+
         _DL.update = _frozen_layer_update
 
         def _patched_denoise_step(self, state, prefix_pad_masks, past_key_values, x_t, timestep):
             suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
-                state, x_t, timestep,
+                state,
+                x_t,
+                timestep,
             )
             suffix_len = suffix_pad_masks.shape[1]
             batch_size = prefix_pad_masks.shape[0]
-            cached_prefix_len = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cached_prefix_len = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
             prefix_len = max(cached_prefix_len, prefix_pad_masks.shape[1])
 
             pad_deficit = prefix_len - prefix_pad_masks.shape[1]
@@ -484,7 +515,9 @@ def apply_export_patches() -> None:
             if pad_deficit > 0:
                 prefix_pad_masks_extended = _F.pad(prefix_pad_masks, (0, pad_deficit), value=True)
 
-            prefix_pad_2d_masks = prefix_pad_masks_extended[:, None, :].expand(batch_size, suffix_len, prefix_len)
+            prefix_pad_2d_masks = prefix_pad_masks_extended[:, None, :].expand(
+                batch_size, suffix_len, prefix_len
+            )
             suffix_att_2d_masks = _make_att_2d_masks(suffix_pad_masks, suffix_att_masks)
 
             prefix_allowed = _F.pad(prefix_pad_2d_masks, (0, suffix_len), value=True)
@@ -506,7 +539,7 @@ def apply_export_patches() -> None:
                 adarms_cond=[None, adarms_cond],
             )
             suffix_out = outputs_embeds[1]
-            suffix_out = suffix_out[:, -self.config.chunk_size:]
+            suffix_out = suffix_out[:, -self.config.chunk_size :]
             suffix_out = suffix_out.to(dtype=torch.float32)
             return self.action_out_proj(suffix_out)
 
@@ -546,12 +579,14 @@ def _fix_onnx_where_dtype_mismatches(onnx_path: Path) -> int:
     from onnx import helper, TensorProto
 
     model = onnx.load(str(onnx_path), load_external_data=False)
-    shape_info = onnx.shape_inference.infer_shapes(
-        model, check_type=False, strict_mode=False
-    )
+    shape_info = onnx.shape_inference.infer_shapes(model, check_type=False, strict_mode=False)
 
     name_dtype: dict[str, int] = {}
-    for vi in list(shape_info.graph.value_info) + list(shape_info.graph.input) + list(shape_info.graph.output):
+    for vi in (
+        list(shape_info.graph.value_info)
+        + list(shape_info.graph.input)
+        + list(shape_info.graph.output)
+    ):
         if vi.type.tensor_type.elem_type:
             name_dtype[vi.name] = vi.type.tensor_type.elem_type
     for init in shape_info.graph.initializer:
@@ -581,16 +616,22 @@ def _fix_onnx_where_dtype_mismatches(onnx_path: Path) -> int:
         if x_dt != target_dt:
             cast_out = f"{node.name}__cast_x"
             cast_node = helper.make_node(
-                "Cast", [x_name], [cast_out],
-                name=f"{node.name}__cast_x_node", to=target_dt,
+                "Cast",
+                [x_name],
+                [cast_out],
+                name=f"{node.name}__cast_x_node",
+                to=target_dt,
             )
             fixes_this.append(cast_node)
             node.input[1] = cast_out
         if y_dt != target_dt:
             cast_out = f"{node.name}__cast_y"
             cast_node = helper.make_node(
-                "Cast", [y_name], [cast_out],
-                name=f"{node.name}__cast_y_node", to=target_dt,
+                "Cast",
+                [y_name],
+                [cast_out],
+                name=f"{node.name}__cast_y_node",
+                to=target_dt,
             )
             fixes_this.append(cast_node)
             node.input[2] = cast_out
@@ -599,7 +640,11 @@ def _fix_onnx_where_dtype_mismatches(onnx_path: Path) -> int:
         fixes += 1
         logger.info(
             "fixed Where node %s (X=%s, Y=%s, out_decl=%s -> target=%s)",
-            node.name, x_dt, y_dt, out_dt, target_dt,
+            node.name,
+            x_dt,
+            y_dt,
+            out_dt,
+            target_dt,
         )
 
     if fixes > 0:
@@ -643,6 +688,7 @@ def export_smolvla_monolithic(
 
     logger.info("[smolvla] Loading %s", model_id)
     from lerobot.policies.smolvla.modeling_smolvla import SmolVLAPolicy
+
     t0 = time.time()
     policy = SmolVLAPolicy.from_pretrained(model_id)
     policy.eval().to("cpu").to(torch.float32)
@@ -657,15 +703,26 @@ def export_smolvla_monolithic(
 
         def forward(
             self,
-            img_cam1, img_cam2, img_cam3,
-            mask_cam1, mask_cam2, mask_cam3,
-            lang_tokens, lang_masks,
-            state, noise,
+            img_cam1,
+            img_cam2,
+            img_cam3,
+            mask_cam1,
+            mask_cam2,
+            mask_cam3,
+            lang_tokens,
+            lang_masks,
+            state,
+            noise,
         ):
             images = [img_cam1, img_cam2, img_cam3]
             img_masks = [mask_cam1, mask_cam2, mask_cam3]
             return self.model.sample_actions(
-                images, img_masks, lang_tokens, lang_masks, state, noise=noise,
+                images,
+                img_masks,
+                lang_tokens,
+                lang_masks,
+                state,
+                noise=noise,
             )
 
     wrapper = SmolVLAMonolithicWrapper(policy.model).eval()
@@ -696,16 +753,21 @@ def export_smolvla_monolithic(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep = torch.export.export(
-            wrapper, tuple(dummy.values()),
-            dynamic_shapes=None, strict=False,
+            wrapper,
+            tuple(dummy.values()),
+            dynamic_shapes=None,
+            strict=False,
         )
     logger.info("[smolvla] torch.export: %.1fs", time.time() - t0)
 
     logger.info("[smolvla] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
-        ep, tuple(dummy.values()), str(onnx_path),
-        input_names=list(dummy.keys()), output_names=["actions"],
+        ep,
+        tuple(dummy.values()),
+        str(onnx_path),
+        input_names=list(dummy.keys()),
+        output_names=["actions"],
         opset_version=19,
     )
     logger.info("[smolvla] ONNX conversion: %.1fs", time.time() - t0)
@@ -714,8 +776,12 @@ def export_smolvla_monolithic(
     logger.info("[smolvla] post-export Cast fixes: %d", fixes)
 
     _write_tether_config(
-        output_dir, policy.config, num_steps=num_steps,
-        model_id=model_id, model_type="smolvla", target=target,
+        output_dir,
+        policy.config,
+        num_steps=num_steps,
+        model_id=model_id,
+        model_type="smolvla",
+        target=target,
     )
 
     size_mb = onnx_path.stat().st_size / 1e6
@@ -753,13 +819,14 @@ def export_pi0_monolithic(
 
     logger.info("[pi0] Loading %s", model_id)
     from lerobot.policies.pi0.modeling_pi0 import PI0Policy
+
     t0 = time.time()
     # Block torch.compile during from_pretrained — see pi05 branch for the
     # "Guard failed on same frame" bug. pi0_base defaults to False so this
     # is a no-op for canonical exports, but any fine-tuned pi0 config with
     # compile_model=True (common pattern) would otherwise break the trace.
     _orig_compile = torch.compile
-    torch.compile = lambda fn=None, *a, **kw: (fn if fn is not None else (lambda f: f))
+    torch.compile = lambda fn=None, *a, **kw: fn if fn is not None else (lambda f: f)
     try:
         policy = PI0Policy.from_pretrained(model_id)
     finally:
@@ -779,16 +846,27 @@ def export_pi0_monolithic(
 
         def forward(
             self,
-            img_base, img_wrist_l, img_wrist_r,
-            mask_base, mask_wrist_l, mask_wrist_r,
-            lang_tokens, lang_masks,
-            state, noise,
+            img_base,
+            img_wrist_l,
+            img_wrist_r,
+            mask_base,
+            mask_wrist_l,
+            mask_wrist_r,
+            lang_tokens,
+            lang_masks,
+            state,
+            noise,
         ):
             images = [img_base, img_wrist_l, img_wrist_r]
             img_masks = [mask_base, mask_wrist_l, mask_wrist_r]
             return self.model.sample_actions(
-                images, img_masks, lang_tokens, lang_masks, state,
-                noise=noise, num_steps=self.n_steps,
+                images,
+                img_masks,
+                lang_tokens,
+                lang_masks,
+                state,
+                noise=noise,
+                num_steps=self.n_steps,
             )
 
     wrapper = Pi0MonolithicWrapper(policy.model, num_steps).eval()
@@ -819,16 +897,21 @@ def export_pi0_monolithic(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep = torch.export.export(
-            wrapper, tuple(dummy.values()),
-            dynamic_shapes=None, strict=False,
+            wrapper,
+            tuple(dummy.values()),
+            dynamic_shapes=None,
+            strict=False,
         )
     logger.info("[pi0] torch.export: %.1fs", time.time() - t0)
 
     logger.info("[pi0] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
-        ep, tuple(dummy.values()), str(onnx_path),
-        input_names=list(dummy.keys()), output_names=["actions"],
+        ep,
+        tuple(dummy.values()),
+        str(onnx_path),
+        input_names=list(dummy.keys()),
+        output_names=["actions"],
         opset_version=19,
     )
     logger.info("[pi0] ONNX conversion: %.1fs", time.time() - t0)
@@ -837,8 +920,12 @@ def export_pi0_monolithic(
     logger.info("[pi0] post-export Cast fixes: %d", fixes)
 
     _write_tether_config(
-        output_dir, policy.config, num_steps=num_steps,
-        model_id=model_id, model_type="pi0", target=target,
+        output_dir,
+        policy.config,
+        num_steps=num_steps,
+        model_id=model_id,
+        model_type="pi0",
+        target=target,
     )
 
     size_mb = onnx_path.stat().st_size / 1e6
@@ -873,13 +960,13 @@ def _write_tether_config(
         "action_dim": getattr(policy_config, "max_action_dim", 32),
         "max_state_dim": getattr(policy_config, "max_state_dim", 32),
         "opset": 19,
-        "export_kind": "monolithic",
+        "export_kind": "monolithic_onnx",
         "notes": _CCM_NONE_RATIONALE if num_steps > 1 else None,
         **tokenizer_meta,
     }
-    (output_dir / "tether_config.json").write_text(
-        json.dumps(cfg_dict, indent=2, default=str)
-    )
+    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+
+    write_tether_config(output_dir, normalize_legacy_tether_config(cfg_dict, output_dir))
 
     # Seed VERIFICATION.md at export time — every export ships a receipt,
     # even before `tether validate` fills in the parity numbers. Callers
@@ -888,6 +975,7 @@ def _write_tether_config(
     # actual export (the ONNX is already on disk by this point).
     try:
         from tether.verification_report import write_verification_report
+
         write_verification_report(output_dir, parity=None)
     except Exception:
         pass
@@ -921,6 +1009,7 @@ def export_pi05_monolithic(
 
     logger.info("[pi05] Loading %s", model_id)
     from lerobot.policies.pi05.modeling_pi05 import PI05Policy
+
     t0 = time.time()
     # Block torch.compile during from_pretrained: LIBERO-finetuned configs
     # (e.g. lerobot/pi05_libero_finetuned_v044) ship with compile_model=True,
@@ -929,7 +1018,7 @@ def export_pi05_monolithic(
     # raise "Guard failed on same frame it was created" during export. Disable
     # the compile step for the duration of the load.
     _orig_compile = torch.compile
-    torch.compile = lambda fn=None, *a, **kw: (fn if fn is not None else (lambda f: f))
+    torch.compile = lambda fn=None, *a, **kw: fn if fn is not None else (lambda f: f)
     try:
         policy = PI05Policy.from_pretrained(model_id)
     finally:
@@ -959,17 +1048,26 @@ def export_pi05_monolithic(
 
         def forward(
             self,
-            img_base, img_wrist_l, img_wrist_r,
-            mask_base, mask_wrist_l, mask_wrist_r,
-            lang_tokens, lang_masks,
+            img_base,
+            img_wrist_l,
+            img_wrist_r,
+            mask_base,
+            mask_wrist_l,
+            mask_wrist_r,
+            lang_tokens,
+            lang_masks,
             noise,
         ):
             # pi0.5: no state arg (state is in lang_tokens).
             images = [img_base, img_wrist_l, img_wrist_r]
             img_masks = [mask_base, mask_wrist_l, mask_wrist_r]
             return self.model.sample_actions(
-                images, img_masks, lang_tokens, lang_masks,
-                noise=noise, num_steps=self.n_steps,
+                images,
+                img_masks,
+                lang_tokens,
+                lang_masks,
+                noise=noise,
+                num_steps=self.n_steps,
             )
 
     wrapper = Pi05MonolithicWrapper(policy.model, num_steps).eval()
@@ -998,16 +1096,21 @@ def export_pi05_monolithic(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep = torch.export.export(
-            wrapper, tuple(dummy.values()),
-            dynamic_shapes=None, strict=False,
+            wrapper,
+            tuple(dummy.values()),
+            dynamic_shapes=None,
+            strict=False,
         )
     logger.info("[pi05] torch.export: %.1fs", time.time() - t0)
 
     logger.info("[pi05] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
-        ep, tuple(dummy.values()), str(onnx_path),
-        input_names=list(dummy.keys()), output_names=["actions"],
+        ep,
+        tuple(dummy.values()),
+        str(onnx_path),
+        input_names=list(dummy.keys()),
+        output_names=["actions"],
         opset_version=19,
     )
     logger.info("[pi05] ONNX conversion: %.1fs", time.time() - t0)
@@ -1016,8 +1119,12 @@ def export_pi05_monolithic(
     logger.info("[pi05] post-export Cast fixes: %d", fixes)
 
     _write_tether_config(
-        output_dir, policy.config, num_steps=num_steps,
-        model_id=model_id, model_type="pi05", target=target,
+        output_dir,
+        policy.config,
+        num_steps=num_steps,
+        model_id=model_id,
+        model_type="pi05",
+        target=target,
     )
 
     size_mb = onnx_path.stat().st_size / 1e6
@@ -1054,11 +1161,14 @@ def _apply_pi05_denoise_step_patch() -> None:
         def _patched(self, prefix_pad_masks, past_key_values, x_t, timestep):
             # pi0.5: NO state arg (tokenized into language upstream).
             suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
-                x_t, timestep,
+                x_t,
+                timestep,
             )
             suffix_len = suffix_pad_masks.shape[1]
             batch_size = prefix_pad_masks.shape[0]
-            cached_prefix_len = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cached_prefix_len = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
             prefix_len = max(cached_prefix_len, prefix_pad_masks.shape[1])
 
             pad_deficit = prefix_len - prefix_pad_masks.shape[1]
@@ -1066,7 +1176,9 @@ def _apply_pi05_denoise_step_patch() -> None:
             if pad_deficit > 0:
                 prefix_pad_masks_extended = _F.pad(prefix_pad_masks, (0, pad_deficit), value=True)
 
-            prefix_pad_2d_masks = prefix_pad_masks_extended[:, None, :].expand(batch_size, suffix_len, prefix_len)
+            prefix_pad_2d_masks = prefix_pad_masks_extended[:, None, :].expand(
+                batch_size, suffix_len, prefix_len
+            )
             suffix_att_2d_masks = _make(suffix_pad_masks, suffix_att_masks)
 
             prefix_allowed = _F.pad(prefix_pad_2d_masks, (0, suffix_len), value=True)
@@ -1088,7 +1200,7 @@ def _apply_pi05_denoise_step_patch() -> None:
                 adarms_cond=[None, adarms_cond],
             )
             suffix_out = outputs_embeds[1]
-            suffix_out = suffix_out[:, -self.config.chunk_size:]
+            suffix_out = suffix_out[:, -self.config.chunk_size :]
             suffix_out = suffix_out.to(dtype=torch.float32)
             return self.action_out_proj(suffix_out)
 
@@ -1159,8 +1271,7 @@ def export_snapflow_student_monolithic(
 
     if not (is_pi05 or is_pi0):
         raise TypeError(
-            f"SnapFlow export supports pi0 / pi0.5 students only; got "
-            f"{type(policy.model).__name__}"
+            f"SnapFlow export supports pi0 / pi0.5 students only; got {type(policy.model).__name__}"
         )
 
     # Monkey-patch the SnapFlow denoise_step to drop detach+deepcopy for
@@ -1174,6 +1285,7 @@ def export_snapflow_student_monolithic(
     logger.info("[snapflow-export] Family=%s, wrapping for export", family)
 
     if is_pi05:
+
         class SnapFlowStudentWrapper(nn.Module):
             def __init__(self, model):
                 super().__init__()
@@ -1181,17 +1293,25 @@ def export_snapflow_student_monolithic(
 
             def forward(
                 self,
-                img_base, img_wrist_l, img_wrist_r,
-                mask_base, mask_wrist_l, mask_wrist_r,
-                lang_tokens, lang_masks,
+                img_base,
+                img_wrist_l,
+                img_wrist_r,
+                mask_base,
+                mask_wrist_l,
+                mask_wrist_r,
+                lang_tokens,
+                lang_masks,
                 noise,
             ):
                 return self.model.sample_actions_1step(
                     [img_base, img_wrist_l, img_wrist_r],
                     [mask_base, mask_wrist_l, mask_wrist_r],
-                    lang_tokens, lang_masks, noise=noise,
+                    lang_tokens,
+                    lang_masks,
+                    noise=noise,
                 )
     else:
+
         class SnapFlowStudentWrapper(nn.Module):
             def __init__(self, model):
                 super().__init__()
@@ -1199,15 +1319,24 @@ def export_snapflow_student_monolithic(
 
             def forward(
                 self,
-                img_cam1, img_cam2, img_cam3,
-                mask_cam1, mask_cam2, mask_cam3,
-                lang_tokens, lang_masks,
-                state, noise,
+                img_cam1,
+                img_cam2,
+                img_cam3,
+                mask_cam1,
+                mask_cam2,
+                mask_cam3,
+                lang_tokens,
+                lang_masks,
+                state,
+                noise,
             ):
                 return self.model.sample_actions_1step(
                     [img_cam1, img_cam2, img_cam3],
                     [mask_cam1, mask_cam2, mask_cam3],
-                    lang_tokens, lang_masks, state, noise=noise,
+                    lang_tokens,
+                    lang_masks,
+                    state,
+                    noise=noise,
                 )
 
     wrapper = SnapFlowStudentWrapper(policy.model).eval()
@@ -1251,16 +1380,21 @@ def export_snapflow_student_monolithic(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep = torch.export.export(
-            wrapper, tuple(dummy.values()),
-            dynamic_shapes=None, strict=False,
+            wrapper,
+            tuple(dummy.values()),
+            dynamic_shapes=None,
+            strict=False,
         )
     logger.info("[snapflow-export] torch.export: %.1fs", time.time() - t0)
 
     logger.info("[snapflow-export] torch.onnx.export ...")
     t0 = time.time()
     torch.onnx.export(
-        ep, tuple(dummy.values()), str(onnx_path),
-        input_names=list(dummy.keys()), output_names=["actions"],
+        ep,
+        tuple(dummy.values()),
+        str(onnx_path),
+        input_names=list(dummy.keys()),
+        output_names=["actions"],
         opset_version=19,
     )
     logger.info("[snapflow-export] ONNX conversion: %.1fs", time.time() - t0)
@@ -1269,8 +1403,11 @@ def export_snapflow_student_monolithic(
     logger.info("[snapflow-export] post-export Cast fixes: %d", fixes)
 
     _write_tether_config(
-        output_dir, policy.config, num_steps=1,
-        model_id=str(checkpoint_path), model_type=f"{family}_snapflow",
+        output_dir,
+        policy.config,
+        num_steps=1,
+        model_id=str(checkpoint_path),
+        model_type=f"{family}_snapflow",
         target=target,
     )
 
@@ -1303,17 +1440,23 @@ def _install_snapflow_export_denoise_step(model: Any, *, is_pi05: bool) -> None:
         from lerobot.policies.pi0.modeling_pi0 import make_att_2d_masks
 
     if is_pi05:
-        def _export_denoise_step(self, prefix_pad_masks, past_key_values, x_t,
-                                 timestep, target_time=None, state=None):
+
+        def _export_denoise_step(
+            self, prefix_pad_masks, past_key_values, x_t, timestep, target_time=None, state=None
+        ):
             suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
-                x_t, timestep, target_time=target_time,
+                x_t,
+                timestep,
+                target_time=target_time,
             )
             suffix_len = suffix_pad_masks.shape[1]
             batch_size = prefix_pad_masks.shape[0]
             prefix_len = prefix_pad_masks.shape[1]
 
             prefix_pad_2d_masks = prefix_pad_masks[:, None, :].expand(
-                batch_size, suffix_len, prefix_len,
+                batch_size,
+                suffix_len,
+                prefix_len,
             )
             suffix_att_2d_masks = make_att_2d_masks(suffix_pad_masks, suffix_att_masks)
             prefix_allowed = _F.pad(prefix_pad_2d_masks, (0, suffix_len), value=True)
@@ -1333,21 +1476,28 @@ def _install_snapflow_export_denoise_step(model: Any, *, is_pi05: bool) -> None:
                 use_cache=False,
                 adarms_cond=[None, adarms_cond],
             )
-            suffix_out = outputs_embeds[1][:, -self.config.chunk_size:]
+            suffix_out = outputs_embeds[1][:, -self.config.chunk_size :]
             suffix_out = suffix_out.to(dtype=self.action_out_proj.weight.dtype)
             return self.action_out_proj(suffix_out)
     else:
-        def _export_denoise_step(self, state, prefix_pad_masks, past_key_values,
-                                 x_t, timestep, target_time=None):
+
+        def _export_denoise_step(
+            self, state, prefix_pad_masks, past_key_values, x_t, timestep, target_time=None
+        ):
             suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
-                state, x_t, timestep, target_time=target_time,
+                state,
+                x_t,
+                timestep,
+                target_time=target_time,
             )
             suffix_len = suffix_pad_masks.shape[1]
             batch_size = prefix_pad_masks.shape[0]
             prefix_len = prefix_pad_masks.shape[1]
 
             prefix_pad_2d_masks = prefix_pad_masks[:, None, :].expand(
-                batch_size, suffix_len, prefix_len,
+                batch_size,
+                suffix_len,
+                prefix_len,
             )
             suffix_att_2d_masks = make_att_2d_masks(suffix_pad_masks, suffix_att_masks)
             prefix_allowed = _F.pad(prefix_pad_2d_masks, (0, suffix_len), value=True)
@@ -1367,7 +1517,7 @@ def _install_snapflow_export_denoise_step(model: Any, *, is_pi05: bool) -> None:
                 use_cache=False,
                 adarms_cond=[None, adarms_cond],
             )
-            suffix_out = outputs_embeds[1][:, -self.config.chunk_size:]
+            suffix_out = outputs_embeds[1][:, -self.config.chunk_size :]
             suffix_out = suffix_out.to(dtype=self.action_out_proj.weight.dtype)
             return self.action_out_proj(suffix_out)
 
@@ -1415,9 +1565,12 @@ def export_gr00t_monolithic(
     t0 = time.time()
     full, meta = build_gr00t_full_stack(state_dict, embodiment_id=embodiment_id)
     full.eval()
-    logger.info("[gr00t] Built in %.1fs — raw_action_dim=%d, params=%.1fM",
-                time.time() - t0, meta["raw_action_dim"],
-                meta["full_stack_params_m"])
+    logger.info(
+        "[gr00t] Built in %.1fs — raw_action_dim=%d, params=%.1fM",
+        time.time() - t0,
+        meta["raw_action_dim"],
+        meta["full_stack_params_m"],
+    )
 
     raw_action_dim = meta["raw_action_dim"]
     chunk = 50
@@ -1450,11 +1603,15 @@ def export_gr00t_monolithic(
 
     _write_tether_config(
         output_dir,
-        type("GR00TConfig", (), {
-            "chunk_size": chunk,
-            "max_action_dim": raw_action_dim,
-            "num_steps": num_steps,
-        })(),
+        type(
+            "GR00TConfig",
+            (),
+            {
+                "chunk_size": chunk,
+                "max_action_dim": raw_action_dim,
+                "num_steps": num_steps,
+            },
+        )(),
         num_steps=num_steps,
         model_id=model_id,
         model_type="gr00t",
@@ -1509,11 +1666,7 @@ def _model_type_from_local_config(model_id: str) -> str | None:
     # lerobot policy convention: 'policy_type' field.
     # SnapFlow checkpoint convention: 'type' field
     # (e.g., 'pi05', 'smolvla'). Caught by 2026-04-25 distill smoke v2.
-    raw = (
-        cfg.get("model_type")
-        or cfg.get("policy_type")
-        or cfg.get("type")
-    )
+    raw = cfg.get("model_type") or cfg.get("policy_type") or cfg.get("type")
     if not isinstance(raw, str):
         return None
     raw = raw.lower()
@@ -1582,9 +1735,7 @@ def export_monolithic(
         gr00t_steps = 4 if num_steps == 10 else num_steps
         result = export_gr00t_monolithic(model_id, output_dir, num_steps=gr00t_steps, target=target)
     else:
-        raise ValueError(
-            f"Monolithic export for model_type={model_type!r} not yet supported."
-        )
+        raise ValueError(f"Monolithic export for model_type={model_type!r} not yet supported.")
 
     # Post-export weight fusion pass (lifted from dexmal/realtime-vla MIT).
     # Fuses RMSNorm scales into MatMul weights, folds Euler dt into output
@@ -1593,6 +1744,7 @@ def export_monolithic(
     if onnx_path:
         try:
             from tether.exporters.weight_fusion import fuse_weights
+
             fused_path = fuse_weights(onnx_path, num_steps=num_steps)
             logger.info("Weight fusion pass complete: %s", fused_path)
         except Exception as e:

--- a/src/tether/exporters/pi0.py
+++ b/src/tether/exporters/pi0.py
@@ -14,16 +14,12 @@ Key differences from SmolVLA:
 
 from __future__ import annotations
 
-import json
 import logging
-import time
 from pathlib import Path
 from typing import Any
 
 import torch
 import torch.nn as nn
-
-import math
 
 import torch.nn.functional as F
 
@@ -31,7 +27,9 @@ from tether.config import ExportConfig, get_hardware_profile
 from tether.checkpoint import load_checkpoint
 from tether.exporters.onnx_export import export_module_to_onnx, optimize_onnx
 from tether.models.heads.expert_stack import (
-    ExpertGQALayer, ExpertStack, Pi05ExpertGQALayer, _DecomposedRoPE,
+    ExpertGQALayer,
+    ExpertStack,
+    Pi05ExpertGQALayer,
     _sinusoidal_pos_embedding,
 )
 from tether.exporters.trt_build import build_engine, check_trtexec
@@ -97,7 +95,7 @@ def build_pi0_expert_stack(
     for k in state_dict.keys():
         if not k.startswith(base_prefix + "layers."):
             continue
-        parts = k[len(base_prefix):].split(".")
+        parts = k[len(base_prefix) :].split(".")
         if len(parts) >= 2 and parts[0] == "layers" and parts[1].isdigit():
             layer_indices.add(int(parts[1]))
     if not layer_indices:
@@ -114,7 +112,13 @@ def build_pi0_expert_stack(
 
     logger.info(
         "pi0 expert: %d layers, hidden=%d, nq=%d, nkv=%d, head_dim=%d, inter=%d, action_dim=%d",
-        num_layers, expert_hidden, nq, nkv, head_dim, inter, action_dim,
+        num_layers,
+        expert_hidden,
+        nq,
+        nkv,
+        head_dim,
+        inter,
+        action_dim,
     )
 
     # 5. Build layers — pi0 expert does NOT use cross-attention (unlike SmolVLA)
@@ -136,7 +140,11 @@ def build_pi0_expert_stack(
         # Without this override RoPE frequencies are ~10x too small → positions
         # barely affect attention → expert output insensitive to position_ids.
         layer = ExpertGQALayer(
-            expert_hidden, nq, nkv, head_dim, inter,
+            expert_hidden,
+            nq,
+            nkv,
+            head_dim,
+            inter,
             kv_in=kv_in if is_cross else None,
             rope_theta=10000.0,
         )
@@ -247,7 +255,11 @@ def export_pi0(
         expert_onnx,
         input_names=["noisy_actions", "timestep", "position_ids"],
         output_names=["velocity"],
-        dynamic_axes={"noisy_actions": {0: "batch"}, "timestep": {0: "batch"}, "position_ids": {0: "batch"}},
+        dynamic_axes={
+            "noisy_actions": {0: "batch"},
+            "timestep": {0: "batch"},
+            "position_ids": {0: "batch"},
+        },
         opset_version=config.opset,
     )
     optimize_onnx(expert_onnx)
@@ -261,15 +273,25 @@ def export_pi0(
             import numpy as np
 
             sess = ort.InferenceSession(str(expert_onnx))
-            ort_out = sess.run(None, {
-                "noisy_actions": dummy_actions.numpy(),
-                "timestep": dummy_time.numpy(),
-                "position_ids": dummy_pos.numpy().astype(np.int64),
-            })[0]
+            ort_out = sess.run(
+                None,
+                {
+                    "noisy_actions": dummy_actions.numpy(),
+                    "timestep": dummy_time.numpy(),
+                    "position_ids": dummy_pos.numpy().astype(np.int64),
+                },
+            )[0]
             torch_out = expert_stack(dummy_actions, dummy_time, dummy_pos).detach().numpy()
             max_diff = float(np.abs(ort_out - torch_out).max())
-            result["metadata"]["onnx_validation"] = {"max_diff": max_diff, "passed": max_diff < 0.01}
-            logger.info("ONNX validation: max_diff=%.2e (%s)", max_diff, "PASS" if max_diff < 0.01 else "FAIL")
+            result["metadata"]["onnx_validation"] = {
+                "max_diff": max_diff,
+                "passed": max_diff < 0.01,
+            }
+            logger.info(
+                "ONNX validation: max_diff=%.2e (%s)",
+                max_diff,
+                "PASS" if max_diff < 0.01 else "FAIL",
+            )
         except ImportError:
             logger.warning("onnxruntime not installed, skipping validation")
 
@@ -287,6 +309,7 @@ def export_pi0(
     export_config = {
         "model_id": config.model_id,
         "model_type": "pi0",
+        "export_kind": "decomposed_onnx",
         "target": config.target,
         "precision": config.precision,
         "opset": config.opset,
@@ -301,8 +324,11 @@ def export_pi0(
         },
         "expert": expert_meta,
     }
-    config_path = output_dir / "tether_config.json"
-    config_path.write_text(json.dumps(export_config, indent=2))
+    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+
+    config_path = write_tether_config(
+        output_dir, normalize_legacy_tether_config(export_config, output_dir)
+    )
     result["files"]["config"] = str(config_path)
     return result
 
@@ -317,8 +343,16 @@ def export_pi0(
 class Pi05ExpertStack(nn.Module):
     """Expert stack for pi0.5 — time embedding flows through every layer."""
 
-    def __init__(self, layers, expert_hidden, action_dim, time_mlp_weights,
-                 action_proj_weights, in_proj_weights, final_norm_weights):
+    def __init__(
+        self,
+        layers,
+        expert_hidden,
+        action_dim,
+        time_mlp_weights,
+        action_proj_weights,
+        in_proj_weights,
+        final_norm_weights,
+    ):
         super().__init__()
         self.layers = nn.ModuleList(layers)
         self.expert_hidden = expert_hidden
@@ -389,7 +423,7 @@ def build_pi05_expert_stack(
     for k in state_dict.keys():
         if not k.startswith(base_prefix + "layers."):
             continue
-        parts = k[len(base_prefix):].split(".")
+        parts = k[len(base_prefix) :].split(".")
         if len(parts) >= 2 and parts[0] == "layers" and parts[1].isdigit():
             layer_indices.add(int(parts[1]))
     if not layer_indices:
@@ -406,7 +440,13 @@ def build_pi05_expert_stack(
 
     logger.info(
         "pi0.5 expert: %d layers, hidden=%d, nq=%d, nkv=%d, head_dim=%d, inter=%d, action_dim=%d",
-        num_layers, expert_hidden, nq, nkv, head_dim, inter, action_dim,
+        num_layers,
+        expert_hidden,
+        nq,
+        nkv,
+        head_dim,
+        inter,
+        action_dim,
     )
 
     # 5. Build layers with AdaRMSNorm
@@ -420,8 +460,12 @@ def build_pi05_expert_stack(
         layer_sd = {
             "input_layernorm.dense.weight": state_dict[f"{prefix}.input_layernorm.dense.weight"],
             "input_layernorm.dense.bias": state_dict[f"{prefix}.input_layernorm.dense.bias"],
-            "post_attention_layernorm.dense.weight": state_dict[f"{prefix}.post_attention_layernorm.dense.weight"],
-            "post_attention_layernorm.dense.bias": state_dict[f"{prefix}.post_attention_layernorm.dense.bias"],
+            "post_attention_layernorm.dense.weight": state_dict[
+                f"{prefix}.post_attention_layernorm.dense.weight"
+            ],
+            "post_attention_layernorm.dense.bias": state_dict[
+                f"{prefix}.post_attention_layernorm.dense.bias"
+            ],
             "q_proj.weight": state_dict[f"{prefix}.self_attn.q_proj.weight"],
             "k_proj.weight": state_dict[f"{prefix}.self_attn.k_proj.weight"],
             "v_proj.weight": state_dict[f"{prefix}.self_attn.v_proj.weight"],
@@ -515,7 +559,11 @@ def export_pi05(
         expert_onnx,
         input_names=["noisy_actions", "timestep", "position_ids"],
         output_names=["velocity"],
-        dynamic_axes={"noisy_actions": {0: "batch"}, "timestep": {0: "batch"}, "position_ids": {0: "batch"}},
+        dynamic_axes={
+            "noisy_actions": {0: "batch"},
+            "timestep": {0: "batch"},
+            "position_ids": {0: "batch"},
+        },
         opset_version=config.opset,
     )
     optimize_onnx(expert_onnx)
@@ -525,16 +573,27 @@ def export_pi05(
         try:
             import onnxruntime as ort
             import numpy as np
+
             sess = ort.InferenceSession(str(expert_onnx))
-            ort_out = sess.run(None, {
-                "noisy_actions": dummy_actions.numpy(),
-                "timestep": dummy_time.numpy(),
-                "position_ids": dummy_pos.numpy().astype(np.int64),
-            })[0]
+            ort_out = sess.run(
+                None,
+                {
+                    "noisy_actions": dummy_actions.numpy(),
+                    "timestep": dummy_time.numpy(),
+                    "position_ids": dummy_pos.numpy().astype(np.int64),
+                },
+            )[0]
             torch_out = expert_stack(dummy_actions, dummy_time, dummy_pos).detach().numpy()
             max_diff = float(np.abs(ort_out - torch_out).max())
-            result["metadata"]["onnx_validation"] = {"max_diff": max_diff, "passed": max_diff < 0.01}
-            logger.info("ONNX validation: max_diff=%.2e (%s)", max_diff, "PASS" if max_diff < 0.01 else "FAIL")
+            result["metadata"]["onnx_validation"] = {
+                "max_diff": max_diff,
+                "passed": max_diff < 0.01,
+            }
+            logger.info(
+                "ONNX validation: max_diff=%.2e (%s)",
+                max_diff,
+                "PASS" if max_diff < 0.01 else "FAIL",
+            )
         except ImportError:
             logger.warning("onnxruntime not installed, skipping validation")
 
@@ -549,6 +608,7 @@ def export_pi05(
     export_config = {
         "model_id": config.model_id,
         "model_type": "pi05",
+        "export_kind": "decomposed_onnx",
         "target": config.target,
         "precision": config.precision,
         "opset": config.opset,
@@ -563,7 +623,10 @@ def export_pi05(
         },
         "expert": expert_meta,
     }
-    config_path = output_dir / "tether_config.json"
-    config_path.write_text(json.dumps(export_config, indent=2))
+    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+
+    config_path = write_tether_config(
+        output_dir, normalize_legacy_tether_config(export_config, output_dir)
+    )
     result["files"]["config"] = str(config_path)
     return result

--- a/src/tether/exporters/pi0.py
+++ b/src/tether/exporters/pi0.py
@@ -95,7 +95,7 @@ def build_pi0_expert_stack(
     for k in state_dict.keys():
         if not k.startswith(base_prefix + "layers."):
             continue
-        parts = k[len(base_prefix) :].split(".")
+        parts = k[len(base_prefix):].split(".")
         if len(parts) >= 2 and parts[0] == "layers" and parts[1].isdigit():
             layer_indices.add(int(parts[1]))
     if not layer_indices:
@@ -112,13 +112,7 @@ def build_pi0_expert_stack(
 
     logger.info(
         "pi0 expert: %d layers, hidden=%d, nq=%d, nkv=%d, head_dim=%d, inter=%d, action_dim=%d",
-        num_layers,
-        expert_hidden,
-        nq,
-        nkv,
-        head_dim,
-        inter,
-        action_dim,
+        num_layers, expert_hidden, nq, nkv, head_dim, inter, action_dim,
     )
 
     # 5. Build layers — pi0 expert does NOT use cross-attention (unlike SmolVLA)
@@ -140,11 +134,7 @@ def build_pi0_expert_stack(
         # Without this override RoPE frequencies are ~10x too small → positions
         # barely affect attention → expert output insensitive to position_ids.
         layer = ExpertGQALayer(
-            expert_hidden,
-            nq,
-            nkv,
-            head_dim,
-            inter,
+            expert_hidden, nq, nkv, head_dim, inter,
             kv_in=kv_in if is_cross else None,
             rope_theta=10000.0,
         )
@@ -255,11 +245,7 @@ def export_pi0(
         expert_onnx,
         input_names=["noisy_actions", "timestep", "position_ids"],
         output_names=["velocity"],
-        dynamic_axes={
-            "noisy_actions": {0: "batch"},
-            "timestep": {0: "batch"},
-            "position_ids": {0: "batch"},
-        },
+        dynamic_axes={"noisy_actions": {0: "batch"}, "timestep": {0: "batch"}, "position_ids": {0: "batch"}},
         opset_version=config.opset,
     )
     optimize_onnx(expert_onnx)
@@ -273,25 +259,15 @@ def export_pi0(
             import numpy as np
 
             sess = ort.InferenceSession(str(expert_onnx))
-            ort_out = sess.run(
-                None,
-                {
-                    "noisy_actions": dummy_actions.numpy(),
-                    "timestep": dummy_time.numpy(),
-                    "position_ids": dummy_pos.numpy().astype(np.int64),
-                },
-            )[0]
+            ort_out = sess.run(None, {
+                "noisy_actions": dummy_actions.numpy(),
+                "timestep": dummy_time.numpy(),
+                "position_ids": dummy_pos.numpy().astype(np.int64),
+            })[0]
             torch_out = expert_stack(dummy_actions, dummy_time, dummy_pos).detach().numpy()
             max_diff = float(np.abs(ort_out - torch_out).max())
-            result["metadata"]["onnx_validation"] = {
-                "max_diff": max_diff,
-                "passed": max_diff < 0.01,
-            }
-            logger.info(
-                "ONNX validation: max_diff=%.2e (%s)",
-                max_diff,
-                "PASS" if max_diff < 0.01 else "FAIL",
-            )
+            result["metadata"]["onnx_validation"] = {"max_diff": max_diff, "passed": max_diff < 0.01}
+            logger.info("ONNX validation: max_diff=%.2e (%s)", max_diff, "PASS" if max_diff < 0.01 else "FAIL")
         except ImportError:
             logger.warning("onnxruntime not installed, skipping validation")
 
@@ -324,11 +300,23 @@ def export_pi0(
         },
         "expert": expert_meta,
     }
-    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+    from tether.export_config import build_producer_config, write_tether_config
 
-    config_path = write_tether_config(
-        output_dir, normalize_legacy_tether_config(export_config, output_dir)
+    optional_artifacts = []
+    if "expert_trt" in result["files"]:
+        optional_artifacts.append(("expert_stack.trt", "engine"))
+    canonical = build_producer_config(
+        output_dir,
+        producer="expert_stack",
+        model_id=config.model_id,
+        model_type="pi0",
+        action_dim=action_dim,
+        num_denoising_steps=config.num_denoising_steps,
+        opset=config.opset,
+        optional_artifacts=optional_artifacts,
+        metadata=export_config,
     )
+    config_path = write_tether_config(output_dir, canonical)
     result["files"]["config"] = str(config_path)
     return result
 
@@ -343,16 +331,8 @@ def export_pi0(
 class Pi05ExpertStack(nn.Module):
     """Expert stack for pi0.5 — time embedding flows through every layer."""
 
-    def __init__(
-        self,
-        layers,
-        expert_hidden,
-        action_dim,
-        time_mlp_weights,
-        action_proj_weights,
-        in_proj_weights,
-        final_norm_weights,
-    ):
+    def __init__(self, layers, expert_hidden, action_dim, time_mlp_weights,
+                 action_proj_weights, in_proj_weights, final_norm_weights):
         super().__init__()
         self.layers = nn.ModuleList(layers)
         self.expert_hidden = expert_hidden
@@ -423,7 +403,7 @@ def build_pi05_expert_stack(
     for k in state_dict.keys():
         if not k.startswith(base_prefix + "layers."):
             continue
-        parts = k[len(base_prefix) :].split(".")
+        parts = k[len(base_prefix):].split(".")
         if len(parts) >= 2 and parts[0] == "layers" and parts[1].isdigit():
             layer_indices.add(int(parts[1]))
     if not layer_indices:
@@ -440,13 +420,7 @@ def build_pi05_expert_stack(
 
     logger.info(
         "pi0.5 expert: %d layers, hidden=%d, nq=%d, nkv=%d, head_dim=%d, inter=%d, action_dim=%d",
-        num_layers,
-        expert_hidden,
-        nq,
-        nkv,
-        head_dim,
-        inter,
-        action_dim,
+        num_layers, expert_hidden, nq, nkv, head_dim, inter, action_dim,
     )
 
     # 5. Build layers with AdaRMSNorm
@@ -460,12 +434,8 @@ def build_pi05_expert_stack(
         layer_sd = {
             "input_layernorm.dense.weight": state_dict[f"{prefix}.input_layernorm.dense.weight"],
             "input_layernorm.dense.bias": state_dict[f"{prefix}.input_layernorm.dense.bias"],
-            "post_attention_layernorm.dense.weight": state_dict[
-                f"{prefix}.post_attention_layernorm.dense.weight"
-            ],
-            "post_attention_layernorm.dense.bias": state_dict[
-                f"{prefix}.post_attention_layernorm.dense.bias"
-            ],
+            "post_attention_layernorm.dense.weight": state_dict[f"{prefix}.post_attention_layernorm.dense.weight"],
+            "post_attention_layernorm.dense.bias": state_dict[f"{prefix}.post_attention_layernorm.dense.bias"],
             "q_proj.weight": state_dict[f"{prefix}.self_attn.q_proj.weight"],
             "k_proj.weight": state_dict[f"{prefix}.self_attn.k_proj.weight"],
             "v_proj.weight": state_dict[f"{prefix}.self_attn.v_proj.weight"],
@@ -559,11 +529,7 @@ def export_pi05(
         expert_onnx,
         input_names=["noisy_actions", "timestep", "position_ids"],
         output_names=["velocity"],
-        dynamic_axes={
-            "noisy_actions": {0: "batch"},
-            "timestep": {0: "batch"},
-            "position_ids": {0: "batch"},
-        },
+        dynamic_axes={"noisy_actions": {0: "batch"}, "timestep": {0: "batch"}, "position_ids": {0: "batch"}},
         opset_version=config.opset,
     )
     optimize_onnx(expert_onnx)
@@ -573,27 +539,16 @@ def export_pi05(
         try:
             import onnxruntime as ort
             import numpy as np
-
             sess = ort.InferenceSession(str(expert_onnx))
-            ort_out = sess.run(
-                None,
-                {
-                    "noisy_actions": dummy_actions.numpy(),
-                    "timestep": dummy_time.numpy(),
-                    "position_ids": dummy_pos.numpy().astype(np.int64),
-                },
-            )[0]
+            ort_out = sess.run(None, {
+                "noisy_actions": dummy_actions.numpy(),
+                "timestep": dummy_time.numpy(),
+                "position_ids": dummy_pos.numpy().astype(np.int64),
+            })[0]
             torch_out = expert_stack(dummy_actions, dummy_time, dummy_pos).detach().numpy()
             max_diff = float(np.abs(ort_out - torch_out).max())
-            result["metadata"]["onnx_validation"] = {
-                "max_diff": max_diff,
-                "passed": max_diff < 0.01,
-            }
-            logger.info(
-                "ONNX validation: max_diff=%.2e (%s)",
-                max_diff,
-                "PASS" if max_diff < 0.01 else "FAIL",
-            )
+            result["metadata"]["onnx_validation"] = {"max_diff": max_diff, "passed": max_diff < 0.01}
+            logger.info("ONNX validation: max_diff=%.2e (%s)", max_diff, "PASS" if max_diff < 0.01 else "FAIL")
         except ImportError:
             logger.warning("onnxruntime not installed, skipping validation")
 
@@ -623,10 +578,22 @@ def export_pi05(
         },
         "expert": expert_meta,
     }
-    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+    from tether.export_config import build_producer_config, write_tether_config
 
-    config_path = write_tether_config(
-        output_dir, normalize_legacy_tether_config(export_config, output_dir)
+    optional_artifacts = []
+    if "expert_trt" in result["files"]:
+        optional_artifacts.append(("expert_stack.trt", "engine"))
+    canonical = build_producer_config(
+        output_dir,
+        producer="expert_stack",
+        model_id=config.model_id,
+        model_type="pi05",
+        action_dim=action_dim,
+        num_denoising_steps=config.num_denoising_steps,
+        opset=config.opset,
+        optional_artifacts=optional_artifacts,
+        metadata=export_config,
     )
+    config_path = write_tether_config(output_dir, canonical)
     result["files"]["config"] = str(config_path)
     return result

--- a/src/tether/exporters/pi0_prefix.py
+++ b/src/tether/exporters/pi0_prefix.py
@@ -40,6 +40,7 @@ Each stage verified independently at cos >= 0.9999:
 
 See https://github.com/FastCrest/reflex-vault/blob/main/reflex_vla/03_research/pi0_empirical_derisk_findings.md
 """
+
 from __future__ import annotations
 
 import json
@@ -142,11 +143,13 @@ def build_siglip_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
     sd = {}
     for k, v in state.items():
         if k.startswith(PI0_VISION_PREFIX):
-            sd[k[len(PI0_VISION_PREFIX):]] = v
+            sd[k[len(PI0_VISION_PREFIX) :]] = v
     missing, unexpected = model.load_state_dict(sd, strict=False)
     logger.info(
         "SigLIP: loaded %d keys, missing=%d unexpected=%d",
-        len(sd), len(missing), len(unexpected),
+        len(sd),
+        len(missing),
+        len(unexpected),
     )
     # Missing keys expected: vision_model.head.* (attention-pool head,
     # unused by PaliGemma)
@@ -154,17 +157,19 @@ def build_siglip_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
     model.save_pretrained(out_dir)
     (out_dir / "preprocessor_config.json").write_text(
-        json.dumps({
-            "do_normalize": True,
-            "do_rescale": True,
-            "do_resize": True,
-            "image_mean": [0.5, 0.5, 0.5],
-            "image_std": [0.5, 0.5, 0.5],
-            "rescale_factor": 1 / 255.0,
-            "resample": 3,
-            "size": {"height": 224, "width": 224},
-            "image_processor_type": "SiglipImageProcessor",
-        })
+        json.dumps(
+            {
+                "do_normalize": True,
+                "do_rescale": True,
+                "do_resize": True,
+                "image_mean": [0.5, 0.5, 0.5],
+                "image_std": [0.5, 0.5, 0.5],
+                "rescale_factor": 1 / 255.0,
+                "resample": 3,
+                "size": {"height": 224, "width": 224},
+                "image_processor_type": "SiglipImageProcessor",
+            }
+        )
     )
     return out_dir
 
@@ -183,7 +188,7 @@ def build_expert_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
     for k in state:
         if k.startswith(PI0_EXPERT_PREFIX + "layers."):
             try:
-                idx = int(k[len(PI0_EXPERT_PREFIX + "layers."):].split(".")[0])
+                idx = int(k[len(PI0_EXPERT_PREFIX + "layers.") :].split(".")[0])
                 layer_ids.add(idx)
             except ValueError:
                 continue
@@ -198,20 +203,23 @@ def build_expert_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
     sd = {}
     for k, v in state.items():
         if k.startswith(PI0_EXPERT_PREFIX):
-            sd[k[len(PI0_EXPERT_PREFIX):]] = v
+            sd[k[len(PI0_EXPERT_PREFIX) :]] = v
     missing, unexpected = model.model.load_state_dict(sd, strict=False)
-    logger.info("Expert: loaded %d keys, missing=%d unexpected=%d",
-                len(sd), len(missing), len(unexpected))
+    logger.info(
+        "Expert: loaded %d keys, missing=%d unexpected=%d", len(sd), len(missing), len(unexpected)
+    )
 
     out_dir.mkdir(parents=True, exist_ok=True)
     model.save_pretrained(out_dir)
     (out_dir / "tokenizer_config.json").write_text(
-        json.dumps({
-            "tokenizer_class": "GemmaTokenizer",
-            "bos_token": "<bos>",
-            "eos_token": "<eos>",
-            "pad_token": "<pad>",
-        })
+        json.dumps(
+            {
+                "tokenizer_class": "GemmaTokenizer",
+                "bos_token": "<bos>",
+                "eos_token": "<eos>",
+                "pad_token": "<pad>",
+            }
+        )
     )
     return out_dir
 
@@ -230,13 +238,14 @@ def build_gemma_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
     sd = {}
     for k, v in state.items():
         if k.startswith(PI0_LANGUAGE_PREFIX):
-            sd[k[len(PI0_LANGUAGE_PREFIX):]] = v
+            sd[k[len(PI0_LANGUAGE_PREFIX) :]] = v
     # Also load embed_tokens from lm_head (tied weights in Gemma)
     if PI0_LM_HEAD_KEY in state:
         sd["embed_tokens.weight"] = state[PI0_LM_HEAD_KEY].clone()
         logger.info(
             "Using tied lm_head (%s) as embed_tokens, shape %s",
-            PI0_LM_HEAD_KEY, tuple(state[PI0_LM_HEAD_KEY].shape),
+            PI0_LM_HEAD_KEY,
+            tuple(state[PI0_LM_HEAD_KEY].shape),
         )
 
     missing, unexpected = model.model.load_state_dict(sd, strict=False)
@@ -245,18 +254,22 @@ def build_gemma_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
         model.lm_head.weight = nn.Parameter(state[PI0_LM_HEAD_KEY].clone())
     logger.info(
         "Gemma: loaded %d keys, missing=%d unexpected=%d",
-        len(sd), len(missing), len(unexpected),
+        len(sd),
+        len(missing),
+        len(unexpected),
     )
 
     out_dir.mkdir(parents=True, exist_ok=True)
     model.save_pretrained(out_dir)
     (out_dir / "tokenizer_config.json").write_text(
-        json.dumps({
-            "tokenizer_class": "GemmaTokenizer",
-            "bos_token": "<bos>",
-            "eos_token": "<eos>",
-            "pad_token": "<pad>",
-        })
+        json.dumps(
+            {
+                "tokenizer_class": "GemmaTokenizer",
+                "bos_token": "<bos>",
+                "eos_token": "<eos>",
+                "pad_token": "<pad>",
+            }
+        )
     )
     return out_dir
 
@@ -338,8 +351,11 @@ def build_and_export_gemma_from_embeds(
             "inputs_embeds": {0: "batch", 1: "seq"},
             "attention_mask": {0: "batch", 1: "seq"},
             "last_hidden_state": {0: "batch", 1: "seq"},
-            **{f"present.{i}.{kv}": {0: "batch", 2: "seq"}
-               for i in range(num_layers) for kv in ("key", "value")},
+            **{
+                f"present.{i}.{kv}": {0: "batch", 2: "seq"}
+                for i in range(num_layers)
+                for kv in ("key", "value")
+            },
         },
         opset_version=19,
     )
@@ -376,8 +392,9 @@ class GemmaExpertFromEmbeds(nn.Module):
         from transformers.cache_utils import DynamicCache
 
         num_layers = self.model.config.num_hidden_layers
-        assert len(past_key_values_flat) == 2 * num_layers, \
-            f"expected {2*num_layers} past_kv tensors, got {len(past_key_values_flat)}"
+        assert len(past_key_values_flat) == 2 * num_layers, (
+            f"expected {2 * num_layers} past_kv tensors, got {len(past_key_values_flat)}"
+        )
 
         cache = DynamicCache()
         for i in range(num_layers):
@@ -476,6 +493,7 @@ class Pi0ExpertStackWithPrefix(nn.Module):
     ):
         super().__init__()
         from tether.decompose import DecomposedRMSNorm
+
         self.layers = nn.ModuleList(layers)
         self.expert_hidden = expert_hidden
 
@@ -541,7 +559,9 @@ class Pi0ExpertStackWithPrefix(nn.Module):
         return self.action_out_proj(x)
 
 
-def build_pi0_expert_with_prefix(state_dict: dict[str, torch.Tensor]) -> tuple[Pi0ExpertStackWithPrefix, dict]:
+def build_pi0_expert_with_prefix(
+    state_dict: dict[str, torch.Tensor],
+) -> tuple[Pi0ExpertStackWithPrefix, dict]:
     """Build pi0's expert stack wired for per-layer prefix-KV concat.
 
     Reuses the existing pi0_exporter.build_pi0_expert_stack to create individual
@@ -559,6 +579,7 @@ def build_pi0_expert_with_prefix(state_dict: dict[str, torch.Tensor]) -> tuple[P
 
     # Weights for suffix/time MLP + action projections from PI0_ACTION_KEYS
     from tether.exporters.pi0 import PI0_ACTION_KEYS
+
     suffix = {
         "in_w": state_dict[PI0_ACTION_KEYS["in_w"]],
         "in_b": state_dict[PI0_ACTION_KEYS["in_b"]],
@@ -575,7 +596,9 @@ def build_pi0_expert_with_prefix(state_dict: dict[str, torch.Tensor]) -> tuple[P
     # so pre-transform stored weight: `w_decomposed = 1 + w_gemma`. Matches
     # the per-layer norm convention in pi0_exporter.py:148-150.
     base_prefix = "paligemma_with_expert.gemma_expert.model."
-    final_norm_w_raw = state_dict.get(f"{base_prefix}norm.weight", torch.zeros(meta["expert_hidden"]))
+    final_norm_w_raw = state_dict.get(
+        f"{base_prefix}norm.weight", torch.zeros(meta["expert_hidden"])
+    )
     final_norm_w = final_norm_w_raw + 1.0
 
     stack = Pi0ExpertStackWithPrefix(
@@ -624,7 +647,10 @@ def export_projector_onnx(projector: MultiModalProjector, out_path: Path) -> Pat
         out_path,
         input_names=["vision_features"],
         output_names=["projected_features"],
-        dynamic_axes={"vision_features": {0: "batch", 1: "seq"}, "projected_features": {0: "batch", 1: "seq"}},
+        dynamic_axes={
+            "vision_features": {0: "batch", 1: "seq"},
+            "projected_features": {0: "batch", 1: "seq"},
+        },
         opset_version=19,
     )
     logger.info("Exported projector ONNX: %s", out_path)
@@ -683,10 +709,15 @@ def optimum_export_onnx(model_dir: Path, task: str, out_dir: Path) -> Path:
     venv_cli = Path(".venv/bin/optimum-cli")
     cli = str(venv_cli) if venv_cli.exists() else "optimum-cli"
     cmd = [
-        cli, "export", "onnx",
-        "--model", str(model_dir),
-        "--task", task,
-        "--framework", "pt",
+        cli,
+        "export",
+        "onnx",
+        "--model",
+        str(model_dir),
+        "--task",
+        task,
+        "--framework",
+        "pt",
         str(out_dir),
     ]
     logger.info("Running: %s", " ".join(cmd))
@@ -805,8 +836,11 @@ def export_pi0_prefix(
             (dummy_actions, dummy_time, dummy_pos, dummy_prefix_k, dummy_prefix_v),
             expert_onnx,
             input_names=[
-                "noisy_actions", "timestep", "position_ids",
-                "prefix_k", "prefix_v",
+                "noisy_actions",
+                "timestep",
+                "position_ids",
+                "prefix_k",
+                "prefix_v",
             ],
             output_names=["velocity"],
             dynamic_axes={
@@ -826,15 +860,25 @@ def export_pi0_prefix(
         result["metadata"]["expert_error"] = str(e)
 
     # 6. Save config manifest
+    if "expert_stack" not in result["files"]:
+        raise RuntimeError("pi0 prefix export is incomplete: expert_stack.onnx was not produced")
     config = {
         "model_id": model_id,
         "model_type": "pi0",
+        "export_kind": "decomposed_onnx",
+        "action_dim": action_dim,
+        "num_denoising_steps": 10,
+        "opset": 19,
         "pipeline": "prefix_optimum + expert_custom",
         "components": result["files"],
         "metadata": result["metadata"],
     }
-    (output_dir / "tether_config.json").write_text(json.dumps(config, indent=2))
-    result["files"]["config"] = str(output_dir / "tether_config.json")
+    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+
+    config_path = write_tether_config(
+        output_dir, normalize_legacy_tether_config(config, output_dir)
+    )
+    result["files"]["config"] = str(config_path)
 
     logger.info("pi0 prefix export complete: %d components", len(result["files"]))
     return result
@@ -880,6 +924,7 @@ class Pi05ExpertStackWithPrefix(nn.Module):
     ):
         super().__init__()
         from tether.decompose import DecomposedAdaRMSNorm, DecomposedRMSNorm
+
         self.layers = nn.ModuleList(layers)
         self.expert_hidden = expert_hidden
 
@@ -937,10 +982,13 @@ class Pi05ExpertStackWithPrefix(nn.Module):
         t_emb = F.silu(self.time_mlp_out(F.silu(self.time_mlp_in(t_emb_raw))))
 
         from tether.models.heads.expert_stack import Pi05ExpertGQALayer as _Pi05Layer
+
         for i, layer in enumerate(self.layers):
             _Pi05Layer.debug_layer_id = i
             x = layer(
-                x, position_ids, t_emb,
+                x,
+                position_ids,
+                t_emb,
                 prefix_k_concat=prefix_k[i],
                 prefix_v_concat=prefix_v[i],
                 attn_mask=attn_mask,
@@ -954,7 +1002,9 @@ class Pi05ExpertStackWithPrefix(nn.Module):
         return self.action_out_proj(x)
 
 
-def build_pi05_expert_with_prefix(state_dict: dict[str, torch.Tensor]) -> tuple[Pi05ExpertStackWithPrefix, dict]:
+def build_pi05_expert_with_prefix(
+    state_dict: dict[str, torch.Tensor],
+) -> tuple[Pi05ExpertStackWithPrefix, dict]:
     """Build pi0.5's expert stack wired for per-layer prefix-KV concat.
 
     Reuses the existing pi0_exporter.build_pi05_expert_stack to validate
@@ -989,8 +1039,12 @@ def build_pi05_expert_with_prefix(state_dict: dict[str, torch.Tensor]) -> tuple[
         layer_sd = {
             "input_layernorm.dense.weight": state_dict[f"{prefix}.input_layernorm.dense.weight"],
             "input_layernorm.dense.bias": state_dict[f"{prefix}.input_layernorm.dense.bias"],
-            "post_attention_layernorm.dense.weight": state_dict[f"{prefix}.post_attention_layernorm.dense.weight"],
-            "post_attention_layernorm.dense.bias": state_dict[f"{prefix}.post_attention_layernorm.dense.bias"],
+            "post_attention_layernorm.dense.weight": state_dict[
+                f"{prefix}.post_attention_layernorm.dense.weight"
+            ],
+            "post_attention_layernorm.dense.bias": state_dict[
+                f"{prefix}.post_attention_layernorm.dense.bias"
+            ],
             "q_proj.weight": state_dict[f"{prefix}.self_attn.q_proj.weight"],
             "k_proj.weight": state_dict[f"{prefix}.self_attn.k_proj.weight"],
             "v_proj.weight": state_dict[f"{prefix}.self_attn.v_proj.weight"],

--- a/src/tether/exporters/pi0_prefix.py
+++ b/src/tether/exporters/pi0_prefix.py
@@ -40,7 +40,6 @@ Each stage verified independently at cos >= 0.9999:
 
 See https://github.com/FastCrest/reflex-vault/blob/main/reflex_vla/03_research/pi0_empirical_derisk_findings.md
 """
-
 from __future__ import annotations
 
 import json
@@ -143,13 +142,11 @@ def build_siglip_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
     sd = {}
     for k, v in state.items():
         if k.startswith(PI0_VISION_PREFIX):
-            sd[k[len(PI0_VISION_PREFIX) :]] = v
+            sd[k[len(PI0_VISION_PREFIX):]] = v
     missing, unexpected = model.load_state_dict(sd, strict=False)
     logger.info(
         "SigLIP: loaded %d keys, missing=%d unexpected=%d",
-        len(sd),
-        len(missing),
-        len(unexpected),
+        len(sd), len(missing), len(unexpected),
     )
     # Missing keys expected: vision_model.head.* (attention-pool head,
     # unused by PaliGemma)
@@ -157,19 +154,17 @@ def build_siglip_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
     model.save_pretrained(out_dir)
     (out_dir / "preprocessor_config.json").write_text(
-        json.dumps(
-            {
-                "do_normalize": True,
-                "do_rescale": True,
-                "do_resize": True,
-                "image_mean": [0.5, 0.5, 0.5],
-                "image_std": [0.5, 0.5, 0.5],
-                "rescale_factor": 1 / 255.0,
-                "resample": 3,
-                "size": {"height": 224, "width": 224},
-                "image_processor_type": "SiglipImageProcessor",
-            }
-        )
+        json.dumps({
+            "do_normalize": True,
+            "do_rescale": True,
+            "do_resize": True,
+            "image_mean": [0.5, 0.5, 0.5],
+            "image_std": [0.5, 0.5, 0.5],
+            "rescale_factor": 1 / 255.0,
+            "resample": 3,
+            "size": {"height": 224, "width": 224},
+            "image_processor_type": "SiglipImageProcessor",
+        })
     )
     return out_dir
 
@@ -188,7 +183,7 @@ def build_expert_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
     for k in state:
         if k.startswith(PI0_EXPERT_PREFIX + "layers."):
             try:
-                idx = int(k[len(PI0_EXPERT_PREFIX + "layers.") :].split(".")[0])
+                idx = int(k[len(PI0_EXPERT_PREFIX + "layers."):].split(".")[0])
                 layer_ids.add(idx)
             except ValueError:
                 continue
@@ -203,23 +198,20 @@ def build_expert_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
     sd = {}
     for k, v in state.items():
         if k.startswith(PI0_EXPERT_PREFIX):
-            sd[k[len(PI0_EXPERT_PREFIX) :]] = v
+            sd[k[len(PI0_EXPERT_PREFIX):]] = v
     missing, unexpected = model.model.load_state_dict(sd, strict=False)
-    logger.info(
-        "Expert: loaded %d keys, missing=%d unexpected=%d", len(sd), len(missing), len(unexpected)
-    )
+    logger.info("Expert: loaded %d keys, missing=%d unexpected=%d",
+                len(sd), len(missing), len(unexpected))
 
     out_dir.mkdir(parents=True, exist_ok=True)
     model.save_pretrained(out_dir)
     (out_dir / "tokenizer_config.json").write_text(
-        json.dumps(
-            {
-                "tokenizer_class": "GemmaTokenizer",
-                "bos_token": "<bos>",
-                "eos_token": "<eos>",
-                "pad_token": "<pad>",
-            }
-        )
+        json.dumps({
+            "tokenizer_class": "GemmaTokenizer",
+            "bos_token": "<bos>",
+            "eos_token": "<eos>",
+            "pad_token": "<pad>",
+        })
     )
     return out_dir
 
@@ -238,14 +230,13 @@ def build_gemma_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
     sd = {}
     for k, v in state.items():
         if k.startswith(PI0_LANGUAGE_PREFIX):
-            sd[k[len(PI0_LANGUAGE_PREFIX) :]] = v
+            sd[k[len(PI0_LANGUAGE_PREFIX):]] = v
     # Also load embed_tokens from lm_head (tied weights in Gemma)
     if PI0_LM_HEAD_KEY in state:
         sd["embed_tokens.weight"] = state[PI0_LM_HEAD_KEY].clone()
         logger.info(
             "Using tied lm_head (%s) as embed_tokens, shape %s",
-            PI0_LM_HEAD_KEY,
-            tuple(state[PI0_LM_HEAD_KEY].shape),
+            PI0_LM_HEAD_KEY, tuple(state[PI0_LM_HEAD_KEY].shape),
         )
 
     missing, unexpected = model.model.load_state_dict(sd, strict=False)
@@ -254,22 +245,18 @@ def build_gemma_dir(state: dict[str, torch.Tensor], out_dir: Path) -> Path:
         model.lm_head.weight = nn.Parameter(state[PI0_LM_HEAD_KEY].clone())
     logger.info(
         "Gemma: loaded %d keys, missing=%d unexpected=%d",
-        len(sd),
-        len(missing),
-        len(unexpected),
+        len(sd), len(missing), len(unexpected),
     )
 
     out_dir.mkdir(parents=True, exist_ok=True)
     model.save_pretrained(out_dir)
     (out_dir / "tokenizer_config.json").write_text(
-        json.dumps(
-            {
-                "tokenizer_class": "GemmaTokenizer",
-                "bos_token": "<bos>",
-                "eos_token": "<eos>",
-                "pad_token": "<pad>",
-            }
-        )
+        json.dumps({
+            "tokenizer_class": "GemmaTokenizer",
+            "bos_token": "<bos>",
+            "eos_token": "<eos>",
+            "pad_token": "<pad>",
+        })
     )
     return out_dir
 
@@ -351,11 +338,8 @@ def build_and_export_gemma_from_embeds(
             "inputs_embeds": {0: "batch", 1: "seq"},
             "attention_mask": {0: "batch", 1: "seq"},
             "last_hidden_state": {0: "batch", 1: "seq"},
-            **{
-                f"present.{i}.{kv}": {0: "batch", 2: "seq"}
-                for i in range(num_layers)
-                for kv in ("key", "value")
-            },
+            **{f"present.{i}.{kv}": {0: "batch", 2: "seq"}
+               for i in range(num_layers) for kv in ("key", "value")},
         },
         opset_version=19,
     )
@@ -392,9 +376,8 @@ class GemmaExpertFromEmbeds(nn.Module):
         from transformers.cache_utils import DynamicCache
 
         num_layers = self.model.config.num_hidden_layers
-        assert len(past_key_values_flat) == 2 * num_layers, (
-            f"expected {2 * num_layers} past_kv tensors, got {len(past_key_values_flat)}"
-        )
+        assert len(past_key_values_flat) == 2 * num_layers, \
+            f"expected {2*num_layers} past_kv tensors, got {len(past_key_values_flat)}"
 
         cache = DynamicCache()
         for i in range(num_layers):
@@ -493,7 +476,6 @@ class Pi0ExpertStackWithPrefix(nn.Module):
     ):
         super().__init__()
         from tether.decompose import DecomposedRMSNorm
-
         self.layers = nn.ModuleList(layers)
         self.expert_hidden = expert_hidden
 
@@ -559,9 +541,7 @@ class Pi0ExpertStackWithPrefix(nn.Module):
         return self.action_out_proj(x)
 
 
-def build_pi0_expert_with_prefix(
-    state_dict: dict[str, torch.Tensor],
-) -> tuple[Pi0ExpertStackWithPrefix, dict]:
+def build_pi0_expert_with_prefix(state_dict: dict[str, torch.Tensor]) -> tuple[Pi0ExpertStackWithPrefix, dict]:
     """Build pi0's expert stack wired for per-layer prefix-KV concat.
 
     Reuses the existing pi0_exporter.build_pi0_expert_stack to create individual
@@ -579,7 +559,6 @@ def build_pi0_expert_with_prefix(
 
     # Weights for suffix/time MLP + action projections from PI0_ACTION_KEYS
     from tether.exporters.pi0 import PI0_ACTION_KEYS
-
     suffix = {
         "in_w": state_dict[PI0_ACTION_KEYS["in_w"]],
         "in_b": state_dict[PI0_ACTION_KEYS["in_b"]],
@@ -596,9 +575,7 @@ def build_pi0_expert_with_prefix(
     # so pre-transform stored weight: `w_decomposed = 1 + w_gemma`. Matches
     # the per-layer norm convention in pi0_exporter.py:148-150.
     base_prefix = "paligemma_with_expert.gemma_expert.model."
-    final_norm_w_raw = state_dict.get(
-        f"{base_prefix}norm.weight", torch.zeros(meta["expert_hidden"])
-    )
+    final_norm_w_raw = state_dict.get(f"{base_prefix}norm.weight", torch.zeros(meta["expert_hidden"]))
     final_norm_w = final_norm_w_raw + 1.0
 
     stack = Pi0ExpertStackWithPrefix(
@@ -647,10 +624,7 @@ def export_projector_onnx(projector: MultiModalProjector, out_path: Path) -> Pat
         out_path,
         input_names=["vision_features"],
         output_names=["projected_features"],
-        dynamic_axes={
-            "vision_features": {0: "batch", 1: "seq"},
-            "projected_features": {0: "batch", 1: "seq"},
-        },
+        dynamic_axes={"vision_features": {0: "batch", 1: "seq"}, "projected_features": {0: "batch", 1: "seq"}},
         opset_version=19,
     )
     logger.info("Exported projector ONNX: %s", out_path)
@@ -709,15 +683,10 @@ def optimum_export_onnx(model_dir: Path, task: str, out_dir: Path) -> Path:
     venv_cli = Path(".venv/bin/optimum-cli")
     cli = str(venv_cli) if venv_cli.exists() else "optimum-cli"
     cmd = [
-        cli,
-        "export",
-        "onnx",
-        "--model",
-        str(model_dir),
-        "--task",
-        task,
-        "--framework",
-        "pt",
+        cli, "export", "onnx",
+        "--model", str(model_dir),
+        "--task", task,
+        "--framework", "pt",
         str(out_dir),
     ]
     logger.info("Running: %s", " ".join(cmd))
@@ -836,11 +805,8 @@ def export_pi0_prefix(
             (dummy_actions, dummy_time, dummy_pos, dummy_prefix_k, dummy_prefix_v),
             expert_onnx,
             input_names=[
-                "noisy_actions",
-                "timestep",
-                "position_ids",
-                "prefix_k",
-                "prefix_v",
+                "noisy_actions", "timestep", "position_ids",
+                "prefix_k", "prefix_v",
             ],
             output_names=["velocity"],
             dynamic_axes={
@@ -873,11 +839,19 @@ def export_pi0_prefix(
         "components": result["files"],
         "metadata": result["metadata"],
     }
-    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+    from tether.export_config import build_producer_config, write_tether_config
 
-    config_path = write_tether_config(
-        output_dir, normalize_legacy_tether_config(config, output_dir)
+    canonical = build_producer_config(
+        output_dir,
+        producer="pi0_prefix",
+        model_id=model_id,
+        model_type="pi0",
+        action_dim=action_dim,
+        num_denoising_steps=10,
+        opset=19,
+        metadata=config,
     )
+    config_path = write_tether_config(output_dir, canonical)
     result["files"]["config"] = str(config_path)
 
     logger.info("pi0 prefix export complete: %d components", len(result["files"]))
@@ -924,7 +898,6 @@ class Pi05ExpertStackWithPrefix(nn.Module):
     ):
         super().__init__()
         from tether.decompose import DecomposedAdaRMSNorm, DecomposedRMSNorm
-
         self.layers = nn.ModuleList(layers)
         self.expert_hidden = expert_hidden
 
@@ -982,13 +955,10 @@ class Pi05ExpertStackWithPrefix(nn.Module):
         t_emb = F.silu(self.time_mlp_out(F.silu(self.time_mlp_in(t_emb_raw))))
 
         from tether.models.heads.expert_stack import Pi05ExpertGQALayer as _Pi05Layer
-
         for i, layer in enumerate(self.layers):
             _Pi05Layer.debug_layer_id = i
             x = layer(
-                x,
-                position_ids,
-                t_emb,
+                x, position_ids, t_emb,
                 prefix_k_concat=prefix_k[i],
                 prefix_v_concat=prefix_v[i],
                 attn_mask=attn_mask,
@@ -1002,9 +972,7 @@ class Pi05ExpertStackWithPrefix(nn.Module):
         return self.action_out_proj(x)
 
 
-def build_pi05_expert_with_prefix(
-    state_dict: dict[str, torch.Tensor],
-) -> tuple[Pi05ExpertStackWithPrefix, dict]:
+def build_pi05_expert_with_prefix(state_dict: dict[str, torch.Tensor]) -> tuple[Pi05ExpertStackWithPrefix, dict]:
     """Build pi0.5's expert stack wired for per-layer prefix-KV concat.
 
     Reuses the existing pi0_exporter.build_pi05_expert_stack to validate
@@ -1039,12 +1007,8 @@ def build_pi05_expert_with_prefix(
         layer_sd = {
             "input_layernorm.dense.weight": state_dict[f"{prefix}.input_layernorm.dense.weight"],
             "input_layernorm.dense.bias": state_dict[f"{prefix}.input_layernorm.dense.bias"],
-            "post_attention_layernorm.dense.weight": state_dict[
-                f"{prefix}.post_attention_layernorm.dense.weight"
-            ],
-            "post_attention_layernorm.dense.bias": state_dict[
-                f"{prefix}.post_attention_layernorm.dense.bias"
-            ],
+            "post_attention_layernorm.dense.weight": state_dict[f"{prefix}.post_attention_layernorm.dense.weight"],
+            "post_attention_layernorm.dense.bias": state_dict[f"{prefix}.post_attention_layernorm.dense.bias"],
             "q_proj.weight": state_dict[f"{prefix}.self_attn.q_proj.weight"],
             "k_proj.weight": state_dict[f"{prefix}.self_attn.k_proj.weight"],
             "v_proj.weight": state_dict[f"{prefix}.self_attn.v_proj.weight"],

--- a/src/tether/exporters/smolvla.py
+++ b/src/tether/exporters/smolvla.py
@@ -31,10 +31,7 @@ from tether.exporters.trt_build import build_engine, check_trtexec
 # sunset. External callers still doing ``from tether.exporters.smolvla import
 # ExpertGQALayer`` keep working through this surface.
 from tether.models.heads.expert_stack import (  # noqa: F401
-    ExpertGQALayer,
-    ExpertStack,
-    _DecomposedRoPE,
-    _sinusoidal_pos_embedding,
+    ExpertGQALayer, ExpertStack, _DecomposedRoPE, _sinusoidal_pos_embedding,
 )
 
 logger = logging.getLogger(__name__)
@@ -73,7 +70,6 @@ def build_expert_stack(
 
     try:
         from transformers import AutoConfig
-
         vlm_cfg = AutoConfig.from_pretrained("HuggingFaceTB/SmolVLM2-500M-Video-Instruct")
         nq = int(vlm_cfg.text_config.num_attention_heads)
         nkv = int(vlm_cfg.text_config.num_key_value_heads)
@@ -86,12 +82,7 @@ def build_expert_stack(
     logger.info(
         "[expert-stack] expert_hidden=%d, num_q_heads=%d, num_kv_heads=%d, "
         "expert_head_dim=%d (vlm head_dim=%d), intermediate=%d",
-        expert_hidden,
-        nq,
-        nkv,
-        expert_head_dim,
-        head_dim,
-        inter,
+        expert_hidden, nq, nkv, expert_head_dim, head_dim, inter,
     )
     head_dim = expert_head_dim
 
@@ -107,18 +98,12 @@ def build_expert_stack(
             vlm_kv_dim = kv_in
 
         layer = ExpertGQALayer(
-            expert_hidden,
-            nq,
-            nkv,
-            head_dim,
-            inter,
+            expert_hidden, nq, nkv, head_dim, inter,
             kv_in=kv_in if is_cross else None,
         )
         layer_sd = {
             "input_layernorm.weight": state_dict[f"{prefix}.input_layernorm.weight"],
-            "post_attention_layernorm.weight": state_dict[
-                f"{prefix}.post_attention_layernorm.weight"
-            ],
+            "post_attention_layernorm.weight": state_dict[f"{prefix}.post_attention_layernorm.weight"],
             "q_proj.weight": state_dict[f"{prefix}.self_attn.q_proj.weight"],
             "k_proj.weight": state_dict[f"{prefix}.self_attn.k_proj.weight"],
             "v_proj.weight": state_dict[f"{prefix}.self_attn.v_proj.weight"],
@@ -227,9 +212,7 @@ def export_smolvla(
     result["metadata"]["expert"] = expert_meta
     logger.info(
         "Expert: %d layers, %.1fM params, cross_attn=%s",
-        expert_meta["num_layers"],
-        expert_meta["total_params_m"],
-        expert_meta["cross_attn_layers"],
+        expert_meta["num_layers"], expert_meta["total_params_m"], expert_meta["cross_attn_layers"],
     )
 
     # 3. Export expert stack to ONNX — identical shape to the legacy path.
@@ -250,29 +233,14 @@ def export_smolvla(
     logger.info("Exporting expert stack to ONNX: %s", expert_onnx)
     export_module_to_onnx(
         expert_stack,
-        (
-            dummy_actions,
-            dummy_time,
-            dummy_pos,
-            dummy_vlm_k,
-            dummy_vlm_v,
-            dummy_prefix_offset,
-            dummy_kv_mask,
-        ),
+        (dummy_actions, dummy_time, dummy_pos, dummy_vlm_k, dummy_vlm_v,
+         dummy_prefix_offset, dummy_kv_mask),
         expert_onnx,
-        input_names=[
-            "noisy_actions",
-            "timestep",
-            "position_ids",
-            "vlm_k",
-            "vlm_v",
-            "prefix_offset",
-            "kv_mask",
-        ],
+        input_names=["noisy_actions", "timestep", "position_ids", "vlm_k", "vlm_v",
+                     "prefix_offset", "kv_mask"],
         output_names=["velocity"],
         dynamic_axes={
-            "noisy_actions": {0: "batch"},
-            "timestep": {0: "batch"},
+            "noisy_actions": {0: "batch"}, "timestep": {0: "batch"},
             "position_ids": {0: "batch"},
             "vlm_k": {1: "batch", 2: "seq"},
             "vlm_v": {1: "batch", 2: "seq"},
@@ -292,41 +260,23 @@ def export_smolvla(
             import numpy as np
 
             sess = ort.InferenceSession(str(expert_onnx))
-            ort_out = sess.run(
-                None,
-                {
-                    "noisy_actions": dummy_actions.numpy(),
-                    "timestep": dummy_time.numpy(),
-                    "position_ids": dummy_pos.numpy().astype(np.int64),
-                    "vlm_k": dummy_vlm_k.numpy(),
-                    "vlm_v": dummy_vlm_v.numpy(),
-                    "prefix_offset": dummy_prefix_offset.numpy(),
-                    "kv_mask": dummy_kv_mask.numpy(),
-                },
-            )[0]
-            torch_out = (
-                expert_stack(
-                    dummy_actions,
-                    dummy_time,
-                    dummy_pos,
-                    dummy_vlm_k,
-                    dummy_vlm_v,
-                    dummy_prefix_offset,
-                    dummy_kv_mask,
-                )
-                .detach()
-                .numpy()
-            )
+            ort_out = sess.run(None, {
+                "noisy_actions": dummy_actions.numpy(),
+                "timestep": dummy_time.numpy(),
+                "position_ids": dummy_pos.numpy().astype(np.int64),
+                "vlm_k": dummy_vlm_k.numpy(),
+                "vlm_v": dummy_vlm_v.numpy(),
+                "prefix_offset": dummy_prefix_offset.numpy(),
+                "kv_mask": dummy_kv_mask.numpy(),
+            })[0]
+            torch_out = expert_stack(
+                dummy_actions, dummy_time, dummy_pos,
+                dummy_vlm_k, dummy_vlm_v, dummy_prefix_offset, dummy_kv_mask
+            ).detach().numpy()
             max_diff = float(np.abs(ort_out - torch_out).max())
-            result["metadata"]["onnx_validation"] = {
-                "max_diff": max_diff,
-                "passed": max_diff < 0.01,
-            }
-            logger.info(
-                "ONNX validation: max_diff=%.2e (%s)",
-                max_diff,
-                "PASS" if max_diff < 0.01 else "FAIL",
-            )
+            result["metadata"]["onnx_validation"] = {"max_diff": max_diff, "passed": max_diff < 0.01}
+            logger.info("ONNX validation: max_diff=%.2e (%s)",
+                        max_diff, "PASS" if max_diff < 0.01 else "FAIL")
         except ImportError:
             logger.warning("onnxruntime not installed, skipping validation")
 
@@ -361,11 +311,23 @@ def export_smolvla(
         "vlm_kv_dim": vlm_kv_dim,
         "spine_path": True,
     }
-    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+    from tether.export_config import build_producer_config, write_tether_config
 
-    config_path = write_tether_config(
-        output_dir, normalize_legacy_tether_config(export_config, output_dir)
+    optional_artifacts = []
+    if "expert_trt" in result["files"]:
+        optional_artifacts.append(("expert_stack.trt", "engine"))
+    canonical = build_producer_config(
+        output_dir,
+        producer="expert_stack",
+        model_id=config.model_id,
+        model_type="smolvla",
+        action_dim=action_dim,
+        num_denoising_steps=config.num_denoising_steps,
+        opset=config.opset,
+        optional_artifacts=optional_artifacts,
+        metadata=export_config,
     )
+    config_path = write_tether_config(output_dir, canonical)
     result["files"]["config"] = str(config_path)
 
     logger.info("Export complete: %s", output_dir)

--- a/src/tether/exporters/smolvla.py
+++ b/src/tether/exporters/smolvla.py
@@ -16,7 +16,6 @@ file lands the export refactor in the same PR as the spine composition.
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -32,7 +31,10 @@ from tether.exporters.trt_build import build_engine, check_trtexec
 # sunset. External callers still doing ``from tether.exporters.smolvla import
 # ExpertGQALayer`` keep working through this surface.
 from tether.models.heads.expert_stack import (  # noqa: F401
-    ExpertGQALayer, ExpertStack, _DecomposedRoPE, _sinusoidal_pos_embedding,
+    ExpertGQALayer,
+    ExpertStack,
+    _DecomposedRoPE,
+    _sinusoidal_pos_embedding,
 )
 
 logger = logging.getLogger(__name__)
@@ -71,6 +73,7 @@ def build_expert_stack(
 
     try:
         from transformers import AutoConfig
+
         vlm_cfg = AutoConfig.from_pretrained("HuggingFaceTB/SmolVLM2-500M-Video-Instruct")
         nq = int(vlm_cfg.text_config.num_attention_heads)
         nkv = int(vlm_cfg.text_config.num_key_value_heads)
@@ -83,7 +86,12 @@ def build_expert_stack(
     logger.info(
         "[expert-stack] expert_hidden=%d, num_q_heads=%d, num_kv_heads=%d, "
         "expert_head_dim=%d (vlm head_dim=%d), intermediate=%d",
-        expert_hidden, nq, nkv, expert_head_dim, head_dim, inter,
+        expert_hidden,
+        nq,
+        nkv,
+        expert_head_dim,
+        head_dim,
+        inter,
     )
     head_dim = expert_head_dim
 
@@ -99,12 +107,18 @@ def build_expert_stack(
             vlm_kv_dim = kv_in
 
         layer = ExpertGQALayer(
-            expert_hidden, nq, nkv, head_dim, inter,
+            expert_hidden,
+            nq,
+            nkv,
+            head_dim,
+            inter,
             kv_in=kv_in if is_cross else None,
         )
         layer_sd = {
             "input_layernorm.weight": state_dict[f"{prefix}.input_layernorm.weight"],
-            "post_attention_layernorm.weight": state_dict[f"{prefix}.post_attention_layernorm.weight"],
+            "post_attention_layernorm.weight": state_dict[
+                f"{prefix}.post_attention_layernorm.weight"
+            ],
             "q_proj.weight": state_dict[f"{prefix}.self_attn.q_proj.weight"],
             "k_proj.weight": state_dict[f"{prefix}.self_attn.k_proj.weight"],
             "v_proj.weight": state_dict[f"{prefix}.self_attn.v_proj.weight"],
@@ -213,7 +227,9 @@ def export_smolvla(
     result["metadata"]["expert"] = expert_meta
     logger.info(
         "Expert: %d layers, %.1fM params, cross_attn=%s",
-        expert_meta["num_layers"], expert_meta["total_params_m"], expert_meta["cross_attn_layers"],
+        expert_meta["num_layers"],
+        expert_meta["total_params_m"],
+        expert_meta["cross_attn_layers"],
     )
 
     # 3. Export expert stack to ONNX — identical shape to the legacy path.
@@ -234,14 +250,29 @@ def export_smolvla(
     logger.info("Exporting expert stack to ONNX: %s", expert_onnx)
     export_module_to_onnx(
         expert_stack,
-        (dummy_actions, dummy_time, dummy_pos, dummy_vlm_k, dummy_vlm_v,
-         dummy_prefix_offset, dummy_kv_mask),
+        (
+            dummy_actions,
+            dummy_time,
+            dummy_pos,
+            dummy_vlm_k,
+            dummy_vlm_v,
+            dummy_prefix_offset,
+            dummy_kv_mask,
+        ),
         expert_onnx,
-        input_names=["noisy_actions", "timestep", "position_ids", "vlm_k", "vlm_v",
-                     "prefix_offset", "kv_mask"],
+        input_names=[
+            "noisy_actions",
+            "timestep",
+            "position_ids",
+            "vlm_k",
+            "vlm_v",
+            "prefix_offset",
+            "kv_mask",
+        ],
         output_names=["velocity"],
         dynamic_axes={
-            "noisy_actions": {0: "batch"}, "timestep": {0: "batch"},
+            "noisy_actions": {0: "batch"},
+            "timestep": {0: "batch"},
             "position_ids": {0: "batch"},
             "vlm_k": {1: "batch", 2: "seq"},
             "vlm_v": {1: "batch", 2: "seq"},
@@ -261,23 +292,41 @@ def export_smolvla(
             import numpy as np
 
             sess = ort.InferenceSession(str(expert_onnx))
-            ort_out = sess.run(None, {
-                "noisy_actions": dummy_actions.numpy(),
-                "timestep": dummy_time.numpy(),
-                "position_ids": dummy_pos.numpy().astype(np.int64),
-                "vlm_k": dummy_vlm_k.numpy(),
-                "vlm_v": dummy_vlm_v.numpy(),
-                "prefix_offset": dummy_prefix_offset.numpy(),
-                "kv_mask": dummy_kv_mask.numpy(),
-            })[0]
-            torch_out = expert_stack(
-                dummy_actions, dummy_time, dummy_pos,
-                dummy_vlm_k, dummy_vlm_v, dummy_prefix_offset, dummy_kv_mask
-            ).detach().numpy()
+            ort_out = sess.run(
+                None,
+                {
+                    "noisy_actions": dummy_actions.numpy(),
+                    "timestep": dummy_time.numpy(),
+                    "position_ids": dummy_pos.numpy().astype(np.int64),
+                    "vlm_k": dummy_vlm_k.numpy(),
+                    "vlm_v": dummy_vlm_v.numpy(),
+                    "prefix_offset": dummy_prefix_offset.numpy(),
+                    "kv_mask": dummy_kv_mask.numpy(),
+                },
+            )[0]
+            torch_out = (
+                expert_stack(
+                    dummy_actions,
+                    dummy_time,
+                    dummy_pos,
+                    dummy_vlm_k,
+                    dummy_vlm_v,
+                    dummy_prefix_offset,
+                    dummy_kv_mask,
+                )
+                .detach()
+                .numpy()
+            )
             max_diff = float(np.abs(ort_out - torch_out).max())
-            result["metadata"]["onnx_validation"] = {"max_diff": max_diff, "passed": max_diff < 0.01}
-            logger.info("ONNX validation: max_diff=%.2e (%s)",
-                        max_diff, "PASS" if max_diff < 0.01 else "FAIL")
+            result["metadata"]["onnx_validation"] = {
+                "max_diff": max_diff,
+                "passed": max_diff < 0.01,
+            }
+            logger.info(
+                "ONNX validation: max_diff=%.2e (%s)",
+                max_diff,
+                "PASS" if max_diff < 0.01 else "FAIL",
+            )
         except ImportError:
             logger.warning("onnxruntime not installed, skipping validation")
 
@@ -293,6 +342,8 @@ def export_smolvla(
     # 6. Save tether_config.json — same schema as legacy
     export_config = {
         "model_id": config.model_id,
+        "model_type": "smolvla",
+        "export_kind": "decomposed_onnx",
         "target": config.target,
         "precision": config.precision,
         "opset": config.opset,
@@ -310,8 +361,11 @@ def export_smolvla(
         "vlm_kv_dim": vlm_kv_dim,
         "spine_path": True,
     }
-    config_path = output_dir / "tether_config.json"
-    config_path.write_text(json.dumps(export_config, indent=2))
+    from tether.export_config import normalize_legacy_tether_config, write_tether_config
+
+    config_path = write_tether_config(
+        output_dir, normalize_legacy_tether_config(export_config, output_dir)
+    )
     result["files"]["config"] = str(config_path)
 
     logger.info("Export complete: %s", output_dir)

--- a/src/tether/exporters/vlm_prefix_exporter.py
+++ b/src/tether/exporters/vlm_prefix_exporter.py
@@ -17,7 +17,6 @@ in the ONNX graph via ``patch_onnx_type_mismatches``.
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -438,47 +437,91 @@ def export_vlm_prefix(
     except ImportError:
         logger.warning("onnxruntime not installed -- skipping ONNX validation")
 
-    # 7. Write / update tether_config.json
-    config_path = output_dir / "tether_config.json"
-    config: dict[str, Any] = {}
-    if config_path.exists():
-        config = json.loads(config_path.read_text())
-
-    config["vlm_image_size"] = [image_size, image_size]
-    config["vlm_hidden_size"] = vlm_hidden_size  # 960 — VLM-internal dim (for state encoder)
-    config["vlm_kv_dim"] = vlm_kv_dim            # 320 — expert cross-attn input dim
-    # L dim in the per-layer tensor; SmolVLA truncates the SmolVLM2 decoder
-    # to 16 of 32 layers at export time, and the expert has a matching count.
-    config["vlm_num_layers"] = SMOLVLA_NUM_DECODER_LAYERS
-    config["vlm_prefix_onnx"] = "vision_encoder.onnx"
-    config["vlm_model_id"] = checkpoint_path_or_id
-    config["export_version"] = "0.5"  # split vlm_k/vlm_v with RoPE on k
-
-    config_path.write_text(json.dumps(config, indent=2))
-    logger.info("Updated config: %s", config_path)
-
-    # 8. Export text embedder
-    text_emb_path = export_text_embedder(
+    # 7. Export text embedder
+    export_text_embedder(
         checkpoint_path_or_id=checkpoint_path_or_id,
         output_dir=output_dir,
         opset=opset,
     )
 
-    # 9. Export decoder prefill
-    decoder_path = export_decoder_prefill(
+    # 8. Export decoder prefill
+    export_decoder_prefill(
         checkpoint_path_or_id=checkpoint_path_or_id,
         output_dir=output_dir,
         opset=opset,
     )
 
-    # Update config with all export paths
-    config = json.loads(config_path.read_text())
-    config["text_embedder_onnx"] = "text_embedder.onnx"
-    config["decoder_prefill_onnx"] = "decoder_prefill.onnx"
-    config_path.write_text(json.dumps(config, indent=2))
+    # Update the validated config only after every declared artifact exists.
+    config_path = _update_vlm_manifest(
+        output_dir,
+        checkpoint_path_or_id=checkpoint_path_or_id,
+        image_size=image_size,
+        vlm_hidden_size=vlm_hidden_size,
+        vlm_kv_dim=vlm_kv_dim,
+    )
     logger.info("Updated config with text_embedder + decoder_prefill: %s", config_path)
 
     return onnx_path
+
+
+def _update_vlm_manifest(
+    output_dir: str | Path,
+    *,
+    checkpoint_path_or_id: str,
+    image_size: int,
+    vlm_hidden_size: int,
+    vlm_kv_dim: int,
+) -> Path:
+    """Replace the VLM component's manifest entries from its known outputs."""
+    from tether.export_config import (
+        SMOLVLA_VLM_MODEL_PATHS,
+        load_tether_config,
+        replace_owned_onnx_artifacts,
+        write_tether_config,
+    )
+
+    output_dir = Path(output_dir)
+    config = load_tether_config(output_dir)
+    extensions = dict(config.get("extensions", {}))
+    artifact_owners = dict(extensions.get("artifact_owners", {}))
+    previous_owned = artifact_owners.get("smolvla_vlm", [])
+    if not isinstance(previous_owned, list) or not all(
+        isinstance(path, str) for path in previous_owned
+    ):
+        previous_owned = []
+
+    # Migrate the old append-only manifest deterministically. Standard ONNX
+    # external-data names use ``<graph>.data``; arbitrary names are tracked by
+    # the owner list from the first canonical run onward.
+    legacy_owned = {
+        value
+        for key in ("vlm_prefix_onnx", "text_embedder_onnx", "decoder_prefill_onnx")
+        if isinstance((value := config.get(key)), str)
+    }
+    for item in config["artifacts"]:
+        path = str(item.get("path", ""))
+        if any(path == model or path.startswith(f"{model}.") for model in SMOLVLA_VLM_MODEL_PATHS):
+            legacy_owned.add(path)
+
+    config["artifacts"], current_owned = replace_owned_onnx_artifacts(
+        output_dir,
+        config["artifacts"],
+        model_paths=SMOLVLA_VLM_MODEL_PATHS,
+        previously_owned_paths=[*previous_owned, *sorted(legacy_owned)],
+    )
+    artifact_owners["smolvla_vlm"] = current_owned
+    extensions["artifact_owners"] = artifact_owners
+    config["extensions"] = extensions
+    config["vlm_image_size"] = [image_size, image_size]
+    config["vlm_hidden_size"] = vlm_hidden_size
+    config["vlm_kv_dim"] = vlm_kv_dim
+    config["vlm_num_layers"] = SMOLVLA_NUM_DECODER_LAYERS
+    config["vlm_prefix_onnx"] = "vision_encoder.onnx"
+    config["text_embedder_onnx"] = "text_embedder.onnx"
+    config["decoder_prefill_onnx"] = "decoder_prefill.onnx"
+    config["vlm_model_id"] = checkpoint_path_or_id
+    config["export_version"] = "0.5"
+    return write_tether_config(output_dir, config)
 
 
 # ---------------------------------------------------------------------------

--- a/src/tether/replay/cli.py
+++ b/src/tether/replay/cli.py
@@ -156,16 +156,12 @@ def _load_target_server(model: str):
     # but bypass FastAPI — we just want the underlying server object.
     # We can't call create_app() here easily because it sets up FastAPI;
     # instead, replicate its dispatch-by-config logic directly.
-    config_path = Path(model) / "tether_config.json"
-    cfg: dict[str, Any] = {}
-    if config_path.exists():
-        try:
-            cfg = json.loads(config_path.read_text())
-        except json.JSONDecodeError:
-            cfg = {}
+    from tether.export_config import decomposed_layout, load_tether_config
 
-    if cfg.get("export_kind") == "monolithic":
-        model_type = cfg.get("model_type", "smolvla")
+    cfg = load_tether_config(Path(model))
+
+    if cfg.get("export_kind") == "monolithic_onnx":
+        model_type = cfg["model_type"]
         if model_type == "pi0":
             from tether.runtime.pi0_onnx_server import Pi0OnnxServer
             srv = Pi0OnnxServer(model)
@@ -177,9 +173,22 @@ def _load_target_server(model: str):
                 f"Replay against monolithic model_type={model_type!r} not "
                 f"yet supported. Day 2 ships pi0 + smolvla only."
             )
+    elif cfg.get("export_kind") == "decomposed_onnx":
+        layout = decomposed_layout(cfg)
+        if layout == "pi05_split":
+            from tether.runtime.decomposed_server import Pi05DecomposedServer
+
+            srv = Pi05DecomposedServer(model)
+        elif layout in {"expert_stack", "smolvla_full_bundle"}:
+            from tether.runtime.server import TetherServer
+
+            srv = TetherServer(model)
+        else:  # pragma: no cover - decomposed_layout is exhaustive
+            raise AssertionError(layout)
     else:
-        from tether.runtime.server import TetherServer
-        srv = TetherServer(model)
+        raise ValueError(
+            f"Replay does not support export_kind={cfg.get('export_kind')!r}"
+        )
     srv.load()
     return srv
 

--- a/src/tether/runtime/decomposed_server.py
+++ b/src/tether/runtime/decomposed_server.py
@@ -19,6 +19,7 @@ Scope per the ADR:
 - Modal validation: filed as follow-up experiments (see ADR §"Validation
   experiments to file")
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -87,9 +88,7 @@ class Pi05DecomposedServer:
         self._requested_device = device
         self._requested_providers = providers
         self._strict_providers = strict_providers
-        self._safety_config_path = (
-            Path(safety_config) if safety_config else None
-        )
+        self._safety_config_path = Path(safety_config) if safety_config else None
         self._adaptive_steps = adaptive_steps
         self._cloud_fallback_url = cloud_fallback_url
         self._deadline_ms = deadline_ms
@@ -166,13 +165,9 @@ class Pi05DecomposedServer:
 
     def _load_config(self) -> dict[str, Any]:
         """Read tether_config.json from the export dir."""
-        config_path = self.export_dir / "tether_config.json"
-        if not config_path.exists():
-            raise FileNotFoundError(
-                f"tether_config.json not found in {self.export_dir}. "
-                f"Decomposed exports must include the config sibling."
-            )
-        return json.loads(config_path.read_text())
+        from tether.export_config import load_tether_config
+
+        return load_tether_config(self.export_dir)
 
     def load(self) -> None:
         """Load the decomposed inference + tokenizer + tether_config."""
@@ -186,24 +181,23 @@ class Pi05DecomposedServer:
 
         # Pull canonical fields from config; validate export_kind.
         export_kind = self.config.get("export_kind", "")
-        if export_kind != "decomposed":
+        if export_kind != "decomposed_onnx":
             raise ValueError(
-                f"Pi05DecomposedServer requires export_kind='decomposed', "
+                f"Pi05DecomposedServer requires export_kind='decomposed_onnx', "
                 f"got {export_kind!r}. Use the matching server class for "
                 f"this export type (monolithic -> Pi0OnnxServer / "
                 f"SmolVLAOnnxServer; legacy decomposed -> TetherServer)."
             )
 
-        self.action_dim = int(self.config.get("action_dim", 7))
+        self.action_dim = int(self.config["action_dim"])
         self.chunk_size = int(
-            self.config.get("chunk_size") or self.config.get("action_chunk_size", DEFAULT_CHUNK_SIZE)
+            self.config.get("chunk_size")
+            or self.config.get("action_chunk_size", DEFAULT_CHUNK_SIZE)
         )
         # max_action_dim is the export's padded action dim (usually 32 for pi05).
         # Read from `decomposed.max_action_dim` if present; default to 32.
         decomposed_block = self.config.get("decomposed", {})
-        self.max_action_dim = int(
-            decomposed_block.get("max_action_dim", DEFAULT_MAX_ACTION_DIM)
-        )
+        self.max_action_dim = int(decomposed_block.get("max_action_dim", DEFAULT_MAX_ACTION_DIM))
 
         # Build providers list.
         providers = self._requested_providers or (
@@ -215,8 +209,11 @@ class Pi05DecomposedServer:
         logger.info(
             "Pi05DecomposedServer loading from %s (action_dim=%d, "
             "chunk_size=%d, max_action_dim=%d, providers=%s)",
-            self.export_dir, self.action_dim, self.chunk_size,
-            self.max_action_dim, providers,
+            self.export_dir,
+            self.action_dim,
+            self.chunk_size,
+            self.max_action_dim,
+            providers,
         )
 
         # Instantiate the inference primitive. Default cache config keeps
@@ -249,9 +246,9 @@ class Pi05DecomposedServer:
                         if len(shape) >= 2 and isinstance(shape[1], int):
                             self.lang_seq_len = int(shape[1])
                             logger.info(
-                                "Pi05DecomposedServer lang_seq_len=%d "
-                                "(probed from %s)",
-                                self.lang_seq_len, sess_attr,
+                                "Pi05DecomposedServer lang_seq_len=%d (probed from %s)",
+                                self.lang_seq_len,
+                                sess_attr,
                             )
                             break
                 if self.lang_seq_len != DEFAULT_LANG_SEQ_LEN:
@@ -259,7 +256,8 @@ class Pi05DecomposedServer:
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "lang_seq_len probe failed (%s); using default %d",
-                exc, self.lang_seq_len,
+                exc,
+                self.lang_seq_len,
             )
 
         # Try to load the HF tokenizer from the export. For decomposed
@@ -278,6 +276,7 @@ class Pi05DecomposedServer:
         if self._safety_config_path is not None:
             try:
                 from tether.safety import ActionGuard, SafetyLimits
+
                 limits = SafetyLimits.from_json(self._safety_config_path)
                 self._action_guard = ActionGuard(limits=limits, mode="clamp")
                 logger.info(
@@ -316,6 +315,7 @@ class Pi05DecomposedServer:
             if teacher_ref:
                 try:
                     from huggingface_hub import snapshot_download
+
                     teacher_path = snapshot_download(
                         teacher_ref,
                         allow_patterns=[
@@ -328,9 +328,9 @@ class Pi05DecomposedServer:
                         source = f"hf-teacher:{teacher_ref}"
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
-                        "Pi05DecomposedServer normalizer fetch from teacher %r "
-                        "failed: %s",
-                        teacher_ref, exc,
+                        "Pi05DecomposedServer normalizer fetch from teacher %r failed: %s",
+                        teacher_ref,
+                        exc,
                     )
 
         if "action_mean" in stats and "action_std" in stats:
@@ -342,8 +342,7 @@ class Pi05DecomposedServer:
 
         if self._action_mean is not None or self._state_mean is not None:
             logger.info(
-                "Pi05DecomposedServer normalizer loaded from %s "
-                "(action=%s, state=%s)",
+                "Pi05DecomposedServer normalizer loaded from %s (action=%s, state=%s)",
                 source,
                 "on" if self._action_mean is not None else "off",
                 "on" if self._state_mean is not None else "off",
@@ -379,11 +378,7 @@ class Pi05DecomposedServer:
             try:
                 prov = json.loads(prov_path.read_text())
                 teacher = prov.get("teacher_export", "")
-                if (
-                    isinstance(teacher, str)
-                    and "/" in teacher
-                    and not teacher.startswith("/")
-                ):
+                if isinstance(teacher, str) and "/" in teacher and not teacher.startswith("/"):
                     return teacher
             except Exception:  # noqa: BLE001
                 pass
@@ -409,6 +404,7 @@ class Pi05DecomposedServer:
             return
 
         from transformers import AutoTokenizer
+
         tried: list[str] = []
         last_exc: Exception | None = None
 
@@ -437,11 +433,7 @@ class Pi05DecomposedServer:
             try:
                 prov = json.loads(prov_path.read_text())
                 teacher = prov.get("teacher_export", "")
-                if (
-                    isinstance(teacher, str)
-                    and "/" in teacher
-                    and not teacher.startswith("/")
-                ):
+                if isinstance(teacher, str) and "/" in teacher and not teacher.startswith("/"):
                     candidates.append(teacher)
             except Exception:  # noqa: BLE001
                 pass
@@ -456,8 +448,9 @@ class Pi05DecomposedServer:
                 tok = AutoTokenizer.from_pretrained(cand)
                 self._tokenizer = tok
                 logger.info(
-                    "Pi05DecomposedServer tokenizer loaded from %r "
-                    "(vocab_size=%d)", cand, tok.vocab_size,
+                    "Pi05DecomposedServer tokenizer loaded from %r (vocab_size=%d)",
+                    cand,
+                    tok.vocab_size,
                 )
                 return
             except Exception as exc:  # noqa: BLE001
@@ -466,8 +459,10 @@ class Pi05DecomposedServer:
                 continue
 
         logger.error(
-            "Pi05DecomposedServer tokenizer load failed; tried %d sources: "
-            "%r. Last error: %s", len(tried), tried, last_exc,
+            "Pi05DecomposedServer tokenizer load failed; tried %d sources: %r. Last error: %s",
+            len(tried),
+            tried,
+            last_exc,
         )
         raise RuntimeError(
             f"No tokenizer found for {self.export_dir}. Tried {len(tried)} "
@@ -498,7 +493,9 @@ class Pi05DecomposedServer:
                 return image_wrist
 
         return self._predict(
-            image=image, instruction=instruction or "", state=state,
+            image=image,
+            instruction=instruction or "",
+            state=state,
             image_wrist=image_wrist,
         )
 
@@ -509,6 +506,7 @@ class Pi05DecomposedServer:
             return None
         try:
             from PIL import Image
+
             img_bytes = base64.b64decode(b64)
             img = Image.open(io.BytesIO(img_bytes)).convert("RGB")
             return np.array(img)
@@ -529,8 +527,10 @@ class Pi05DecomposedServer:
         return await loop.run_in_executor(
             None,
             lambda: self.predict_from_base64(
-                image_b64=image_b64, instruction=instruction,
-                state=state, image_wrist_b64=image_wrist_b64,
+                image_b64=image_b64,
+                instruction=instruction,
+                state=state,
+                image_wrist_b64=image_wrist_b64,
             ),
         )
 
@@ -563,6 +563,7 @@ class Pi05DecomposedServer:
         any exception in the standard error dict (so /act returns a clean
         envelope; circuit breaker fires on the dict-with-error key)."""
         import time
+
         if not self._ready or self._inference is None:
             return {"error": "server not ready -- load() not called"}
 
@@ -605,14 +606,20 @@ class Pi05DecomposedServer:
                 rng = np.random.default_rng()  # nondeterministic per call
 
                 def _sample_one(_i: int) -> np.ndarray:
-                    noise_i = rng.standard_normal(
-                        (1, self.chunk_size, self.max_action_dim)
-                    ).astype(np.float32)
+                    noise_i = rng.standard_normal((1, self.chunk_size, self.max_action_dim)).astype(
+                        np.float32
+                    )
                     out = self._inference.predict_action_chunk(
-                        img_base=img_base, img_wrist_l=img_wrist_l, img_wrist_r=img_pad,
-                        mask_base=mask_base, mask_wrist_l=mask_wrist_l, mask_wrist_r=mask_pad,
-                        lang_tokens=lang_tokens, lang_masks=lang_masks,
-                        noise=noise_i, state=state_arr,
+                        img_base=img_base,
+                        img_wrist_l=img_wrist_l,
+                        img_wrist_r=img_pad,
+                        mask_base=mask_base,
+                        mask_wrist_l=mask_wrist_l,
+                        mask_wrist_r=mask_pad,
+                        lang_tokens=lang_tokens,
+                        lang_masks=lang_masks,
+                        noise=noise_i,
+                        state=state_arr,
                     )
                     if out.ndim == 3:
                         out = out[0]
@@ -631,13 +638,21 @@ class Pi05DecomposedServer:
             else:
                 # Single-sample (default).
                 noise = np.random.randn(
-                    1, self.chunk_size, self.max_action_dim,
+                    1,
+                    self.chunk_size,
+                    self.max_action_dim,
                 ).astype(np.float32)
                 actions_padded = self._inference.predict_action_chunk(
-                    img_base=img_base, img_wrist_l=img_wrist_l, img_wrist_r=img_pad,
-                    mask_base=mask_base, mask_wrist_l=mask_wrist_l, mask_wrist_r=mask_pad,
-                    lang_tokens=lang_tokens, lang_masks=lang_masks,
-                    noise=noise, state=state_arr,
+                    img_base=img_base,
+                    img_wrist_l=img_wrist_l,
+                    img_wrist_r=img_pad,
+                    mask_base=mask_base,
+                    mask_wrist_l=mask_wrist_l,
+                    mask_wrist_r=mask_pad,
+                    lang_tokens=lang_tokens,
+                    lang_masks=lang_masks,
+                    noise=noise,
+                    state=state_arr,
                 )
 
             # 5b. A2C2 hook -- applied in NORMALIZED action space (between
@@ -664,12 +679,10 @@ class Pi05DecomposedServer:
                 a_std = self._action_std
                 ad = actions_padded.shape[-1]
                 if a_mean.shape[0] < ad:
-                    a_mean = np.concatenate([
-                        a_mean, np.zeros(ad - a_mean.shape[0], dtype=np.float32)
-                    ])
-                    a_std = np.concatenate([
-                        a_std, np.ones(ad - a_std.shape[0], dtype=np.float32)
-                    ])
+                    a_mean = np.concatenate(
+                        [a_mean, np.zeros(ad - a_mean.shape[0], dtype=np.float32)]
+                    )
+                    a_std = np.concatenate([a_std, np.ones(ad - a_std.shape[0], dtype=np.float32)])
                 elif a_mean.shape[0] > ad:
                     a_mean = a_mean[:ad]
                     a_std = a_std[:ad]
@@ -724,7 +737,9 @@ class Pi05DecomposedServer:
             logger.info(
                 "Pi05DecomposedServer A2C2 hook bound INTERNALLY (applied in "
                 "normalized action space before denorm). action_dim=%d, "
-                "obs_dim=%d", hook.head.config.action_dim, hook.head.config.obs_dim,
+                "obs_dim=%d",
+                hook.head.config.action_dim,
+                hook.head.config.obs_dim,
             )
 
     def set_bid_config(self, config: Any) -> None:
@@ -749,9 +764,10 @@ class Pi05DecomposedServer:
                 )
                 self._a2c2_hook = None
             logger.info(
-                "Pi05DecomposedServer BID enabled: n_candidates=%d, "
-                "coherence_window=%d, metric=%s",
-                config.n_candidates, config.coherence_window, config.coherence_metric,
+                "Pi05DecomposedServer BID enabled: n_candidates=%d, coherence_window=%d, metric=%s",
+                config.n_candidates,
+                config.coherence_window,
+                config.coherence_metric,
             )
 
     def reset_bid_state(self) -> None:
@@ -782,8 +798,8 @@ class Pi05DecomposedServer:
                 has_batch = False
             hook_dim = self._a2c2_hook.head.config.action_dim
             actions_for_hook = chunk[:, :hook_dim].copy()
-            corrected, decision, magnitude = (
-                self._a2c2_hook.maybe_apply_to_chunk(actions=actions_for_hook)
+            corrected, decision, magnitude = self._a2c2_hook.maybe_apply_to_chunk(
+                actions=actions_for_hook
             )
             if decision.apply:
                 if has_batch:
@@ -804,7 +820,8 @@ class Pi05DecomposedServer:
             }
 
     def _prep_image(
-        self, image: np.ndarray | None,
+        self,
+        image: np.ndarray | None,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Resize/pad an HxWx3 uint8 image to (1, 3, R, R) float32 [0, 1] +
         a (1,) bool mask. When image is None, returns a -1 padding image +
@@ -816,22 +833,25 @@ class Pi05DecomposedServer:
             return img, mask
 
         if image.ndim != 3 or image.shape[2] != 3:
-            raise ValueError(
-                f"image must be HxWx3 uint8, got shape {image.shape}"
-            )
+            raise ValueError(f"image must be HxWx3 uint8, got shape {image.shape}")
 
         # Resize-with-pad to RxR (preserves aspect; pads short side).
         from PIL import Image
+
         h, w = image.shape[:2]
         if h > w:
             pad = (h - w) // 2
             image = np.pad(
-                image, [(0, 0), (pad, h - w - pad), (0, 0)], mode="constant",
+                image,
+                [(0, 0), (pad, h - w - pad), (0, 0)],
+                mode="constant",
             )
         elif w > h:
             pad = (w - h) // 2
             image = np.pad(
-                image, [(pad, w - h - pad), (0, 0), (0, 0)], mode="constant",
+                image,
+                [(pad, w - h - pad), (0, 0), (0, 0)],
+                mode="constant",
             )
         pil = Image.fromarray(image)
         pil = pil.resize((R, R), Image.BILINEAR)
@@ -899,9 +919,12 @@ class Pi05DecomposedServer:
         if arr.shape[0] > self.max_action_dim:
             arr = arr[: self.max_action_dim]
         elif arr.shape[0] < self.max_action_dim:
-            arr = np.concatenate([
-                arr, np.zeros(self.max_action_dim - arr.shape[0], dtype=np.float32),
-            ])
+            arr = np.concatenate(
+                [
+                    arr,
+                    np.zeros(self.max_action_dim - arr.shape[0], dtype=np.float32),
+                ]
+            )
         return arr[np.newaxis, ...]
 
 

--- a/src/tether/runtime/decomposed_server.py
+++ b/src/tether/runtime/decomposed_server.py
@@ -19,7 +19,6 @@ Scope per the ADR:
 - Modal validation: filed as follow-up experiments (see ADR §"Validation
   experiments to file")
 """
-
 from __future__ import annotations
 
 import asyncio
@@ -88,7 +87,9 @@ class Pi05DecomposedServer:
         self._requested_device = device
         self._requested_providers = providers
         self._strict_providers = strict_providers
-        self._safety_config_path = Path(safety_config) if safety_config else None
+        self._safety_config_path = (
+            Path(safety_config) if safety_config else None
+        )
         self._adaptive_steps = adaptive_steps
         self._cloud_fallback_url = cloud_fallback_url
         self._deadline_ms = deadline_ms
@@ -191,13 +192,14 @@ class Pi05DecomposedServer:
 
         self.action_dim = int(self.config["action_dim"])
         self.chunk_size = int(
-            self.config.get("chunk_size")
-            or self.config.get("action_chunk_size", DEFAULT_CHUNK_SIZE)
+            self.config.get("chunk_size") or self.config.get("action_chunk_size", DEFAULT_CHUNK_SIZE)
         )
         # max_action_dim is the export's padded action dim (usually 32 for pi05).
         # Read from `decomposed.max_action_dim` if present; default to 32.
         decomposed_block = self.config.get("decomposed", {})
-        self.max_action_dim = int(decomposed_block.get("max_action_dim", DEFAULT_MAX_ACTION_DIM))
+        self.max_action_dim = int(
+            decomposed_block.get("max_action_dim", DEFAULT_MAX_ACTION_DIM)
+        )
 
         # Build providers list.
         providers = self._requested_providers or (
@@ -209,11 +211,8 @@ class Pi05DecomposedServer:
         logger.info(
             "Pi05DecomposedServer loading from %s (action_dim=%d, "
             "chunk_size=%d, max_action_dim=%d, providers=%s)",
-            self.export_dir,
-            self.action_dim,
-            self.chunk_size,
-            self.max_action_dim,
-            providers,
+            self.export_dir, self.action_dim, self.chunk_size,
+            self.max_action_dim, providers,
         )
 
         # Instantiate the inference primitive. Default cache config keeps
@@ -246,9 +245,9 @@ class Pi05DecomposedServer:
                         if len(shape) >= 2 and isinstance(shape[1], int):
                             self.lang_seq_len = int(shape[1])
                             logger.info(
-                                "Pi05DecomposedServer lang_seq_len=%d (probed from %s)",
-                                self.lang_seq_len,
-                                sess_attr,
+                                "Pi05DecomposedServer lang_seq_len=%d "
+                                "(probed from %s)",
+                                self.lang_seq_len, sess_attr,
                             )
                             break
                 if self.lang_seq_len != DEFAULT_LANG_SEQ_LEN:
@@ -256,8 +255,7 @@ class Pi05DecomposedServer:
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "lang_seq_len probe failed (%s); using default %d",
-                exc,
-                self.lang_seq_len,
+                exc, self.lang_seq_len,
             )
 
         # Try to load the HF tokenizer from the export. For decomposed
@@ -276,7 +274,6 @@ class Pi05DecomposedServer:
         if self._safety_config_path is not None:
             try:
                 from tether.safety import ActionGuard, SafetyLimits
-
                 limits = SafetyLimits.from_json(self._safety_config_path)
                 self._action_guard = ActionGuard(limits=limits, mode="clamp")
                 logger.info(
@@ -315,7 +312,6 @@ class Pi05DecomposedServer:
             if teacher_ref:
                 try:
                     from huggingface_hub import snapshot_download
-
                     teacher_path = snapshot_download(
                         teacher_ref,
                         allow_patterns=[
@@ -328,9 +324,9 @@ class Pi05DecomposedServer:
                         source = f"hf-teacher:{teacher_ref}"
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
-                        "Pi05DecomposedServer normalizer fetch from teacher %r failed: %s",
-                        teacher_ref,
-                        exc,
+                        "Pi05DecomposedServer normalizer fetch from teacher %r "
+                        "failed: %s",
+                        teacher_ref, exc,
                     )
 
         if "action_mean" in stats and "action_std" in stats:
@@ -342,7 +338,8 @@ class Pi05DecomposedServer:
 
         if self._action_mean is not None or self._state_mean is not None:
             logger.info(
-                "Pi05DecomposedServer normalizer loaded from %s (action=%s, state=%s)",
+                "Pi05DecomposedServer normalizer loaded from %s "
+                "(action=%s, state=%s)",
                 source,
                 "on" if self._action_mean is not None else "off",
                 "on" if self._state_mean is not None else "off",
@@ -378,7 +375,11 @@ class Pi05DecomposedServer:
             try:
                 prov = json.loads(prov_path.read_text())
                 teacher = prov.get("teacher_export", "")
-                if isinstance(teacher, str) and "/" in teacher and not teacher.startswith("/"):
+                if (
+                    isinstance(teacher, str)
+                    and "/" in teacher
+                    and not teacher.startswith("/")
+                ):
                     return teacher
             except Exception:  # noqa: BLE001
                 pass
@@ -404,7 +405,6 @@ class Pi05DecomposedServer:
             return
 
         from transformers import AutoTokenizer
-
         tried: list[str] = []
         last_exc: Exception | None = None
 
@@ -433,7 +433,11 @@ class Pi05DecomposedServer:
             try:
                 prov = json.loads(prov_path.read_text())
                 teacher = prov.get("teacher_export", "")
-                if isinstance(teacher, str) and "/" in teacher and not teacher.startswith("/"):
+                if (
+                    isinstance(teacher, str)
+                    and "/" in teacher
+                    and not teacher.startswith("/")
+                ):
                     candidates.append(teacher)
             except Exception:  # noqa: BLE001
                 pass
@@ -448,9 +452,8 @@ class Pi05DecomposedServer:
                 tok = AutoTokenizer.from_pretrained(cand)
                 self._tokenizer = tok
                 logger.info(
-                    "Pi05DecomposedServer tokenizer loaded from %r (vocab_size=%d)",
-                    cand,
-                    tok.vocab_size,
+                    "Pi05DecomposedServer tokenizer loaded from %r "
+                    "(vocab_size=%d)", cand, tok.vocab_size,
                 )
                 return
             except Exception as exc:  # noqa: BLE001
@@ -459,10 +462,8 @@ class Pi05DecomposedServer:
                 continue
 
         logger.error(
-            "Pi05DecomposedServer tokenizer load failed; tried %d sources: %r. Last error: %s",
-            len(tried),
-            tried,
-            last_exc,
+            "Pi05DecomposedServer tokenizer load failed; tried %d sources: "
+            "%r. Last error: %s", len(tried), tried, last_exc,
         )
         raise RuntimeError(
             f"No tokenizer found for {self.export_dir}. Tried {len(tried)} "
@@ -493,9 +494,7 @@ class Pi05DecomposedServer:
                 return image_wrist
 
         return self._predict(
-            image=image,
-            instruction=instruction or "",
-            state=state,
+            image=image, instruction=instruction or "", state=state,
             image_wrist=image_wrist,
         )
 
@@ -506,7 +505,6 @@ class Pi05DecomposedServer:
             return None
         try:
             from PIL import Image
-
             img_bytes = base64.b64decode(b64)
             img = Image.open(io.BytesIO(img_bytes)).convert("RGB")
             return np.array(img)
@@ -527,10 +525,8 @@ class Pi05DecomposedServer:
         return await loop.run_in_executor(
             None,
             lambda: self.predict_from_base64(
-                image_b64=image_b64,
-                instruction=instruction,
-                state=state,
-                image_wrist_b64=image_wrist_b64,
+                image_b64=image_b64, instruction=instruction,
+                state=state, image_wrist_b64=image_wrist_b64,
             ),
         )
 
@@ -563,7 +559,6 @@ class Pi05DecomposedServer:
         any exception in the standard error dict (so /act returns a clean
         envelope; circuit breaker fires on the dict-with-error key)."""
         import time
-
         if not self._ready or self._inference is None:
             return {"error": "server not ready -- load() not called"}
 
@@ -606,20 +601,14 @@ class Pi05DecomposedServer:
                 rng = np.random.default_rng()  # nondeterministic per call
 
                 def _sample_one(_i: int) -> np.ndarray:
-                    noise_i = rng.standard_normal((1, self.chunk_size, self.max_action_dim)).astype(
-                        np.float32
-                    )
+                    noise_i = rng.standard_normal(
+                        (1, self.chunk_size, self.max_action_dim)
+                    ).astype(np.float32)
                     out = self._inference.predict_action_chunk(
-                        img_base=img_base,
-                        img_wrist_l=img_wrist_l,
-                        img_wrist_r=img_pad,
-                        mask_base=mask_base,
-                        mask_wrist_l=mask_wrist_l,
-                        mask_wrist_r=mask_pad,
-                        lang_tokens=lang_tokens,
-                        lang_masks=lang_masks,
-                        noise=noise_i,
-                        state=state_arr,
+                        img_base=img_base, img_wrist_l=img_wrist_l, img_wrist_r=img_pad,
+                        mask_base=mask_base, mask_wrist_l=mask_wrist_l, mask_wrist_r=mask_pad,
+                        lang_tokens=lang_tokens, lang_masks=lang_masks,
+                        noise=noise_i, state=state_arr,
                     )
                     if out.ndim == 3:
                         out = out[0]
@@ -638,21 +627,13 @@ class Pi05DecomposedServer:
             else:
                 # Single-sample (default).
                 noise = np.random.randn(
-                    1,
-                    self.chunk_size,
-                    self.max_action_dim,
+                    1, self.chunk_size, self.max_action_dim,
                 ).astype(np.float32)
                 actions_padded = self._inference.predict_action_chunk(
-                    img_base=img_base,
-                    img_wrist_l=img_wrist_l,
-                    img_wrist_r=img_pad,
-                    mask_base=mask_base,
-                    mask_wrist_l=mask_wrist_l,
-                    mask_wrist_r=mask_pad,
-                    lang_tokens=lang_tokens,
-                    lang_masks=lang_masks,
-                    noise=noise,
-                    state=state_arr,
+                    img_base=img_base, img_wrist_l=img_wrist_l, img_wrist_r=img_pad,
+                    mask_base=mask_base, mask_wrist_l=mask_wrist_l, mask_wrist_r=mask_pad,
+                    lang_tokens=lang_tokens, lang_masks=lang_masks,
+                    noise=noise, state=state_arr,
                 )
 
             # 5b. A2C2 hook -- applied in NORMALIZED action space (between
@@ -679,10 +660,12 @@ class Pi05DecomposedServer:
                 a_std = self._action_std
                 ad = actions_padded.shape[-1]
                 if a_mean.shape[0] < ad:
-                    a_mean = np.concatenate(
-                        [a_mean, np.zeros(ad - a_mean.shape[0], dtype=np.float32)]
-                    )
-                    a_std = np.concatenate([a_std, np.ones(ad - a_std.shape[0], dtype=np.float32)])
+                    a_mean = np.concatenate([
+                        a_mean, np.zeros(ad - a_mean.shape[0], dtype=np.float32)
+                    ])
+                    a_std = np.concatenate([
+                        a_std, np.ones(ad - a_std.shape[0], dtype=np.float32)
+                    ])
                 elif a_mean.shape[0] > ad:
                     a_mean = a_mean[:ad]
                     a_std = a_std[:ad]
@@ -737,9 +720,7 @@ class Pi05DecomposedServer:
             logger.info(
                 "Pi05DecomposedServer A2C2 hook bound INTERNALLY (applied in "
                 "normalized action space before denorm). action_dim=%d, "
-                "obs_dim=%d",
-                hook.head.config.action_dim,
-                hook.head.config.obs_dim,
+                "obs_dim=%d", hook.head.config.action_dim, hook.head.config.obs_dim,
             )
 
     def set_bid_config(self, config: Any) -> None:
@@ -764,10 +745,9 @@ class Pi05DecomposedServer:
                 )
                 self._a2c2_hook = None
             logger.info(
-                "Pi05DecomposedServer BID enabled: n_candidates=%d, coherence_window=%d, metric=%s",
-                config.n_candidates,
-                config.coherence_window,
-                config.coherence_metric,
+                "Pi05DecomposedServer BID enabled: n_candidates=%d, "
+                "coherence_window=%d, metric=%s",
+                config.n_candidates, config.coherence_window, config.coherence_metric,
             )
 
     def reset_bid_state(self) -> None:
@@ -798,8 +778,8 @@ class Pi05DecomposedServer:
                 has_batch = False
             hook_dim = self._a2c2_hook.head.config.action_dim
             actions_for_hook = chunk[:, :hook_dim].copy()
-            corrected, decision, magnitude = self._a2c2_hook.maybe_apply_to_chunk(
-                actions=actions_for_hook
+            corrected, decision, magnitude = (
+                self._a2c2_hook.maybe_apply_to_chunk(actions=actions_for_hook)
             )
             if decision.apply:
                 if has_batch:
@@ -820,8 +800,7 @@ class Pi05DecomposedServer:
             }
 
     def _prep_image(
-        self,
-        image: np.ndarray | None,
+        self, image: np.ndarray | None,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Resize/pad an HxWx3 uint8 image to (1, 3, R, R) float32 [0, 1] +
         a (1,) bool mask. When image is None, returns a -1 padding image +
@@ -833,25 +812,22 @@ class Pi05DecomposedServer:
             return img, mask
 
         if image.ndim != 3 or image.shape[2] != 3:
-            raise ValueError(f"image must be HxWx3 uint8, got shape {image.shape}")
+            raise ValueError(
+                f"image must be HxWx3 uint8, got shape {image.shape}"
+            )
 
         # Resize-with-pad to RxR (preserves aspect; pads short side).
         from PIL import Image
-
         h, w = image.shape[:2]
         if h > w:
             pad = (h - w) // 2
             image = np.pad(
-                image,
-                [(0, 0), (pad, h - w - pad), (0, 0)],
-                mode="constant",
+                image, [(0, 0), (pad, h - w - pad), (0, 0)], mode="constant",
             )
         elif w > h:
             pad = (w - h) // 2
             image = np.pad(
-                image,
-                [(pad, w - h - pad), (0, 0), (0, 0)],
-                mode="constant",
+                image, [(pad, w - h - pad), (0, 0), (0, 0)], mode="constant",
             )
         pil = Image.fromarray(image)
         pil = pil.resize((R, R), Image.BILINEAR)
@@ -919,12 +895,9 @@ class Pi05DecomposedServer:
         if arr.shape[0] > self.max_action_dim:
             arr = arr[: self.max_action_dim]
         elif arr.shape[0] < self.max_action_dim:
-            arr = np.concatenate(
-                [
-                    arr,
-                    np.zeros(self.max_action_dim - arr.shape[0], dtype=np.float32),
-                ]
-            )
+            arr = np.concatenate([
+                arr, np.zeros(self.max_action_dim - arr.shape[0], dtype=np.float32),
+            ])
         return arr[np.newaxis, ...]
 
 

--- a/src/tether/runtime/pi05_decomposed_server.py
+++ b/src/tether/runtime/pi05_decomposed_server.py
@@ -21,11 +21,9 @@ The class exposes the same ``predict_action_chunk`` contract as
 ``Pi0OnnxServer.predict`` so downstream harnesses don't need to know
 which export pattern is active.
 """
-
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import time
 from dataclasses import dataclass
@@ -40,13 +38,12 @@ logger = logging.getLogger(__name__)
 @dataclass
 class CacheEntry:
     """One VLM output we keep around for potential reuse."""
-
-    past_kv: list[np.ndarray]  # flat [k_0, v_0, ..., k_17, v_17]
+    past_kv: list[np.ndarray]            # flat [k_0, v_0, ..., k_17, v_17]
     prefix_pad_masks: np.ndarray
-    image_phashes: tuple[bytes, ...]  # per-camera perceptual hash
-    lang_hash: bytes  # exact md5 of language tokens
-    timestamp: float  # wall-clock time (for TTL-sec path)
-    step_index: int  # predict_action_chunk call number (for step-count path)
+    image_phashes: tuple[bytes, ...]     # per-camera perceptual hash
+    lang_hash: bytes                     # exact md5 of language tokens
+    timestamp: float                     # wall-clock time (for TTL-sec path)
+    step_index: int                      # predict_action_chunk call number (for step-count path)
 
 
 @dataclass
@@ -57,7 +54,6 @@ class ActionCacheEntry:
     across calls — but for a SnapFlow 1-NFE student at target_time=1
     the noise dependence is minimal, so reusing a cached chunk on a
     matching obs is effectively zero-cost."""
-
     image_phashes: tuple[bytes, ...]
     lang_hash: bytes
     state_signature: np.ndarray | None
@@ -69,7 +65,6 @@ class ActionCacheEntry:
 class CacheStats:
     """Cumulative cache metrics — exposed via get_stats() so callers
     can log hit rate alongside LIBERO task success."""
-
     hits: int = 0
     misses: int = 0
     evictions_ttl: int = 0
@@ -204,7 +199,6 @@ class Pi05DecomposedInference:
         self._call_index: int = 0  # monotonic call counter for step-count TTL
         self._action_cache: ActionCacheEntry | None = None
         from tether.runtime.temporal_vla_cache import TemporalVLAReusePolicy
-
         self._temporal_reuse_policy = TemporalVLAReusePolicy(
             phash_hamming_threshold=phash_hamming_threshold,
         )
@@ -214,7 +208,6 @@ class Pi05DecomposedInference:
         # existing behavior is unchanged unless --action-similarity-threshold
         # is set on the CLI.
         from tether.runtime.action_fast_path import ActionFastPath
-
         self._fast_path = ActionFastPath(
             threshold=float(action_similarity_threshold),
             max_skips=int(max_similar_skips),
@@ -233,7 +226,6 @@ class Pi05DecomposedInference:
         self._cuda_graphs_model_id = cuda_graphs_model_id
         if cuda_graphs_enabled:
             from tether.runtime.cuda_graphs import build_cuda_graph_providers
-
             if providers is not None:
                 logger.warning(
                     "cuda_graphs_enabled=True overrides user-provided providers=%s",
@@ -264,8 +256,7 @@ class Pi05DecomposedInference:
         if self._per_step_expert:
             logger.info(
                 "Pi05DecomposedInference: per-step expert path active "
-                "(num_steps=%d, Python Euler loop)",
-                self._num_steps,
+                "(num_steps=%d, Python Euler loop)", self._num_steps,
             )
 
         prefix_path = self.export_dir / self.config["decomposed"]["vlm_prefix_onnx"]
@@ -282,8 +273,7 @@ class Pi05DecomposedInference:
         # captures cleanly on both A10G + A100; vlm_prefix captures on A100+
         # only (per ADR 2026-04-24 Day-0 spike findings).
         cuda_required = self._providers[0] == "CUDAExecutionProvider" or (
-            isinstance(self._providers[0], tuple)
-            and self._providers[0][0] == "CUDAExecutionProvider"
+            isinstance(self._providers[0], tuple) and self._providers[0][0] == "CUDAExecutionProvider"
         )
 
         if cuda_graphs_enabled:
@@ -340,10 +330,8 @@ class Pi05DecomposedInference:
             logger.info(
                 "cuda-graphs enabled: vlm_prefix.captured=%s, expert_denoise.captured=%s "
                 "(embodiment=%s, model_id=%s)",
-                self._sess_prefix.captured,
-                self._sess_expert.captured,
-                cuda_graphs_embodiment,
-                cuda_graphs_model_id,
+                self._sess_prefix.captured, self._sess_expert.captured,
+                cuda_graphs_embodiment, cuda_graphs_model_id,
             )
         else:
             logger.info("loading vlm_prefix: %s", prefix_path)
@@ -380,7 +368,6 @@ class Pi05DecomposedInference:
         self._episode_cache = None
         if cache_level == "episode":
             from tether.runtime.episode_cache import EpisodeCache
-
             # Reuse the embodiment/model_id already threaded in for CUDA
             # graph metrics — same process, same labels — so the
             # tether_episode_cache_bytes_total gauge actually emits instead
@@ -447,16 +434,10 @@ class Pi05DecomposedInference:
                 )
             return self._predict_with_episode_cache(
                 episode_id=episode_id,
-                img_base=img_base,
-                img_wrist_l=img_wrist_l,
-                img_wrist_r=img_wrist_r,
-                mask_base=mask_base,
-                mask_wrist_l=mask_wrist_l,
-                mask_wrist_r=mask_wrist_r,
-                lang_tokens=lang_tokens,
-                lang_masks=lang_masks,
-                noise=noise,
-                state=state,
+                img_base=img_base, img_wrist_l=img_wrist_l, img_wrist_r=img_wrist_r,
+                mask_base=mask_base, mask_wrist_l=mask_wrist_l, mask_wrist_r=mask_wrist_r,
+                lang_tokens=lang_tokens, lang_masks=lang_masks,
+                noise=noise, state=state,
             )
 
         image_phashes = (
@@ -538,7 +519,6 @@ class Pi05DecomposedInference:
                 # so unit tests without the prometheus extra don't fail.
                 try:
                     from tether.observability.prometheus import inc_action_skip
-
                     inc_action_skip()
                 except Exception:  # noqa: BLE001
                     pass
@@ -595,7 +575,6 @@ class Pi05DecomposedInference:
         # overhead, passes gate 4 (≤20% median, ≤1.30x p99). See
         # 03_experiments/2026-04-30-per-step-overhead-modal-a100.md.
         import onnxruntime as ort
-
         n = self._num_steps
         dt = -1.0 / n
         x_t = noise.astype(np.float32, copy=False)
@@ -652,16 +631,10 @@ class Pi05DecomposedInference:
         self,
         *,
         episode_id: str,
-        img_base,
-        img_wrist_l,
-        img_wrist_r,
-        mask_base,
-        mask_wrist_l,
-        mask_wrist_r,
-        lang_tokens,
-        lang_masks,
-        noise,
-        state,
+        img_base, img_wrist_l, img_wrist_r,
+        mask_base, mask_wrist_l, mask_wrist_r,
+        lang_tokens, lang_masks,
+        noise, state,
     ) -> np.ndarray:
         """Episode-keyed cache path. Looks up (episode_id, lang_hash);
         on hit reuses cached past_kv + prefix_pad_masks (skips VLM).
@@ -675,14 +648,9 @@ class Pi05DecomposedInference:
         else:
             # Cache miss — run the VLM forward
             prefix_feed: dict[str, np.ndarray] = {
-                "img_base": img_base,
-                "img_wrist_l": img_wrist_l,
-                "img_wrist_r": img_wrist_r,
-                "mask_base": mask_base,
-                "mask_wrist_l": mask_wrist_l,
-                "mask_wrist_r": mask_wrist_r,
-                "lang_tokens": lang_tokens,
-                "lang_masks": lang_masks,
+                "img_base": img_base, "img_wrist_l": img_wrist_l, "img_wrist_r": img_wrist_r,
+                "mask_base": mask_base, "mask_wrist_l": mask_wrist_l, "mask_wrist_r": mask_wrist_r,
+                "lang_tokens": lang_tokens, "lang_masks": lang_masks,
             }
             prefix_feed = {k: v for k, v in prefix_feed.items() if k in self._prefix_input_names}
             prefix_out = self._sess_prefix.run(self._prefix_output_names, prefix_feed)
@@ -721,14 +689,9 @@ class Pi05DecomposedInference:
     def _get_or_run_prefix(
         self,
         *,
-        img_base,
-        img_wrist_l,
-        img_wrist_r,
-        mask_base,
-        mask_wrist_l,
-        mask_wrist_r,
-        lang_tokens,
-        lang_masks,
+        img_base, img_wrist_l, img_wrist_r,
+        mask_base, mask_wrist_l, mask_wrist_r,
+        lang_tokens, lang_masks,
         image_phashes: tuple[bytes, ...],
         lang_hash: bytes,
     ) -> tuple[list[np.ndarray], np.ndarray]:
@@ -821,7 +784,7 @@ class Pi05DecomposedInference:
         step_h = max(1, h // cls.PHASH_SIZE)
         step_w = max(1, w // cls.PHASH_SIZE)
         # Integer downsample — coarse but fast + dependency-free
-        small = gray[: step_h * cls.PHASH_SIZE, : step_w * cls.PHASH_SIZE]
+        small = gray[:step_h * cls.PHASH_SIZE, :step_w * cls.PHASH_SIZE]
         small = small.reshape(cls.PHASH_SIZE, step_h, cls.PHASH_SIZE, step_w).mean(axis=(1, 3))
         bits = small > small.mean()
         bits_flat = bits.flatten()

--- a/src/tether/runtime/pi05_decomposed_server.py
+++ b/src/tether/runtime/pi05_decomposed_server.py
@@ -21,6 +21,7 @@ The class exposes the same ``predict_action_chunk`` contract as
 ``Pi0OnnxServer.predict`` so downstream harnesses don't need to know
 which export pattern is active.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -39,12 +40,13 @@ logger = logging.getLogger(__name__)
 @dataclass
 class CacheEntry:
     """One VLM output we keep around for potential reuse."""
-    past_kv: list[np.ndarray]            # flat [k_0, v_0, ..., k_17, v_17]
+
+    past_kv: list[np.ndarray]  # flat [k_0, v_0, ..., k_17, v_17]
     prefix_pad_masks: np.ndarray
-    image_phashes: tuple[bytes, ...]     # per-camera perceptual hash
-    lang_hash: bytes                     # exact md5 of language tokens
-    timestamp: float                     # wall-clock time (for TTL-sec path)
-    step_index: int                      # predict_action_chunk call number (for step-count path)
+    image_phashes: tuple[bytes, ...]  # per-camera perceptual hash
+    lang_hash: bytes  # exact md5 of language tokens
+    timestamp: float  # wall-clock time (for TTL-sec path)
+    step_index: int  # predict_action_chunk call number (for step-count path)
 
 
 @dataclass
@@ -55,6 +57,7 @@ class ActionCacheEntry:
     across calls — but for a SnapFlow 1-NFE student at target_time=1
     the noise dependence is minimal, so reusing a cached chunk on a
     matching obs is effectively zero-cost."""
+
     image_phashes: tuple[bytes, ...]
     lang_hash: bytes
     state_signature: np.ndarray | None
@@ -66,6 +69,7 @@ class ActionCacheEntry:
 class CacheStats:
     """Cumulative cache metrics — exposed via get_stats() so callers
     can log hit rate alongside LIBERO task success."""
+
     hits: int = 0
     misses: int = 0
     evictions_ttl: int = 0
@@ -200,6 +204,7 @@ class Pi05DecomposedInference:
         self._call_index: int = 0  # monotonic call counter for step-count TTL
         self._action_cache: ActionCacheEntry | None = None
         from tether.runtime.temporal_vla_cache import TemporalVLAReusePolicy
+
         self._temporal_reuse_policy = TemporalVLAReusePolicy(
             phash_hamming_threshold=phash_hamming_threshold,
         )
@@ -209,6 +214,7 @@ class Pi05DecomposedInference:
         # existing behavior is unchanged unless --action-similarity-threshold
         # is set on the CLI.
         from tether.runtime.action_fast_path import ActionFastPath
+
         self._fast_path = ActionFastPath(
             threshold=float(action_similarity_threshold),
             max_skips=int(max_similar_skips),
@@ -227,6 +233,7 @@ class Pi05DecomposedInference:
         self._cuda_graphs_model_id = cuda_graphs_model_id
         if cuda_graphs_enabled:
             from tether.runtime.cuda_graphs import build_cuda_graph_providers
+
             if providers is not None:
                 logger.warning(
                     "cuda_graphs_enabled=True overrides user-provided providers=%s",
@@ -236,14 +243,14 @@ class Pi05DecomposedInference:
         else:
             self._providers = providers or ["CUDAExecutionProvider", "CPUExecutionProvider"]
 
+        from tether.export_config import load_tether_config
+
         cfg_path = self.export_dir / "tether_config.json"
-        if not cfg_path.exists():
-            raise FileNotFoundError(f"tether_config.json missing in {self.export_dir}")
-        self.config: dict[str, Any] = json.loads(cfg_path.read_text())
-        if self.config.get("export_kind") != "decomposed":
+        self.config = load_tether_config(cfg_path)
+        if self.config.get("export_kind") != "decomposed_onnx":
             raise ValueError(
                 f"{cfg_path} has export_kind={self.config.get('export_kind')!r}; "
-                "Pi05DecomposedInference requires 'decomposed'"
+                "Pi05DecomposedInference requires 'decomposed_onnx'"
             )
         self._past_kv_names: list[str] = self.config["decomposed"]["past_kv_tensor_names"]
         self._n_layers: int = self.config["decomposed"]["paligemma_layers"]
@@ -252,14 +259,13 @@ class Pi05DecomposedInference:
         # (x_t, t, past_kv) → v_t and we drive the Euler loop in Python.
         # When False (default), it's the baked-loop shape (noise → actions,
         # single call). Spec: features/03_export/per-step-expert-export.md.
-        self._per_step_expert: bool = bool(
-            self.config["decomposed"].get("per_step_expert", False)
-        )
-        self._num_steps: int = int(self.config.get("num_denoising_steps", 1))
+        self._per_step_expert: bool = bool(self.config["decomposed"].get("per_step_expert", False))
+        self._num_steps = int(self.config["num_denoising_steps"])
         if self._per_step_expert:
             logger.info(
                 "Pi05DecomposedInference: per-step expert path active "
-                "(num_steps=%d, Python Euler loop)", self._num_steps,
+                "(num_steps=%d, Python Euler loop)",
+                self._num_steps,
             )
 
         prefix_path = self.export_dir / self.config["decomposed"]["vlm_prefix_onnx"]
@@ -276,7 +282,8 @@ class Pi05DecomposedInference:
         # captures cleanly on both A10G + A100; vlm_prefix captures on A100+
         # only (per ADR 2026-04-24 Day-0 spike findings).
         cuda_required = self._providers[0] == "CUDAExecutionProvider" or (
-            isinstance(self._providers[0], tuple) and self._providers[0][0] == "CUDAExecutionProvider"
+            isinstance(self._providers[0], tuple)
+            and self._providers[0][0] == "CUDAExecutionProvider"
         )
 
         if cuda_graphs_enabled:
@@ -333,8 +340,10 @@ class Pi05DecomposedInference:
             logger.info(
                 "cuda-graphs enabled: vlm_prefix.captured=%s, expert_denoise.captured=%s "
                 "(embodiment=%s, model_id=%s)",
-                self._sess_prefix.captured, self._sess_expert.captured,
-                cuda_graphs_embodiment, cuda_graphs_model_id,
+                self._sess_prefix.captured,
+                self._sess_expert.captured,
+                cuda_graphs_embodiment,
+                cuda_graphs_model_id,
             )
         else:
             logger.info("loading vlm_prefix: %s", prefix_path)
@@ -371,6 +380,7 @@ class Pi05DecomposedInference:
         self._episode_cache = None
         if cache_level == "episode":
             from tether.runtime.episode_cache import EpisodeCache
+
             # Reuse the embodiment/model_id already threaded in for CUDA
             # graph metrics — same process, same labels — so the
             # tether_episode_cache_bytes_total gauge actually emits instead
@@ -437,10 +447,16 @@ class Pi05DecomposedInference:
                 )
             return self._predict_with_episode_cache(
                 episode_id=episode_id,
-                img_base=img_base, img_wrist_l=img_wrist_l, img_wrist_r=img_wrist_r,
-                mask_base=mask_base, mask_wrist_l=mask_wrist_l, mask_wrist_r=mask_wrist_r,
-                lang_tokens=lang_tokens, lang_masks=lang_masks,
-                noise=noise, state=state,
+                img_base=img_base,
+                img_wrist_l=img_wrist_l,
+                img_wrist_r=img_wrist_r,
+                mask_base=mask_base,
+                mask_wrist_l=mask_wrist_l,
+                mask_wrist_r=mask_wrist_r,
+                lang_tokens=lang_tokens,
+                lang_masks=lang_masks,
+                noise=noise,
+                state=state,
             )
 
         image_phashes = (
@@ -522,6 +538,7 @@ class Pi05DecomposedInference:
                 # so unit tests without the prometheus extra don't fail.
                 try:
                     from tether.observability.prometheus import inc_action_skip
+
                     inc_action_skip()
                 except Exception:  # noqa: BLE001
                     pass
@@ -578,6 +595,7 @@ class Pi05DecomposedInference:
         # overhead, passes gate 4 (≤20% median, ≤1.30x p99). See
         # 03_experiments/2026-04-30-per-step-overhead-modal-a100.md.
         import onnxruntime as ort
+
         n = self._num_steps
         dt = -1.0 / n
         x_t = noise.astype(np.float32, copy=False)
@@ -634,10 +652,16 @@ class Pi05DecomposedInference:
         self,
         *,
         episode_id: str,
-        img_base, img_wrist_l, img_wrist_r,
-        mask_base, mask_wrist_l, mask_wrist_r,
-        lang_tokens, lang_masks,
-        noise, state,
+        img_base,
+        img_wrist_l,
+        img_wrist_r,
+        mask_base,
+        mask_wrist_l,
+        mask_wrist_r,
+        lang_tokens,
+        lang_masks,
+        noise,
+        state,
     ) -> np.ndarray:
         """Episode-keyed cache path. Looks up (episode_id, lang_hash);
         on hit reuses cached past_kv + prefix_pad_masks (skips VLM).
@@ -651,9 +675,14 @@ class Pi05DecomposedInference:
         else:
             # Cache miss — run the VLM forward
             prefix_feed: dict[str, np.ndarray] = {
-                "img_base": img_base, "img_wrist_l": img_wrist_l, "img_wrist_r": img_wrist_r,
-                "mask_base": mask_base, "mask_wrist_l": mask_wrist_l, "mask_wrist_r": mask_wrist_r,
-                "lang_tokens": lang_tokens, "lang_masks": lang_masks,
+                "img_base": img_base,
+                "img_wrist_l": img_wrist_l,
+                "img_wrist_r": img_wrist_r,
+                "mask_base": mask_base,
+                "mask_wrist_l": mask_wrist_l,
+                "mask_wrist_r": mask_wrist_r,
+                "lang_tokens": lang_tokens,
+                "lang_masks": lang_masks,
             }
             prefix_feed = {k: v for k, v in prefix_feed.items() if k in self._prefix_input_names}
             prefix_out = self._sess_prefix.run(self._prefix_output_names, prefix_feed)
@@ -692,9 +721,14 @@ class Pi05DecomposedInference:
     def _get_or_run_prefix(
         self,
         *,
-        img_base, img_wrist_l, img_wrist_r,
-        mask_base, mask_wrist_l, mask_wrist_r,
-        lang_tokens, lang_masks,
+        img_base,
+        img_wrist_l,
+        img_wrist_r,
+        mask_base,
+        mask_wrist_l,
+        mask_wrist_r,
+        lang_tokens,
+        lang_masks,
         image_phashes: tuple[bytes, ...],
         lang_hash: bytes,
     ) -> tuple[list[np.ndarray], np.ndarray]:
@@ -787,7 +821,7 @@ class Pi05DecomposedInference:
         step_h = max(1, h // cls.PHASH_SIZE)
         step_w = max(1, w // cls.PHASH_SIZE)
         # Integer downsample — coarse but fast + dependency-free
-        small = gray[:step_h * cls.PHASH_SIZE, :step_w * cls.PHASH_SIZE]
+        small = gray[: step_h * cls.PHASH_SIZE, : step_w * cls.PHASH_SIZE]
         small = small.reshape(cls.PHASH_SIZE, step_h, cls.PHASH_SIZE, step_w).mean(axis=(1, 3))
         bits = small > small.mean()
         bits_flat = bits.flatten()

--- a/src/tether/runtime/server.py
+++ b/src/tether/runtime/server.py
@@ -832,10 +832,11 @@ class TetherServer:
         self._replan_threshold: float = 0.5
 
     def _load_config(self) -> dict[str, Any]:
-        config_path = self.export_dir / "tether_config.json"
-        if config_path.exists():
-            return json.loads(config_path.read_text())
-        return {}
+        from tether.export_config import load_tether_config, require_supported_pipeline
+
+        config = load_tether_config(self.export_dir)
+        require_supported_pipeline(config, set(), "TetherServer")
+        return config
 
     def configure_replan(
         self,
@@ -966,7 +967,7 @@ class TetherServer:
         start = time.perf_counter()
 
         expert_meta = self.config.get("expert", {})
-        self.action_dim = self.config.get("action_dim", expert_meta.get("action_dim", 32))
+        self.action_dim = int(self.config["action_dim"])
         self.chunk_size = self.config.get(
             "action_chunk_size",
             self.config.get("chunk_size", 50),
@@ -2003,29 +2004,36 @@ def create_app(
 
     # Dispatch order:
     #   1. TETHER_NATIVE=1 — SmolVLANativeServer (PyTorch native path)
-    #   2. tether_config.json export_kind == "monolithic" → model-specific
+    #   2. tether_config.json export_kind == "monolithic_onnx" → model-specific
     #      monolithic server (Pi0OnnxServer / SmolVLAOnnxServer). This is
     #      the cos=1.0 verified production path as of 2026-04-18.
     #   3. Default: TetherServer (legacy decomposed path).
     _config_path = Path(export_dir) / "tether_config.json"
-    _monolithic_cfg = {}
-    if _config_path.exists():
-        try:
-            _monolithic_cfg = json.loads(_config_path.read_text())
-        except Exception:
-            _monolithic_cfg = {}
+    from tether.export_config import decomposed_layout, load_tether_config
+
+    _monolithic_cfg = load_tether_config(_config_path)
+
+    def _decomposed_layout(config: dict[str, Any]) -> str:
+        return decomposed_layout(config)
+
+    def _require_native_smolvla(config: dict[str, Any], label: str) -> None:
+        if (
+            config.get("model_type") != "smolvla"
+            or config.get("export_kind") != "decomposed_onnx"
+            or _decomposed_layout(config) not in {"expert_stack", "smolvla_full_bundle"}
+        ):
+            raise ValueError(
+                f"TETHER_NATIVE=1 requires a SmolVLA expert_stack/full-bundle decomposed export; "
+                f"{label} declares model_type={config.get('model_type')!r}, "
+                f"export_kind={config.get('export_kind')!r}"
+            )
 
     def _build_shadow_server(shadow_export_dir: str | Path) -> Any:
         shadow_export_dir = Path(shadow_export_dir)
-        shadow_cfg_path = shadow_export_dir / "tether_config.json"
-        shadow_cfg: dict[str, Any] = {}
-        if shadow_cfg_path.exists():
-            try:
-                shadow_cfg = json.loads(shadow_cfg_path.read_text())
-            except Exception:
-                shadow_cfg = {}
+        shadow_cfg = load_tether_config(shadow_export_dir)
 
         if _os.environ.get("TETHER_NATIVE", "0") == "1":
+            _require_native_smolvla(shadow_cfg, "shadow export")
             from tether.runtime.smolvla_native import SmolVLANativeServer
             shadow_srv = SmolVLANativeServer(
                 shadow_export_dir,
@@ -2039,7 +2047,10 @@ def create_app(
                 max_batch=max_batch,
                 batch_timeout_ms=batch_timeout_ms,
             )
-        elif shadow_cfg.get("export_kind") == "decomposed":
+        elif (
+            shadow_cfg.get("export_kind") == "decomposed_onnx"
+            and _decomposed_layout(shadow_cfg) == "pi05_split"
+        ):
             from tether.runtime.decomposed_server import Pi05DecomposedServer
             shadow_srv = Pi05DecomposedServer(
                 shadow_export_dir,
@@ -2055,8 +2066,26 @@ def create_app(
                 action_similarity_threshold=action_similarity_threshold,
                 max_similar_skips=max_similar_skips,
             )
-        elif shadow_cfg.get("export_kind") == "monolithic":
-            model_type = shadow_cfg.get("model_type", "smolvla")
+        elif (
+            shadow_cfg.get("export_kind") == "decomposed_onnx"
+            and _decomposed_layout(shadow_cfg) in {"expert_stack", "smolvla_full_bundle"}
+        ):
+            shadow_srv = TetherServer(
+                shadow_export_dir,
+                device=device,
+                providers=providers,
+                strict_providers=strict_providers,
+                safety_config=safety_config,
+                adaptive_steps=adaptive_steps,
+                cloud_fallback_url=cloud_fallback_url,
+                deadline_ms=deadline_ms,
+                max_batch=max_batch,
+                batch_timeout_ms=batch_timeout_ms,
+                inference_executor_workers=inference_executor_workers,
+                inference_executor_queue=inference_executor_queue,
+            )
+        elif shadow_cfg.get("export_kind") == "monolithic_onnx":
+            model_type = shadow_cfg["model_type"]
             if model_type == "pi0":
                 from tether.runtime.pi0_onnx_server import Pi0OnnxServer
                 shadow_srv = Pi0OnnxServer(
@@ -2104,25 +2133,15 @@ def create_app(
                     f"Shadow runtime for model_type={model_type!r} is not supported"
                 )
         else:
-            shadow_srv = TetherServer(
-                shadow_export_dir,
-                device=device,
-                providers=providers,
-                strict_providers=strict_providers,
-                safety_config=safety_config,
-                adaptive_steps=adaptive_steps,
-                cloud_fallback_url=cloud_fallback_url,
-                deadline_ms=deadline_ms,
-                max_batch=max_batch,
-                batch_timeout_ms=batch_timeout_ms,
-                inference_executor_workers=inference_executor_workers,
-                inference_executor_queue=inference_executor_queue,
+            raise ValueError(
+                f"Shadow serving does not support export_kind={shadow_cfg.get('export_kind')!r}"
             )
         shadow_srv.embodiment_config = embodiment_config
         shadow_srv._inference_policy_slot = "shadow"  # type: ignore[attr-defined]
         return shadow_srv
 
     if _os.environ.get("TETHER_NATIVE", "0") == "1":
+        _require_native_smolvla(_monolithic_cfg, "primary export")
         from tether.runtime.smolvla_native import SmolVLANativeServer
         server = SmolVLANativeServer(
             export_dir,
@@ -2136,7 +2155,10 @@ def create_app(
             max_batch=max_batch,
             batch_timeout_ms=batch_timeout_ms,
         )
-    elif _monolithic_cfg.get("export_kind") == "decomposed":
+    elif (
+        _monolithic_cfg.get("export_kind") == "decomposed_onnx"
+        and _decomposed_layout(_monolithic_cfg) == "pi05_split"
+    ):
         # Per ADR 2026-04-25-decomposed-dispatch-via-tether-serve: the
         # decomposed export (vlm_prefix.onnx + expert_denoise.onnx) needs
         # the wrapper around Pi05DecomposedInference, NOT the legacy
@@ -2158,8 +2180,26 @@ def create_app(
             action_similarity_threshold=action_similarity_threshold,
             max_similar_skips=max_similar_skips,
         )
-    elif _monolithic_cfg.get("export_kind") == "monolithic":
-        _model_type = _monolithic_cfg.get("model_type", "smolvla")
+    elif (
+        _monolithic_cfg.get("export_kind") == "decomposed_onnx"
+        and _decomposed_layout(_monolithic_cfg) in {"expert_stack", "smolvla_full_bundle"}
+    ):
+        server = TetherServer(
+            export_dir,
+            device=device,
+            providers=providers,
+            strict_providers=strict_providers,
+            safety_config=safety_config,
+            adaptive_steps=adaptive_steps,
+            cloud_fallback_url=cloud_fallback_url,
+            deadline_ms=deadline_ms,
+            max_batch=max_batch,
+            batch_timeout_ms=batch_timeout_ms,
+            inference_executor_workers=inference_executor_workers,
+            inference_executor_queue=inference_executor_queue,
+        )
+    elif _monolithic_cfg.get("export_kind") == "monolithic_onnx":
+        _model_type = _monolithic_cfg["model_type"]
         if _model_type == "pi0":
             from tether.runtime.pi0_onnx_server import Pi0OnnxServer
             server = Pi0OnnxServer(
@@ -2208,19 +2248,8 @@ def create_app(
                 f"supported. v0.2 covers smolvla, pi0, pi05, and gr00t."
             )
     else:
-        server = TetherServer(
-            export_dir,
-            device=device,
-            providers=providers,
-            strict_providers=strict_providers,
-            safety_config=safety_config,
-            adaptive_steps=adaptive_steps,
-            cloud_fallback_url=cloud_fallback_url,
-            deadline_ms=deadline_ms,
-            max_batch=max_batch,
-            batch_timeout_ms=batch_timeout_ms,
-            inference_executor_workers=inference_executor_workers,
-            inference_executor_queue=inference_executor_queue,
+        raise ValueError(
+            f"Serving does not support export_kind={_monolithic_cfg.get('export_kind')!r}"
         )
 
     # Paid mode is explicit and is validated before the app/lifespan exists.

--- a/src/tether/smoke.py
+++ b/src/tether/smoke.py
@@ -140,12 +140,11 @@ def create_smoke_export(export_dir: str | Path) -> Path:
         unk_token="[UNK]",
         pad_token="[PAD]",
     )
-    fast_tokenizer.save_pretrained(tokenizer_dir)
+    tokenizer_files = fast_tokenizer.save_pretrained(tokenizer_dir)
 
     config = {
+        "model_id": "tether/smoke-smolvla",
         "model_type": "smolvla",
-        "export_kind": "monolithic",
-        "num_denoising_steps": 1,
         "chunk_size": 50,
         "action_chunk_size": 50,
         "action_dim": 32,
@@ -157,7 +156,27 @@ def create_smoke_export(export_dir: str | Path) -> Path:
         "created_by": "tether smoke",
         "created_at": _now_iso(),
     }
-    (export_path / "tether_config.json").write_text(json.dumps(config, indent=2) + "\n")
+    from tether.export_config import build_producer_config, write_tether_config
+
+    optional_artifacts = [
+        (
+            Path(path).resolve().relative_to(export_path.resolve()).as_posix(),
+            "tokenizer",
+        )
+        for path in tokenizer_files
+    ]
+    canonical = build_producer_config(
+        export_path,
+        producer="monolithic",
+        model_id="tether/smoke-smolvla",
+        model_type="smolvla",
+        action_dim=32,
+        num_denoising_steps=1,
+        opset=17,
+        optional_artifacts=optional_artifacts,
+        metadata=config,
+    )
+    write_tether_config(export_path, canonical)
     return export_path
 
 

--- a/src/tether/validate_roundtrip.py
+++ b/src/tether/validate_roundtrip.py
@@ -33,7 +33,6 @@ into the following process exit codes:
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -41,27 +40,19 @@ from typing import Any
 import numpy as np
 import torch
 
-from tether.checkpoint import detect_model_type, load_checkpoint
 from tether.fixtures.vla_fixtures import load_fixtures
+from tether.export_config import load_tether_config, require_supported_export_kind
 from tether.validate import ValidationResult, validate_outputs
 
 # Backends from Issues 4/5 — required at import time now.
 from tether._pytorch_backend import load_pytorch_backend
 from tether._onnx_backend import load_onnx_backend
 
-# Per-model action_dim fallback when tether_config.json doesn't specify it.
-_ACTION_DIM_FALLBACK: dict[str, int] = {
-    "smolvla": 6,
-    "pi0": 14,
-    "gr00t": 64,
-}
-
 logger = logging.getLogger(__name__)
 
 SUPPORTED_MODEL_TYPES: tuple[str, ...] = ("smolvla", "pi0", "gr00t")
 UNSUPPORTED_MODEL_MESSAGE = (
-    "tether validate v1 supports smolvla, pi0, gr00t. "
-    "For pi0.5 / openvla see roadmap."
+    "tether validate v1 supports smolvla, pi0, gr00t. For pi0.5 / openvla see roadmap."
 )
 
 
@@ -119,53 +110,22 @@ class ValidateRoundTrip:
         self.device: str = device
 
         if self.num_test_cases < 1:
-            raise ValueError(
-                f"num_test_cases must be >= 1, got {self.num_test_cases}"
-            )
+            raise ValueError(f"num_test_cases must be >= 1, got {self.num_test_cases}")
         if self.threshold <= 0:
-            raise ValueError(
-                f"threshold must be > 0, got {self.threshold}"
-            )
+            raise ValueError(f"threshold must be > 0, got {self.threshold}")
 
         if not self.export_dir.exists():
-            raise FileNotFoundError(
-                f"Export directory does not exist: {self.export_dir}"
-            )
+            raise FileNotFoundError(f"Export directory does not exist: {self.export_dir}")
         if not self.export_dir.is_dir():
-            raise ValueError(
-                f"Export path is not a directory: {self.export_dir}"
-            )
+            raise ValueError(f"Export path is not a directory: {self.export_dir}")
 
-        config_path = self.export_dir / "tether_config.json"
-        if not config_path.exists():
-            raise ValueError(
-                f"Missing tether_config.json in export dir: {self.export_dir}"
-            )
-        try:
-            self.config: dict[str, Any] = json.loads(config_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"Malformed tether_config.json at {config_path}: {exc}"
-            ) from exc
-
-        num_steps = self.config.get("num_denoising_steps", 10)
-        if not isinstance(num_steps, int) or num_steps < 1:
-            raise ValueError(
-                f"num_denoising_steps in tether_config.json must be a positive "
-                f"integer, got {num_steps!r}"
-            )
-
-        model_type = self.config.get("model_type")
-        if not model_type:
-            logger.debug("model_type missing from tether_config.json; detecting from checkpoint")
-            ref_id = self.model_id or self.config.get("model_id")
-            if ref_id is None:
-                raise ValueError(
-                    "Cannot detect model_type: tether_config.json has no "
-                    "model_type or model_id field, and --model was not passed."
-                )
-            state_dict, _ = load_checkpoint(ref_id, device="cpu")
-            model_type = detect_model_type(state_dict)
+        self.config = load_tether_config(self.export_dir)
+        require_supported_export_kind(
+            self.config,
+            {"monolithic_onnx", "decomposed_onnx"},
+            "tether validate",
+        )
+        model_type = self.config["model_type"]
 
         if model_type not in SUPPORTED_MODEL_TYPES:
             raise ValueError(UNSUPPORTED_MODEL_MESSAGE)
@@ -224,14 +184,9 @@ class ValidateRoundTrip:
     def _generate_initial_noise(self, rng: torch.Generator) -> np.ndarray:
         """Generate the initial-noise tensor shared by both backends."""
         chunk_size = int(
-            self.config.get("action_chunk_size")
-            or self.config.get("chunk_size")
-            or 50
+            self.config.get("action_chunk_size") or self.config.get("chunk_size") or 50
         )
-        action_dim = int(
-            self.config.get("action_dim")
-            or _ACTION_DIM_FALLBACK.get(self.model_type, 6)
-        )
+        action_dim = int(self.config["action_dim"])
         noise = torch.randn((chunk_size, action_dim), generator=rng).numpy().astype(np.float32)
         return noise
 
@@ -241,9 +196,7 @@ class ValidateRoundTrip:
         onnx_out: np.ndarray,
     ) -> dict[str, Any]:
         """Compare a single fixture's PyTorch and ONNX outputs."""
-        result = validate_outputs(
-            pytorch_out, onnx_out, threshold=self.threshold, name="roundtrip"
-        )
+        result = validate_outputs(pytorch_out, onnx_out, threshold=self.threshold, name="roundtrip")
         return result.to_dict()
 
     def _aggregate(
@@ -255,7 +208,9 @@ class ValidateRoundTrip:
             max_abs = max(float(r["max_abs_diff"]) for r in per_fixture_results)
         else:
             max_abs = 0.0
-        passed = all(bool(r["passed"]) for r in per_fixture_results) if per_fixture_results else False
+        passed = (
+            all(bool(r["passed"]) for r in per_fixture_results) if per_fixture_results else False
+        )
 
         return {
             "model_type": self.model_type,

--- a/src/tether/validate_roundtrip.py
+++ b/src/tether/validate_roundtrip.py
@@ -41,7 +41,13 @@ import numpy as np
 import torch
 
 from tether.fixtures.vla_fixtures import load_fixtures
-from tether.export_config import load_tether_config, require_supported_export_kind
+from tether.export_config import (
+    UnsupportedExportPipelineError,
+    decomposed_layout,
+    load_tether_config,
+    require_supported_export_kind,
+    require_supported_pipeline,
+)
 from tether.validate import ValidationResult, validate_outputs
 
 # Backends from Issues 4/5 — required at import time now.
@@ -52,7 +58,8 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_MODEL_TYPES: tuple[str, ...] = ("smolvla", "pi0", "gr00t")
 UNSUPPORTED_MODEL_MESSAGE = (
-    "tether validate v1 supports smolvla, pi0, gr00t. For pi0.5 / openvla see roadmap."
+    "tether validate v1 supports smolvla, pi0, gr00t. "
+    "For pi0.5 / openvla see roadmap."
 )
 
 
@@ -110,21 +117,35 @@ class ValidateRoundTrip:
         self.device: str = device
 
         if self.num_test_cases < 1:
-            raise ValueError(f"num_test_cases must be >= 1, got {self.num_test_cases}")
+            raise ValueError(
+                f"num_test_cases must be >= 1, got {self.num_test_cases}"
+            )
         if self.threshold <= 0:
-            raise ValueError(f"threshold must be > 0, got {self.threshold}")
+            raise ValueError(
+                f"threshold must be > 0, got {self.threshold}"
+            )
 
         if not self.export_dir.exists():
-            raise FileNotFoundError(f"Export directory does not exist: {self.export_dir}")
+            raise FileNotFoundError(
+                f"Export directory does not exist: {self.export_dir}"
+            )
         if not self.export_dir.is_dir():
-            raise ValueError(f"Export path is not a directory: {self.export_dir}")
+            raise ValueError(
+                f"Export path is not a directory: {self.export_dir}"
+            )
 
         self.config = load_tether_config(self.export_dir)
         require_supported_export_kind(
             self.config,
-            {"monolithic_onnx", "decomposed_onnx"},
+            {"decomposed_onnx"},
             "tether validate",
         )
+        require_supported_pipeline(self.config, set(), "tether validate")
+        layout = decomposed_layout(self.config)
+        if layout not in {"expert_stack", "smolvla_full_bundle"}:
+            raise UnsupportedExportPipelineError(
+                f"tether validate supports only the expert_stack family, got {layout!r}"
+            )
         model_type = self.config["model_type"]
 
         if model_type not in SUPPORTED_MODEL_TYPES:
@@ -184,7 +205,9 @@ class ValidateRoundTrip:
     def _generate_initial_noise(self, rng: torch.Generator) -> np.ndarray:
         """Generate the initial-noise tensor shared by both backends."""
         chunk_size = int(
-            self.config.get("action_chunk_size") or self.config.get("chunk_size") or 50
+            self.config.get("action_chunk_size")
+            or self.config.get("chunk_size")
+            or 50
         )
         action_dim = int(self.config["action_dim"])
         noise = torch.randn((chunk_size, action_dim), generator=rng).numpy().astype(np.float32)
@@ -196,7 +219,9 @@ class ValidateRoundTrip:
         onnx_out: np.ndarray,
     ) -> dict[str, Any]:
         """Compare a single fixture's PyTorch and ONNX outputs."""
-        result = validate_outputs(pytorch_out, onnx_out, threshold=self.threshold, name="roundtrip")
+        result = validate_outputs(
+            pytorch_out, onnx_out, threshold=self.threshold, name="roundtrip"
+        )
         return result.to_dict()
 
     def _aggregate(
@@ -208,9 +233,7 @@ class ValidateRoundTrip:
             max_abs = max(float(r["max_abs_diff"]) for r in per_fixture_results)
         else:
             max_abs = 0.0
-        passed = (
-            all(bool(r["passed"]) for r in per_fixture_results) if per_fixture_results else False
-        )
+        passed = all(bool(r["passed"]) for r in per_fixture_results) if per_fixture_results else False
 
         return {
             "model_type": self.model_type,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tether test support package."""

--- a/tests/export_config_factory.py
+++ b/tests/export_config_factory.py
@@ -1,0 +1,74 @@
+"""Small canonical export-config factory shared by runtime unit tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def write_test_onnx(path: Path, *, action_dim: int = 7) -> Path:
+    """Write a tiny valid ONNX identity graph for artifact-inspection tests."""
+    import onnx
+
+    source = onnx.helper.make_tensor_value_info(
+        "input", onnx.TensorProto.FLOAT, ["batch", action_dim]
+    )
+    target = onnx.helper.make_tensor_value_info(
+        "output", onnx.TensorProto.FLOAT, ["batch", action_dim]
+    )
+    graph = onnx.helper.make_graph(
+        [onnx.helper.make_node("Identity", ["input"], ["output"])],
+        path.stem,
+        [source],
+        [target],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[onnx.helper.make_opsetid("", 19)],
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    onnx.save(model, path)
+    return path
+
+
+def write_test_export_config(
+    root: Path,
+    *,
+    model_type: str = "smolvla",
+    export_kind: str = "monolithic_onnx",
+    action_dim: int = 32,
+    num_denoising_steps: int = 10,
+    artifacts: list[str] | None = None,
+    **extras: Any,
+) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    if artifacts is None:
+        artifacts = ["model.onnx"]
+    for relative in artifacts:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            path.write_bytes(b"test artifact")
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "model_id": f"test/{model_type}",
+        "model_type": model_type,
+        "action_dim": action_dim,
+        "num_denoising_steps": num_denoising_steps,
+        "opset": 19,
+        "export_kind": export_kind,
+        "artifacts": [{"path": path, "role": "model"} for path in artifacts],
+        "io_contract": {
+            "inputs": [
+                {"name": "input", "dtype": "float32", "shape": [1, 50, action_dim]}
+            ],
+            "outputs": [
+                {"name": "actions", "dtype": "float32", "shape": [1, 50, action_dim]}
+            ],
+        },
+    }
+    payload.update(extras)
+    target = root / "tether_config.json"
+    target.write_text(json.dumps(payload))
+    return target

--- a/tests/test_a2c2_serve_integration.py
+++ b/tests/test_a2c2_serve_integration.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import base64
 import io
 import inspect
-import json
 import logging
 from pathlib import Path
 import sys
@@ -21,6 +20,7 @@ import numpy as np
 import pytest
 
 from tether.kernels.a2c2_correction import A2C2Config, A2C2Head
+from tests.export_config_factory import write_test_export_config
 
 
 def _stub_ort_session(input_names: list[str], output_shape=(1, 50, 32)):
@@ -36,33 +36,31 @@ def _stub_ort_session(input_names: list[str], output_shape=(1, 50, 32)):
 def _make_export_dir(tmp_path: Path) -> Path:
     export_dir = tmp_path / "export"
     export_dir.mkdir()
-    (export_dir / "model.onnx").write_bytes(b"stub")
-    (export_dir / "tether_config.json").write_text(json.dumps({
-        "model_type": "smolvla",
-        "export_kind": "monolithic",
-        "num_denoising_steps": 10,
-        "chunk_size": 50,
-        "action_chunk_size": 50,
-        "action_dim": 32,
-        "max_state_dim": 32,
-    }))
+    write_test_export_config(
+        export_dir,
+        model_type="smolvla",
+        chunk_size=50,
+        action_chunk_size=50,
+        max_state_dim=32,
+    )
     return export_dir
 
 
 def _make_decomposed_export_dir(tmp_path: Path) -> Path:
     export_dir = tmp_path / "decomposed_export"
     export_dir.mkdir()
-    (export_dir / "tether_config.json").write_text(json.dumps({
-        "model_type": "pi05_decomposed_student",
-        "export_kind": "decomposed",
-        "chunk_size": 50,
-        "action_dim": 32,
-        "decomposed": {
+    write_test_export_config(
+        export_dir,
+        model_type="pi05_decomposed_student",
+        export_kind="decomposed_onnx",
+        artifacts=["vlm_prefix.onnx", "expert_denoise.onnx"],
+        chunk_size=50,
+        decomposed={
             "vlm_prefix_onnx": "vlm_prefix.onnx",
             "expert_denoise_onnx": "expert_denoise.onnx",
             "max_action_dim": 32,
         },
-    }))
+    )
     return export_dir
 
 

--- a/tests/test_api_key_auth.py
+++ b/tests/test_api_key_auth.py
@@ -11,27 +11,21 @@ build the app without a real export directory on disk.
 """
 from __future__ import annotations
 
-import json
-from contextlib import asynccontextmanager
 
 import pytest
+
+from tests.export_config_factory import write_test_export_config
 
 
 @pytest.fixture
 def minimal_export_dir(tmp_path):
     """Minimal tether_config.json so the server can at least instantiate."""
-    cfg = {
-        "model_id": "lerobot/smolvla_base",
-        "model_type": "smolvla",
-        "target": "desktop",
-        "action_chunk_size": 50,
-        "action_dim": 32,
-        "expert": {"expert_hidden": 720, "action_dim": 32, "num_layers": 16},
-    }
-    (tmp_path / "tether_config.json").write_text(json.dumps(cfg))
-    # Touch an "onnx" file so the CLI path wouldn't fail sanity checks —
-    # we're not testing the CLI here, but some create_app code paths peek.
-    (tmp_path / "model.onnx").write_bytes(b"\x00")
+    write_test_export_config(
+        tmp_path,
+        model_type="smolvla",
+        action_chunk_size=50,
+        expert={"expert_hidden": 720, "action_dim": 32, "num_layers": 16},
+    )
     return tmp_path
 
 

--- a/tests/test_check_cuda_graphs.py
+++ b/tests/test_check_cuda_graphs.py
@@ -3,15 +3,12 @@
 Covers the skip / pass / warn / fail branches of the check without
 requiring a real GPU — all ORT session construction + capture is mocked.
 """
-
 from __future__ import annotations
 
 import json
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from tether.diagnostics.check_cuda_graphs import _run as check_run
 
@@ -72,18 +69,37 @@ def test_skip_when_export_is_monolithic(tmp_path):
     assert "decomposed" in result.expected.lower()
 
 
+def test_invalid_config_returns_identified_failure(tmp_path):
+    (tmp_path / "tether_config.json").write_text("{}")
+
+    result = check_run(model_path=str(tmp_path), embodiment_name="franka", rtc=False)
+
+    assert result.check_id == "cuda_graphs"
+    assert result.status == "fail"
+    assert result.actual
+
+
+def test_skip_is_explicit_for_expert_stack_layout(tmp_path):
+    config = _decomposed_config()
+    config["artifacts"] = [{"path": "expert_stack.onnx", "role": "model"}]
+    (tmp_path / "expert_stack.onnx").write_bytes(b"\x00")
+    _write_export(tmp_path, config)
+
+    result = check_run(model_path=str(tmp_path), embodiment_name="franka", rtc=False)
+
+    assert result.status == "skip"
+    assert "pi05 split" in result.expected
+    assert "expert_stack" in result.actual
+
+
 def test_skip_when_onnxruntime_not_importable(tmp_path):
     _write_export(tmp_path, _decomposed_config())
 
     # Simulate missing onnxruntime by intercepting the import inside the check
-    import tether.diagnostics.check_cuda_graphs as mod
-
     # Monkey-patch ort import at the check module level by stashing a raising
     # import into sys.modules
     orig_ort = sys.modules.pop("onnxruntime", None)
     try:
-        import importlib
-
         # Insert a dummy that raises ImportError on attribute access
         fake = MagicMock()
         fake.get_available_providers = MagicMock(side_effect=ImportError("mock no ort"))
@@ -113,12 +129,10 @@ def _patched_ort_with_providers(providers: list[str]):
     mock_input.name = "img_base"
     mock_input.shape = [1, 3, 224, 224]
     mock_input.type = "tensor(float)"
-    fake.InferenceSession = MagicMock(
-        return_value=MagicMock(
-            get_inputs=MagicMock(return_value=[mock_input]),
-            run=MagicMock(return_value=[[]]),
-        )
-    )
+    fake.InferenceSession = MagicMock(return_value=MagicMock(
+        get_inputs=MagicMock(return_value=[mock_input]),
+        run=MagicMock(return_value=[[]]),
+    ))
     return fake
 
 
@@ -126,14 +140,7 @@ def test_pass_when_both_sessions_capture(tmp_path):
     _write_export(tmp_path, _decomposed_config())
 
     # Mock try_capture_or_fall_back to return CudaGraphWrapper (captured=True) for both
-    with patch.dict(
-        sys.modules,
-        {
-            "onnxruntime": _patched_ort_with_providers(
-                ["CUDAExecutionProvider", "CPUExecutionProvider"]
-            )
-        },
-    ):
+    with patch.dict(sys.modules, {"onnxruntime": _patched_ort_with_providers(["CUDAExecutionProvider", "CPUExecutionProvider"])}):
         with patch("tether.runtime.cuda_graphs.try_capture_or_fall_back") as mock_try:
             mock_wrapper = MagicMock()
             mock_wrapper.captured = True
@@ -147,14 +154,7 @@ def test_pass_when_both_sessions_capture(tmp_path):
 def test_warn_when_only_expert_captures(tmp_path):
     _write_export(tmp_path, _decomposed_config())
 
-    with patch.dict(
-        sys.modules,
-        {
-            "onnxruntime": _patched_ort_with_providers(
-                ["CUDAExecutionProvider", "CPUExecutionProvider"]
-            )
-        },
-    ):
+    with patch.dict(sys.modules, {"onnxruntime": _patched_ort_with_providers(["CUDAExecutionProvider", "CPUExecutionProvider"])}):
         with patch("tether.runtime.cuda_graphs.try_capture_or_fall_back") as mock_try:
             # First call (vlm_prefix): eager fallback (captured=False)
             # Second call (expert_denoise): captured=True
@@ -174,14 +174,7 @@ def test_warn_when_only_expert_captures(tmp_path):
 def test_fail_when_neither_captures(tmp_path):
     _write_export(tmp_path, _decomposed_config())
 
-    with patch.dict(
-        sys.modules,
-        {
-            "onnxruntime": _patched_ort_with_providers(
-                ["CUDAExecutionProvider", "CPUExecutionProvider"]
-            )
-        },
-    ):
+    with patch.dict(sys.modules, {"onnxruntime": _patched_ort_with_providers(["CUDAExecutionProvider", "CPUExecutionProvider"])}):
         with patch("tether.runtime.cuda_graphs.try_capture_or_fall_back") as mock_try:
             prefix_wrapper = MagicMock()
             prefix_wrapper.captured = False

--- a/tests/test_check_cuda_graphs.py
+++ b/tests/test_check_cuda_graphs.py
@@ -3,6 +3,7 @@
 Covers the skip / pass / warn / fail branches of the check without
 requiring a real GPU — all ORT session construction + capture is mocked.
 """
+
 from __future__ import annotations
 
 import json
@@ -17,7 +18,21 @@ from tether.diagnostics.check_cuda_graphs import _run as check_run
 
 def _decomposed_config() -> dict:
     return {
-        "export_kind": "decomposed",
+        "schema_version": 1,
+        "model_id": "test/pi05",
+        "model_type": "pi05_decomposed",
+        "action_dim": 7,
+        "num_denoising_steps": 10,
+        "opset": 19,
+        "export_kind": "decomposed_onnx",
+        "artifacts": [
+            {"path": "vlm_prefix.onnx", "role": "model"},
+            {"path": "expert_denoise.onnx", "role": "model"},
+        ],
+        "io_contract": {
+            "inputs": [{"name": "noise", "dtype": "float32", "shape": [1, 50, 32]}],
+            "outputs": [{"name": "actions", "dtype": "float32", "shape": [1, 50, 32]}],
+        },
         "decomposed": {
             "vlm_prefix_onnx": "vlm_prefix.onnx",
             "expert_denoise_onnx": "expert_denoise.onnx",
@@ -28,7 +43,10 @@ def _decomposed_config() -> dict:
 
 
 def _monolithic_config() -> dict:
-    return {"export_kind": "monolithic"}
+    config = _decomposed_config()
+    config["export_kind"] = "monolithic_onnx"
+    config["artifacts"] = [{"path": "model.onnx", "role": "model"}]
+    return config
 
 
 def _write_export(tmp_path: Path, config: dict) -> Path:
@@ -37,6 +55,7 @@ def _write_export(tmp_path: Path, config: dict) -> Path:
     # Create empty onnx files for path existence
     (tmp_path / "vlm_prefix.onnx").write_bytes(b"\x00")
     (tmp_path / "expert_denoise.onnx").write_bytes(b"\x00")
+    (tmp_path / "model.onnx").write_bytes(b"\x00")
     return tmp_path
 
 
@@ -64,6 +83,7 @@ def test_skip_when_onnxruntime_not_importable(tmp_path):
     orig_ort = sys.modules.pop("onnxruntime", None)
     try:
         import importlib
+
         # Insert a dummy that raises ImportError on attribute access
         fake = MagicMock()
         fake.get_available_providers = MagicMock(side_effect=ImportError("mock no ort"))
@@ -93,10 +113,12 @@ def _patched_ort_with_providers(providers: list[str]):
     mock_input.name = "img_base"
     mock_input.shape = [1, 3, 224, 224]
     mock_input.type = "tensor(float)"
-    fake.InferenceSession = MagicMock(return_value=MagicMock(
-        get_inputs=MagicMock(return_value=[mock_input]),
-        run=MagicMock(return_value=[[]]),
-    ))
+    fake.InferenceSession = MagicMock(
+        return_value=MagicMock(
+            get_inputs=MagicMock(return_value=[mock_input]),
+            run=MagicMock(return_value=[[]]),
+        )
+    )
     return fake
 
 
@@ -104,7 +126,14 @@ def test_pass_when_both_sessions_capture(tmp_path):
     _write_export(tmp_path, _decomposed_config())
 
     # Mock try_capture_or_fall_back to return CudaGraphWrapper (captured=True) for both
-    with patch.dict(sys.modules, {"onnxruntime": _patched_ort_with_providers(["CUDAExecutionProvider", "CPUExecutionProvider"])}):
+    with patch.dict(
+        sys.modules,
+        {
+            "onnxruntime": _patched_ort_with_providers(
+                ["CUDAExecutionProvider", "CPUExecutionProvider"]
+            )
+        },
+    ):
         with patch("tether.runtime.cuda_graphs.try_capture_or_fall_back") as mock_try:
             mock_wrapper = MagicMock()
             mock_wrapper.captured = True
@@ -118,7 +147,14 @@ def test_pass_when_both_sessions_capture(tmp_path):
 def test_warn_when_only_expert_captures(tmp_path):
     _write_export(tmp_path, _decomposed_config())
 
-    with patch.dict(sys.modules, {"onnxruntime": _patched_ort_with_providers(["CUDAExecutionProvider", "CPUExecutionProvider"])}):
+    with patch.dict(
+        sys.modules,
+        {
+            "onnxruntime": _patched_ort_with_providers(
+                ["CUDAExecutionProvider", "CPUExecutionProvider"]
+            )
+        },
+    ):
         with patch("tether.runtime.cuda_graphs.try_capture_or_fall_back") as mock_try:
             # First call (vlm_prefix): eager fallback (captured=False)
             # Second call (expert_denoise): captured=True
@@ -138,7 +174,14 @@ def test_warn_when_only_expert_captures(tmp_path):
 def test_fail_when_neither_captures(tmp_path):
     _write_export(tmp_path, _decomposed_config())
 
-    with patch.dict(sys.modules, {"onnxruntime": _patched_ort_with_providers(["CUDAExecutionProvider", "CPUExecutionProvider"])}):
+    with patch.dict(
+        sys.modules,
+        {
+            "onnxruntime": _patched_ort_with_providers(
+                ["CUDAExecutionProvider", "CPUExecutionProvider"]
+            )
+        },
+    ):
         with patch("tether.runtime.cuda_graphs.try_capture_or_fall_back") as mock_try:
             prefix_wrapper = MagicMock()
             prefix_wrapper.captured = False

--- a/tests/test_chunk_budget_integration.py
+++ b/tests/test_chunk_budget_integration.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 
 import base64
 import io
-import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+
+from tests.export_config_factory import write_test_export_config
 
 
 def _stub_ort_session(input_names: list[str], output_shape=(1, 50, 32)):
@@ -36,16 +37,13 @@ def _stub_ort_session(input_names: list[str], output_shape=(1, 50, 32)):
 def _make_export_dir(tmp_path: Path) -> Path:
     export_dir = tmp_path / "export"
     export_dir.mkdir()
-    (export_dir / "model.onnx").write_bytes(b"stub")
-    (export_dir / "tether_config.json").write_text(json.dumps({
-        "model_type": "smolvla",
-        "export_kind": "monolithic",
-        "num_denoising_steps": 10,
-        "chunk_size": 50,
-        "action_chunk_size": 50,
-        "action_dim": 32,
-        "max_state_dim": 32,
-    }))
+    write_test_export_config(
+        export_dir,
+        model_type="smolvla",
+        chunk_size=50,
+        action_chunk_size=50,
+        max_state_dim=32,
+    )
     return export_dir
 
 

--- a/tests/test_cuda_graphs_integration.py
+++ b/tests/test_cuda_graphs_integration.py
@@ -23,13 +23,14 @@ and are skipped in local dev environments.
 """
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+
+from tests.export_config_factory import write_test_export_config
 
 
 # ---------------------------------------------------------------------------
@@ -51,23 +52,22 @@ def decomposed_export_dir(tmp_path: Path) -> Path:
     Pi05DecomposedInference's __init__ will accept."""
     export_dir = tmp_path / "export"
     export_dir.mkdir()
-    (export_dir / "vlm_prefix.onnx").write_bytes(b"stub-prefix")
-    (export_dir / "expert_denoise.onnx").write_bytes(b"stub-expert")
-    (export_dir / "tether_config.json").write_text(json.dumps({
-        "model_type": "pi05",
-        "export_kind": "decomposed",
-        "num_denoising_steps": 10,
-        "chunk_size": 50,
-        "action_chunk_size": 50,
-        "action_dim": 7,
-        "max_state_dim": 32,
-        "decomposed": {
+    write_test_export_config(
+        export_dir,
+        model_type="pi05",
+        export_kind="decomposed_onnx",
+        action_dim=7,
+        artifacts=["vlm_prefix.onnx", "expert_denoise.onnx"],
+        chunk_size=50,
+        action_chunk_size=50,
+        max_state_dim=32,
+        decomposed={
             "vlm_prefix_onnx": "vlm_prefix.onnx",
             "expert_denoise_onnx": "expert_denoise.onnx",
             "past_kv_tensor_names": [f"past_kv_{i}" for i in range(2)],
             "paligemma_layers": 2,
         },
-    }))
+    )
     return export_dir
 
 
@@ -104,16 +104,14 @@ def test_create_app_propagates_cuda_graphs_enabled_to_server_attr(tmp_path, monk
 
     monolithic_export = tmp_path / "export"
     monolithic_export.mkdir()
-    (monolithic_export / "model.onnx").write_bytes(b"stub")
-    (monolithic_export / "tether_config.json").write_text(json.dumps({
-        "model_type": "smolvla",
-        "export_kind": "monolithic",
-        "num_denoising_steps": 10,
-        "chunk_size": 50,
-        "action_chunk_size": 50,
-        "action_dim": 7,
-        "max_state_dim": 32,
-    }))
+    write_test_export_config(
+        monolithic_export,
+        model_type="smolvla",
+        action_dim=7,
+        chunk_size=50,
+        action_chunk_size=50,
+        max_state_dim=32,
+    )
 
     from tether.runtime.server import create_app
 
@@ -132,16 +130,14 @@ def test_create_app_default_cuda_graphs_disabled(tmp_path, monkeypatch):
 
     monolithic_export = tmp_path / "export"
     monolithic_export.mkdir()
-    (monolithic_export / "model.onnx").write_bytes(b"stub")
-    (monolithic_export / "tether_config.json").write_text(json.dumps({
-        "model_type": "smolvla",
-        "export_kind": "monolithic",
-        "num_denoising_steps": 10,
-        "chunk_size": 50,
-        "action_chunk_size": 50,
-        "action_dim": 7,
-        "max_state_dim": 32,
-    }))
+    write_test_export_config(
+        monolithic_export,
+        model_type="smolvla",
+        action_dim=7,
+        chunk_size=50,
+        action_chunk_size=50,
+        max_state_dim=32,
+    )
 
     from tether.runtime.server import create_app
 
@@ -167,15 +163,16 @@ def test_legacy_tether_server_logs_noop_warning_when_cuda_graphs_set(
 
     legacy_export = tmp_path / "export"
     legacy_export.mkdir()
-    (legacy_export / "expert_stack.onnx").write_bytes(b"stub")
-    (legacy_export / "tether_config.json").write_text(json.dumps({
-        "model_type": "pi05",
-        "num_denoising_steps": 10,
-        "chunk_size": 50,
-        "action_chunk_size": 50,
-        "action_dim": 7,
-        "max_state_dim": 32,
-    }))
+    write_test_export_config(
+        legacy_export,
+        model_type="pi05",
+        export_kind="decomposed_onnx",
+        action_dim=7,
+        artifacts=["expert_stack.onnx"],
+        chunk_size=50,
+        action_chunk_size=50,
+        max_state_dim=32,
+    )
 
     from tether.runtime.server import create_app
 
@@ -297,16 +294,14 @@ def test_metrics_endpoint_includes_cuda_graph_counter_names(tmp_path, monkeypatc
 
     export_dir = tmp_path / "export"
     export_dir.mkdir()
-    (export_dir / "model.onnx").write_bytes(b"stub")
-    (export_dir / "tether_config.json").write_text(json.dumps({
-        "model_type": "smolvla",
-        "export_kind": "monolithic",
-        "num_denoising_steps": 10,
-        "chunk_size": 50,
-        "action_chunk_size": 50,
-        "action_dim": 7,
-        "max_state_dim": 32,
-    }))
+    write_test_export_config(
+        export_dir,
+        model_type="smolvla",
+        action_dim=7,
+        chunk_size=50,
+        action_chunk_size=50,
+        max_state_dim=32,
+    )
 
     from tether.runtime.cuda_graphs import CudaGraphWrapper
 

--- a/tests/test_decomposed_server.py
+++ b/tests/test_decomposed_server.py
@@ -9,7 +9,6 @@ create_app + the existing /act handler + all wedges.
 These tests stub Pi05DecomposedInference so they don't require ORT or
 GPU; they exercise the prep + dispatch contract.
 """
-
 from __future__ import annotations
 
 import asyncio
@@ -88,7 +87,6 @@ def _make_export_dir(
 def _make_b64_image(width: int = 100, height: int = 80) -> str:
     """Generate a synthetic JPEG-encoded base64 image."""
     from PIL import Image
-
     arr = (np.random.rand(height, width, 3) * 255).astype(np.uint8)
     img = Image.fromarray(arr)
     buf = io.BytesIO()
@@ -266,9 +264,7 @@ def test_predict_handles_missing_image(tmp_path, monkeypatch):
     camera convention used by SmolVLA training)."""
     server = _build_loaded_server(tmp_path, monkeypatch)
     result = server.predict_from_base64(
-        image_b64=None,
-        instruction="x",
-        state=None,
+        image_b64=None, instruction="x", state=None,
     )
     # Doesn't error -- pads + still returns actions
     assert "actions" in result
@@ -327,13 +323,9 @@ def test_predict_state_truncated_when_too_long(tmp_path, monkeypatch):
 
 def test_predict_from_base64_async_returns_same_shape(tmp_path, monkeypatch):
     server = _build_loaded_server(tmp_path, monkeypatch)
-    result = asyncio.run(
-        server.predict_from_base64_async(
-            image_b64=_make_b64_image(),
-            instruction="x",
-            state=None,
-        )
-    )
+    result = asyncio.run(server.predict_from_base64_async(
+        image_b64=_make_b64_image(), instruction="x", state=None,
+    ))
     assert "actions" in result
     assert len(result["actions"]) == 50
 

--- a/tests/test_decomposed_server.py
+++ b/tests/test_decomposed_server.py
@@ -9,6 +9,7 @@ create_app + the existing /act handler + all wedges.
 These tests stub Pi05DecomposedInference so they don't require ORT or
 GPU; they exercise the prep + dispatch contract.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -43,14 +44,17 @@ def _disable_hf_normalizer_fallback(monkeypatch):
 def _make_export_dir(
     tmp_path: Path,
     *,
-    export_kind: str = "decomposed",
+    export_kind: str = "decomposed_onnx",
     action_dim: int = 7,
     chunk_size: int = 50,
 ) -> Path:
     """Build a minimal export dir with a tether_config.json."""
     p = tmp_path / "export"
     p.mkdir()
+    (p / "vlm_prefix.onnx").write_bytes(b"prefix")
+    (p / "expert_denoise.onnx").write_bytes(b"expert")
     config = {
+        "schema_version": 1,
         # Keep this fixture local-only. A real HF repo id triggers teacher
         # normalizer fallback during server.load(), which makes these unit
         # tests depend on network/cache state.
@@ -63,6 +67,14 @@ def _make_export_dir(
         "action_dim": action_dim,
         "opset": 19,
         "export_kind": export_kind,
+        "artifacts": [
+            {"path": "vlm_prefix.onnx", "role": "model"},
+            {"path": "expert_denoise.onnx", "role": "model"},
+        ],
+        "io_contract": {
+            "inputs": [{"name": "noise", "dtype": "float32", "shape": [1, chunk_size, 32]}],
+            "outputs": [{"name": "actions", "dtype": "float32", "shape": [1, chunk_size, 32]}],
+        },
         "decomposed": {
             "vlm_prefix_onnx": "vlm_prefix.onnx",
             "expert_denoise_onnx": "expert_denoise.onnx",
@@ -76,6 +88,7 @@ def _make_export_dir(
 def _make_b64_image(width: int = 100, height: int = 80) -> str:
     """Generate a synthetic JPEG-encoded base64 image."""
     from PIL import Image
+
     arr = (np.random.rand(height, width, 3) * 255).astype(np.uint8)
     img = Image.fromarray(arr)
     buf = io.BytesIO()
@@ -129,13 +142,13 @@ def test_load_rejects_missing_config(tmp_path):
 
 
 def test_load_rejects_wrong_export_kind(tmp_path, monkeypatch):
-    p = _make_export_dir(tmp_path, export_kind="monolithic")
+    p = _make_export_dir(tmp_path, export_kind="monolithic_onnx")
     monkeypatch.setattr(
         "tether.runtime.pi05_decomposed_server.Pi05DecomposedInference",
         _StubInference,
     )
     server = Pi05DecomposedServer(p)
-    with pytest.raises(ValueError, match="export_kind='decomposed'"):
+    with pytest.raises(ValueError, match="export_kind='decomposed_onnx'"):
         server.load()
 
 
@@ -253,7 +266,9 @@ def test_predict_handles_missing_image(tmp_path, monkeypatch):
     camera convention used by SmolVLA training)."""
     server = _build_loaded_server(tmp_path, monkeypatch)
     result = server.predict_from_base64(
-        image_b64=None, instruction="x", state=None,
+        image_b64=None,
+        instruction="x",
+        state=None,
     )
     # Doesn't error -- pads + still returns actions
     assert "actions" in result
@@ -312,9 +327,13 @@ def test_predict_state_truncated_when_too_long(tmp_path, monkeypatch):
 
 def test_predict_from_base64_async_returns_same_shape(tmp_path, monkeypatch):
     server = _build_loaded_server(tmp_path, monkeypatch)
-    result = asyncio.run(server.predict_from_base64_async(
-        image_b64=_make_b64_image(), instruction="x", state=None,
-    ))
+    result = asyncio.run(
+        server.predict_from_base64_async(
+            image_b64=_make_b64_image(),
+            instruction="x",
+            state=None,
+        )
+    )
     assert "actions" in result
     assert len(result["actions"]) == 50
 

--- a/tests/test_episode_cache_production_wiring.py
+++ b/tests/test_episode_cache_production_wiring.py
@@ -12,12 +12,13 @@ was enabled (EpisodeCache._emit_bytes_metric is a no-op unless both are set).
 """
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+
+from tests.export_config_factory import write_test_export_config
 
 
 def _stub_ort_session_with_io(input_names: list[str], output_shape=(1, 50, 7)):
@@ -42,23 +43,22 @@ def decomposed_export_dir(tmp_path: Path) -> Path:
     """Minimal decomposed export dir Pi05DecomposedInference.__init__ accepts."""
     export_dir = tmp_path / "export"
     export_dir.mkdir()
-    (export_dir / "vlm_prefix.onnx").write_bytes(b"stub-prefix")
-    (export_dir / "expert_denoise.onnx").write_bytes(b"stub-expert")
-    (export_dir / "tether_config.json").write_text(json.dumps({
-        "model_type": "pi05",
-        "export_kind": "decomposed",
-        "num_denoising_steps": 10,
-        "chunk_size": 50,
-        "action_chunk_size": 50,
-        "action_dim": 7,
-        "max_state_dim": 32,
-        "decomposed": {
+    write_test_export_config(
+        export_dir,
+        model_type="pi05",
+        export_kind="decomposed_onnx",
+        action_dim=7,
+        artifacts=["vlm_prefix.onnx", "expert_denoise.onnx"],
+        chunk_size=50,
+        action_chunk_size=50,
+        max_state_dim=32,
+        decomposed={
             "vlm_prefix_onnx": "vlm_prefix.onnx",
             "expert_denoise_onnx": "expert_denoise.onnx",
             "past_kv_tensor_names": [f"past_kv_{i}" for i in range(2)],
             "paligemma_layers": 2,
         },
-    }))
+    )
     return export_dir
 
 

--- a/tests/test_export_config_contract.py
+++ b/tests/test_export_config_contract.py
@@ -4,14 +4,20 @@ import hashlib
 import json
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from tether.export_config import (
+    PRODUCER_LAYOUTS,
     ExportConfigError,
     UnsupportedExportKindError,
+    UnsupportedExportPipelineError,
+    build_producer_config,
+    decomposed_layout,
     load_tether_config,
     normalize_legacy_tether_config,
     require_supported_export_kind,
+    require_supported_pipeline,
     validate_tether_config,
     write_tether_config,
 )
@@ -68,6 +74,72 @@ def test_legacy_kind_is_normalized_without_guessing_required_fields(tmp_path):
 
     assert loaded["schema_version"] == 1
     assert loaded["export_kind"] == "monolithic_onnx"
+
+
+def test_legacy_top_level_num_inference_steps_is_normalized(tmp_path):
+    root, payload = _export(tmp_path)
+    payload.pop("schema_version")
+    payload.pop("num_denoising_steps")
+    payload["num_inference_steps"] = 6
+    payload["export_kind"] = "monolithic"
+    (root / "tether_config.json").write_text(json.dumps(payload))
+
+    loaded = load_tether_config(root)
+
+    assert loaded["num_denoising_steps"] == 6
+
+
+def test_old_pi0_expert_layout_derives_decomposed_kind(tmp_path):
+    root = tmp_path / "pi0-old"
+    _write_identity_onnx(root / "expert_stack.onnx", action_dim=7)
+    legacy = {
+        "model_id": "lerobot/pi0",
+        "model_type": "pi0",
+        "action_dim": 7,
+        "num_inference_steps": 10,
+    }
+    (root / "tether_config.json").write_text(json.dumps(legacy))
+
+    loaded = load_tether_config(root)
+
+    assert loaded["export_kind"] == "decomposed_onnx"
+    assert loaded["num_denoising_steps"] == 10
+
+
+def test_old_gr00t_model_layout_derives_monolithic_kind(tmp_path):
+    root = tmp_path / "gr00t-old"
+    _write_identity_onnx(root / "model.onnx", action_dim=14)
+    legacy = {
+        "model_id": "nvidia/gr00t",
+        "model_type": "gr00t",
+        "action_dim": 14,
+        "num_inference_steps": 4,
+    }
+    (root / "tether_config.json").write_text(json.dumps(legacy))
+
+    loaded = load_tether_config(root)
+
+    assert loaded["export_kind"] == "monolithic_onnx"
+
+
+def test_old_dreamzero_export_format_derives_config_only(tmp_path):
+    root = tmp_path / "dreamzero-old"
+    root.mkdir()
+    legacy = {
+        "checkpoint_path": "org/dreamzero",
+        "model_family": "dreamzero",
+        "export_format": "dreamzero_decomposed",
+        "action_dim": 32,
+        "num_inference_steps": 4,
+        "opset_version": 17,
+    }
+    (root / "tether_config.json").write_text(json.dumps(legacy))
+
+    loaded = load_tether_config(root)
+
+    assert loaded["export_kind"] == "config_only"
+    assert loaded["artifacts"] == []
+    assert loaded["io_contract"] == {"inputs": [], "outputs": []}
 
 
 def test_legacy_onnx_metadata_and_external_weights_are_inspected(tmp_path):
@@ -203,3 +275,465 @@ def test_symlink_artifact_cannot_escape_export_root(tmp_path):
     (root / "model.onnx").symlink_to(outside)
     with pytest.raises(ExportConfigError, match="outside the export directory"):
         validate_tether_config(payload, root=root)
+
+
+def _write_identity_onnx(path: Path, *, action_dim: int = 7, opset: int = 17) -> None:
+    onnx = pytest.importorskip("onnx")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    x = onnx.helper.make_tensor_value_info("input", onnx.TensorProto.FLOAT, [1, 50, action_dim])
+    y = onnx.helper.make_tensor_value_info("output", onnx.TensorProto.FLOAT, [1, 50, action_dim])
+    graph = onnx.helper.make_graph(
+        [onnx.helper.make_node("Identity", ["input"], ["output"])],
+        path.stem,
+        [x],
+        [y],
+    )
+    model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", opset)])
+    onnx.save(model, path)
+
+
+def _materialize_producer(
+    tmp_path: Path,
+    producer: str,
+    *,
+    model_type: str,
+    action_dim: int = 7,
+) -> Path:
+    root = tmp_path / producer
+    for path, role in PRODUCER_LAYOUTS[producer]["artifacts"]:
+        if role == "model":
+            _write_identity_onnx(root / path, action_dim=action_dim)
+    payload = build_producer_config(
+        root,
+        producer=producer,
+        model_id=f"org/{model_type}",
+        model_type=model_type,
+        action_dim=action_dim,
+        num_denoising_steps=10,
+        opset=17,
+    )
+    write_tether_config(root, payload)
+    return root
+
+
+def _materialize_smolvla_full_bundle(tmp_path: Path) -> Path:
+    from tether.exporters.vlm_prefix_exporter import _update_vlm_manifest
+
+    root = _materialize_producer(tmp_path, "expert_stack", model_type="smolvla")
+    for filename in ("vision_encoder.onnx", "text_embedder.onnx", "decoder_prefill.onnx"):
+        _write_identity_onnx(root / filename)
+    _update_vlm_manifest(
+        root,
+        checkpoint_path_or_id="org/smolvla",
+        image_size=512,
+        vlm_hidden_size=960,
+        vlm_kv_dim=320,
+    )
+    return root
+
+
+@pytest.mark.parametrize(
+    ("producer", "model_type"),
+    [
+        ("monolithic", "pi0"),
+        ("pi05_split", "pi05_decomposed"),
+        ("expert_stack", "smolvla"),
+        ("pi0_prefix", "pi0"),
+        ("dreamzero", "dreamzero"),
+    ],
+)
+def test_each_real_producer_layout_builds_a_valid_config(tmp_path, producer, model_type):
+    root = _materialize_producer(tmp_path, producer, model_type=model_type)
+    assert load_tether_config(root)["export_kind"] == PRODUCER_LAYOUTS[producer]["export_kind"]
+
+
+def test_canonical_producer_does_not_discover_stale_files(tmp_path):
+    root = tmp_path / "export"
+    _write_identity_onnx(root / "model.onnx")
+    _write_identity_onnx(root / "stale.onnx")
+    (root / "old.bin").write_bytes(b"stale")
+
+    payload = build_producer_config(
+        root,
+        producer="monolithic",
+        model_id="org/model",
+        model_type="pi0",
+        action_dim=7,
+        num_denoising_steps=10,
+        opset=17,
+    )
+
+    assert [artifact["path"] for artifact in payload["artifacts"]] == ["model.onnx"]
+
+
+def test_canonical_producer_includes_only_referenced_external_weights(tmp_path):
+    import numpy as np
+
+    onnx = pytest.importorskip("onnx")
+    root = tmp_path / "export"
+    root.mkdir()
+    x = onnx.helper.make_tensor_value_info("input", onnx.TensorProto.FLOAT, [1, 7])
+    y = onnx.helper.make_tensor_value_info("output", onnx.TensorProto.FLOAT, [1, 7])
+    weight = onnx.numpy_helper.from_array(np.eye(7, dtype=np.float32), name="weight")
+    graph = onnx.helper.make_graph(
+        [onnx.helper.make_node("MatMul", ["input", "weight"], ["output"])],
+        "external",
+        [x],
+        [y],
+        [weight],
+    )
+    model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 17)])
+    onnx.save_model(
+        model,
+        root / "model.onnx",
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location="model.onnx.data",
+        size_threshold=0,
+    )
+    (root / "stale.data").write_bytes(b"stale")
+
+    payload = build_producer_config(
+        root,
+        producer="monolithic",
+        model_id="org/model",
+        model_type="pi0",
+        action_dim=7,
+        num_denoising_steps=10,
+        opset=17,
+    )
+
+    assert [artifact["path"] for artifact in payload["artifacts"]] == [
+        "model.onnx",
+        "model.onnx.data",
+    ]
+
+
+def test_gr00t_robot_action_dim_comes_from_encoder_not_token_width():
+    import torch
+
+    from tether.exporters.gr00t import GR00T_META_KEYS, _raw_action_dim_from_checkpoint
+
+    checkpoint = {GR00T_META_KEYS["action_enc_W1_W"]: torch.empty(32, 14, 1024)}
+    assert _raw_action_dim_from_checkpoint(checkpoint) == 14
+
+
+def test_gr00t_token_expert_is_not_routed_as_raw_action_reader(tmp_path):
+    from tether.validate_roundtrip import ValidateRoundTrip
+
+    root = tmp_path / "gr00t-token-expert"
+    _write_identity_onnx(root / "expert_stack.onnx", action_dim=1024)
+    payload = build_producer_config(
+        root,
+        producer="expert_stack",
+        model_id="nvidia/gr00t",
+        model_type="gr00t",
+        action_dim=14,
+        num_denoising_steps=4,
+        opset=17,
+        metadata={
+            "pipeline": "gr00t_token_expert",
+            "extensions": {"token_input_dim": 1024, "token_output_dim": 1024},
+        },
+    )
+    write_tether_config(root, payload)
+
+    with pytest.raises(UnsupportedExportPipelineError, match="does not support pipeline"):
+        ValidateRoundTrip(root, num_test_cases=1)
+    with pytest.raises(UnsupportedExportPipelineError, match="unsupported decomposed pipeline"):
+        decomposed_layout(load_tether_config(root))
+
+
+@pytest.mark.parametrize(
+    "producer_and_model",
+    [
+        ("expert_stack", "pi0"),
+        ("expert_stack", "smolvla"),
+        ("expert_stack", "gr00t"),
+    ],
+)
+def test_declared_round_trip_reader_pairs_load_config(tmp_path, producer_and_model):
+    from tether.validate_roundtrip import ValidateRoundTrip
+
+    producer, model_type = producer_and_model
+    root = _materialize_producer(tmp_path, producer, model_type=model_type)
+    reader = ValidateRoundTrip(root, num_test_cases=1)
+    assert reader.config == load_tether_config(root)
+
+
+@pytest.mark.parametrize(
+    ("producer", "model_type", "error", "message"),
+    [
+        ("monolithic", "pi0", UnsupportedExportKindError, "does not support export_kind"),
+        (
+            "pi05_split",
+            "pi05_decomposed",
+            UnsupportedExportPipelineError,
+            "supports only the expert_stack",
+        ),
+        ("dreamzero", "dreamzero", UnsupportedExportKindError, "does not support export_kind"),
+        ("pi0_prefix", "pi0", UnsupportedExportPipelineError, "does not support pipeline"),
+    ],
+)
+def test_unsupported_reader_pairs_fail_explicitly(
+    tmp_path, producer, model_type, error, message
+):
+    from tether.validate_roundtrip import ValidateRoundTrip
+
+    root = _materialize_producer(tmp_path, producer, model_type=model_type)
+    with pytest.raises(error, match=message):
+        ValidateRoundTrip(root, num_test_cases=1)
+
+
+def test_decomposed_reader_gate_distinguishes_supported_layouts(tmp_path):
+    split = _materialize_producer(tmp_path, "pi05_split", model_type="pi05_decomposed")
+    expert = _materialize_producer(tmp_path, "expert_stack", model_type="smolvla")
+    custom = _materialize_producer(tmp_path, "pi0_prefix", model_type="pi0")
+
+    assert decomposed_layout(load_tether_config(split)) == "pi05_split"
+    assert decomposed_layout(load_tether_config(expert)) == "expert_stack"
+    with pytest.raises(UnsupportedExportPipelineError, match="unsupported decomposed pipeline"):
+        decomposed_layout(load_tether_config(custom))
+
+
+def test_smolvla_full_bundle_is_an_exact_supported_layout(tmp_path):
+    root = _materialize_smolvla_full_bundle(tmp_path)
+
+    assert decomposed_layout(load_tether_config(root)) == "smolvla_full_bundle"
+
+    config = load_tether_config(root)
+    config["artifacts"].append({"path": "custom.onnx", "role": "model"})
+    with pytest.raises(UnsupportedExportPipelineError, match="unsupported decomposed"):
+        decomposed_layout(config)
+
+
+def test_ambiguous_decomposed_manifest_is_rejected():
+    payload = _payload()
+    payload["export_kind"] = "decomposed_onnx"
+    payload["artifacts"] = [
+        {"path": "vlm_prefix.onnx", "role": "model"},
+        {"path": "expert_denoise.onnx", "role": "model"},
+        {"path": "expert_stack.onnx", "role": "model"},
+    ]
+
+    with pytest.raises(UnsupportedExportPipelineError, match="unsupported decomposed"):
+        decomposed_layout(payload)
+
+
+def test_declared_expert_onnx_reader_executes_with_exact_inputs(tmp_path):
+    onnx = pytest.importorskip("onnx")
+    pytest.importorskip("onnxruntime")
+    from tether._onnx_backend import load_onnx_backend
+
+    root = tmp_path / "expert-reader"
+    root.mkdir()
+    noisy = onnx.helper.make_tensor_value_info(
+        "noisy_actions", onnx.TensorProto.FLOAT, [1, 2, 3]
+    )
+    timestep = onnx.helper.make_tensor_value_info(
+        "timestep", onnx.TensorProto.FLOAT, [1]
+    )
+    position_ids = onnx.helper.make_tensor_value_info(
+        "position_ids", onnx.TensorProto.INT64, [1, 2]
+    )
+    velocity = onnx.helper.make_tensor_value_info(
+        "velocity", onnx.TensorProto.FLOAT, [1, 2, 3]
+    )
+    graph = onnx.helper.make_graph(
+        [onnx.helper.make_node("Sub", ["noisy_actions", "noisy_actions"], ["velocity"])],
+        "expert-reader",
+        [noisy, timestep, position_ids],
+        [velocity],
+    )
+    model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    onnx.save(model, root / "expert_stack.onnx")
+    payload = build_producer_config(
+        root,
+        producer="expert_stack",
+        model_id="org/pi0",
+        model_type="pi0",
+        action_dim=3,
+        num_denoising_steps=2,
+        opset=17,
+        metadata={"action_chunk_size": 2},
+    )
+    write_tether_config(root, payload)
+    backend = load_onnx_backend(root)
+
+    real_session = backend.session
+
+    class SessionSpy:
+        def __init__(self):
+            self.feeds = []
+
+        def run(self, outputs, feed):
+            self.feeds.append(dict(feed))
+            return real_session.run(outputs, feed)
+
+        def get_inputs(self):
+            return real_session.get_inputs()
+
+    spy = SessionSpy()
+    backend.session = spy
+    initial = np.ones((2, 3), dtype=np.float32)
+    result = backend.forward(
+        np.zeros((1, 1, 3), dtype=np.float32),
+        "pick",
+        np.zeros(3, dtype=np.float32),
+        initial,
+    )
+
+    np.testing.assert_array_equal(result, initial)
+    assert len(spy.feeds) == 2
+    assert all(
+        set(feed) == {"noisy_actions", "timestep", "position_ids"}
+        for feed in spy.feeds
+    )
+
+
+def test_declared_pytorch_expert_reader_executes_euler_inputs():
+    import torch
+
+    from tether._pytorch_backend import PyTorchBackend
+
+    class ZeroVelocity(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+
+        def forward(self, actions, timestep, position_ids, vlm_kv=None):
+            self.calls.append((actions.shape, timestep.shape, position_ids.shape, vlm_kv))
+            return torch.zeros_like(actions)
+
+    model = ZeroVelocity()
+    backend = PyTorchBackend(
+        "pi0",
+        model,
+        {
+            "action_dim": 3,
+            "action_chunk_size": 2,
+            "num_denoising_steps": 2,
+        },
+        "cpu",
+    )
+    initial = np.ones((2, 3), dtype=np.float32)
+
+    result = backend.forward(
+        np.zeros((1, 1, 3), dtype=np.float32),
+        "pick",
+        np.zeros(3, dtype=np.float32),
+        initial,
+    )
+
+    np.testing.assert_array_equal(result, initial)
+    assert model.calls == [
+        (torch.Size([1, 2, 3]), torch.Size([1]), torch.Size([1, 2]), None),
+        (torch.Size([1, 2, 3]), torch.Size([1]), torch.Size([1, 2]), None),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("producer", "model_type", "expected_class"),
+    [
+        ("monolithic", "gr00t", "TetherServer"),
+        ("pi05_split", "pi05_decomposed", "Pi05DecomposedServer"),
+        ("expert_stack", "smolvla", "TetherServer"),
+    ],
+)
+def test_benchmark_dispatch_uses_declared_decomposed_reader(
+    tmp_path, producer, model_type, expected_class
+):
+    from tether.cli import _build_benchmark_server
+
+    root = _materialize_producer(tmp_path, producer, model_type=model_type)
+    server = _build_benchmark_server(root, load_tether_config(root), "cpu")
+
+    assert type(server).__name__ == expected_class
+
+
+def test_benchmark_dispatches_smolvla_full_bundle(tmp_path):
+    from tether.cli import _build_benchmark_server
+
+    root = _materialize_smolvla_full_bundle(tmp_path)
+    server = _build_benchmark_server(root, load_tether_config(root), "cpu")
+
+    assert type(server).__name__ == "TetherServer"
+
+
+def test_create_app_dispatches_produced_smolvla_bundle_in_onnx_and_native_modes(
+    tmp_path, monkeypatch
+):
+    from tether.runtime.server import TetherServer, create_app
+    from tether.runtime.smolvla_native import SmolVLANativeServer
+
+    root = _materialize_smolvla_full_bundle(tmp_path)
+    monkeypatch.delenv("TETHER_NATIVE", raising=False)
+    onnx_app = create_app(str(root), device="cpu")
+    assert isinstance(onnx_app.state.tether_server, TetherServer)
+
+    monkeypatch.setenv("TETHER_NATIVE", "1")
+    native_app = create_app(str(root), device="cpu")
+    assert isinstance(native_app.state.tether_server, SmolVLANativeServer)
+
+
+@pytest.mark.parametrize(
+    ("producer", "model_type", "expected_class"),
+    [
+        ("pi05_split", "pi05_decomposed", "Pi05DecomposedServer"),
+        ("expert_stack", "smolvla", "TetherServer"),
+    ],
+)
+def test_replay_dispatch_uses_declared_decomposed_reader(
+    tmp_path, producer, model_type, expected_class, monkeypatch
+):
+    from tether.replay.cli import _load_target_server
+    from tether.runtime import decomposed_server, server
+
+    class FakeServer:
+        def __init__(self, _root):
+            self.ready = False
+
+        def load(self):
+            self.ready = True
+
+    FakeServer.__name__ = expected_class
+    monkeypatch.setattr(decomposed_server, "Pi05DecomposedServer", FakeServer)
+    monkeypatch.setattr(server, "TetherServer", FakeServer)
+    root = _materialize_producer(tmp_path, producer, model_type=model_type)
+
+    loaded = _load_target_server(str(root))
+
+    assert type(loaded).__name__ == expected_class
+    assert loaded.ready
+
+
+def test_replay_dispatches_smolvla_full_bundle(tmp_path, monkeypatch):
+    from tether.replay.cli import _load_target_server
+    from tether.runtime import server
+
+    class FakeServer:
+        def __init__(self, _root):
+            self.ready = False
+
+        def load(self):
+            self.ready = True
+
+    monkeypatch.setattr(server, "TetherServer", FakeServer)
+    root = _materialize_smolvla_full_bundle(tmp_path)
+
+    loaded = _load_target_server(str(root))
+
+    assert isinstance(loaded, FakeServer)
+    assert loaded.ready
+
+
+def test_custom_pipeline_requires_reader_opt_in():
+    payload = _payload()
+    payload["pipeline"] = "prefix_optimum + expert_custom"
+    with pytest.raises(UnsupportedExportPipelineError, match="does not support pipeline"):
+        require_supported_pipeline(payload, set(), "test reader")
+    assert (
+        require_supported_pipeline(payload, {"prefix_optimum + expert_custom"}, "test reader")
+        == "prefix_optimum + expert_custom"
+    )

--- a/tests/test_export_config_contract.py
+++ b/tests/test_export_config_contract.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from tether.export_config import (
+    ExportConfigError,
+    UnsupportedExportKindError,
+    load_tether_config,
+    normalize_legacy_tether_config,
+    require_supported_export_kind,
+    validate_tether_config,
+    write_tether_config,
+)
+
+
+def _payload(path: str = "model.onnx") -> dict:
+    return {
+        "schema_version": 1,
+        "model_id": "org/model",
+        "model_type": "pi0",
+        "action_dim": 7,
+        "num_denoising_steps": 10,
+        "opset": 17,
+        "export_kind": "monolithic_onnx",
+        "artifacts": [{"path": path, "role": "model"}],
+        "io_contract": {
+            "inputs": [
+                {"name": "state", "dtype": "float32", "shape": ["batch", 7]},
+                {"name": "image", "dtype": "uint8", "shape": [None, 224, 224, 3]},
+            ],
+            "outputs": [{"name": "actions", "dtype": "float32", "shape": ["batch", 50, 7]}],
+        },
+    }
+
+
+def _export(tmp_path: Path) -> tuple[Path, dict]:
+    root = tmp_path / "export"
+    root.mkdir()
+    artifact = root / "model.onnx"
+    artifact.write_bytes(b"not an actual onnx graph")
+    payload = _payload()
+    return root, payload
+
+
+def test_canonical_round_trip_checks_digest_and_preserves_extensions(tmp_path):
+    root, payload = _export(tmp_path)
+    payload["artifacts"][0]["sha256"] = hashlib.sha256(b"not an actual onnx graph").hexdigest()
+    payload["extensions"] = {"vendor": {"token_width": 2048}}
+
+    path = write_tether_config(root, payload)
+    loaded = load_tether_config(path)
+
+    assert loaded == payload
+    assert json.loads(path.read_text())["extensions"] == payload["extensions"]
+
+
+def test_legacy_kind_is_normalized_without_guessing_required_fields(tmp_path):
+    root, payload = _export(tmp_path)
+    payload.pop("schema_version")
+    payload["export_kind"] = "monolithic"
+    (root / "tether_config.json").write_text(json.dumps(payload))
+
+    loaded = load_tether_config(root)
+
+    assert loaded["schema_version"] == 1
+    assert loaded["export_kind"] == "monolithic_onnx"
+
+
+def test_legacy_onnx_metadata_and_external_weights_are_inspected(tmp_path):
+    onnx = pytest.importorskip("onnx")
+    root = tmp_path / "export"
+    root.mkdir()
+    x = onnx.helper.make_tensor_value_info("state", onnx.TensorProto.FLOAT, ["batch", 7])
+    y = onnx.helper.make_tensor_value_info("actions", onnx.TensorProto.FLOAT, ["batch", 7])
+    node = onnx.helper.make_node("Identity", ["state"], ["actions"])
+    graph = onnx.helper.make_graph([node], "fixture", [x], [y])
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[onnx.helper.make_opsetid("", 17)],
+    )
+    onnx.save(model, root / "model.onnx")
+    (root / "model.onnx.data").write_bytes(b"external weights")
+    legacy = {
+        "model_id": "org/model",
+        "model_type": "pi0",
+        "action_dim": 7,
+        "num_denoising_steps": 10,
+        "export_kind": "monolithic",
+    }
+
+    normalized = normalize_legacy_tether_config(legacy, root)
+    validated = validate_tether_config(normalized, root=root)
+
+    assert validated["opset"] == 17
+    assert validated["io_contract"]["inputs"] == [
+        {"name": "state", "dtype": "float32", "shape": ["batch", 7]}
+    ]
+    assert {item["role"] for item in validated["artifacts"]} == {"model", "weights"}
+
+
+@pytest.mark.parametrize(
+    "missing", ["model_id", "model_type", "action_dim", "num_denoising_steps", "opset"]
+)
+def test_legacy_migration_never_guesses_required_fields(tmp_path, missing):
+    root, payload = _export(tmp_path)
+    payload.pop("schema_version")
+    payload.pop(missing)
+    if missing == "opset":
+        (root / "model.onnx").rename(root / "model.bin")
+        payload["artifacts"][0]["path"] = "model.bin"
+    (root / "tether_config.json").write_text(json.dumps(payload))
+
+    with pytest.raises(ExportConfigError, match=missing):
+        load_tether_config(root, inspect_artifacts=False)
+
+
+@pytest.mark.parametrize(
+    ("path", "message"),
+    [
+        ("/tmp/model.onnx", "relative path"),
+        ("../model.onnx", "without '\\.\\.'"),
+        ("parts/../model.onnx", "without '\\.\\.'"),
+        ("parts\\model.onnx", "POSIX separators"),
+        ("./model.onnx", "normalized"),
+        ("parts//model.onnx", "normalized"),
+    ],
+)
+def test_artifact_paths_are_confined_and_normalized(path, message):
+    payload = _payload(path)
+    with pytest.raises(ExportConfigError, match=message):
+        validate_tether_config(payload, inspect_artifacts=False)
+
+
+@pytest.mark.parametrize("role", ["checkpoint", "onnx", "MODEL", ""])
+def test_unknown_artifact_role_fails(role):
+    payload = _payload()
+    payload["artifacts"][0]["role"] = role
+    with pytest.raises(ExportConfigError, match="role must be one of"):
+        validate_tether_config(payload, inspect_artifacts=False)
+
+
+@pytest.mark.parametrize("digest", ["A" * 64, "a" * 63, "z" * 64, 42])
+def test_malformed_digest_fails(digest):
+    payload = _payload()
+    payload["artifacts"][0]["sha256"] = digest
+    with pytest.raises(ExportConfigError, match="lowercase 64-hex"):
+        validate_tether_config(payload, inspect_artifacts=False)
+
+
+def test_missing_and_digest_mismatched_artifacts_fail(tmp_path):
+    root, payload = _export(tmp_path)
+    payload["artifacts"][0]["sha256"] = "0" * 64
+    with pytest.raises(ExportConfigError, match="sha256 mismatch"):
+        validate_tether_config(payload, root=root)
+    (root / "model.onnx").unlink()
+    payload["artifacts"][0].pop("sha256")
+    with pytest.raises(ExportConfigError, match="is missing"):
+        validate_tether_config(payload, root=root)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [[0], [-1], [True], ["9batch"], ["has-hyphen"], [{}]],
+)
+def test_invalid_tensor_dimensions_fail(shape):
+    payload = _payload()
+    payload["io_contract"]["inputs"][0]["shape"] = shape
+    with pytest.raises(ExportConfigError, match="shape"):
+        validate_tether_config(payload, inspect_artifacts=False)
+
+
+def test_config_only_can_have_empty_artifacts_and_io_contract():
+    payload = _payload()
+    payload["export_kind"] = "config_only"
+    payload["artifacts"] = []
+    payload["io_contract"] = {"inputs": [], "outputs": []}
+    assert validate_tether_config(payload)["export_kind"] == "config_only"
+
+
+def test_non_config_export_requires_an_artifact():
+    payload = _payload()
+    payload["artifacts"] = []
+    with pytest.raises(ExportConfigError, match="must not be empty"):
+        validate_tether_config(payload)
+
+
+def test_unsupported_kind_is_explicit_after_validation():
+    payload = _payload()
+    payload["export_kind"] = "trt_engine"
+    with pytest.raises(UnsupportedExportKindError, match="does not support"):
+        require_supported_export_kind(payload, {"monolithic_onnx"}, "local verifier")
+
+
+def test_symlink_artifact_cannot_escape_export_root(tmp_path):
+    root, payload = _export(tmp_path)
+    outside = tmp_path / "outside.onnx"
+    outside.write_bytes(b"outside")
+    (root / "model.onnx").unlink()
+    (root / "model.onnx").symlink_to(outside)
+    with pytest.raises(ExportConfigError, match="outside the export directory"):
+        validate_tether_config(payload, root=root)

--- a/tests/test_export_mode.py
+++ b/tests/test_export_mode.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.export_config_factory import write_test_onnx
+
 import tether.exporters.decomposed as decomposed
 from tether.exporters._export_mode import (
     ExportMode,
@@ -214,13 +216,13 @@ def test_pi05_decomposed_sequential_reuses_single_policy(monkeypatch, tmp_path):
     def fake_prefix_pass(policy_arg, output_dir, past_kv_names):
         assert policy_arg is policy
         pass_order.append("prefix")
-        (output_dir / "vlm_prefix.onnx").write_bytes(b"prefix")
+        write_test_onnx(output_dir / "vlm_prefix.onnx", action_dim=32)
         return {"chunk_size": 50, "action_dim": 32, "prefix_seq_len": 968}
 
     def fake_expert_pass(**kwargs):
         assert kwargs["policy"] is policy
         pass_order.append("expert")
-        (kwargs["output_dir"] / "expert_denoise.onnx").write_bytes(b"expert")
+        write_test_onnx(kwargs["output_dir"] / "expert_denoise.onnx", action_dim=32)
         return {"chunk_size": 50, "action_dim": 32, "prefix_seq_len": 968}
 
     monkeypatch.setattr(decomposed, "_load_pi05_policy", fake_load_policy)
@@ -302,8 +304,8 @@ def test_run_parallel_pi05_exports_submits_both_workers(monkeypatch, tmp_path):
 
 
 def test_write_decomposed_result_records_export_mode(tmp_path):
-    (tmp_path / "vlm_prefix.onnx").write_bytes(b"prefix")
-    (tmp_path / "expert_denoise.onnx").write_bytes(b"expert")
+    write_test_onnx(tmp_path / "vlm_prefix.onnx", action_dim=32)
+    write_test_onnx(tmp_path / "expert_denoise.onnx", action_dim=32)
 
     result = decomposed._write_decomposed_export_result(
         model_id="lerobot/pi05_libero_finetuned_v044",

--- a/tests/test_latency_and_determinism.py
+++ b/tests/test_latency_and_determinism.py
@@ -12,24 +12,21 @@ TetherServer so we don't need ONNX runtime or a real export.
 """
 from __future__ import annotations
 
-import json
 
 import pytest
+
+from tests.export_config_factory import write_test_export_config
 
 
 @pytest.fixture
 def stub_export_dir(tmp_path):
     """Minimal export dir — tether_config.json + stub onnx file."""
-    cfg = {
-        "model_id": "lerobot/smolvla_base",
-        "model_type": "smolvla",
-        "target": "desktop",
-        "action_chunk_size": 50,
-        "action_dim": 32,
-        "expert": {"expert_hidden": 720, "action_dim": 32, "num_layers": 16},
-    }
-    (tmp_path / "tether_config.json").write_text(json.dumps(cfg))
-    (tmp_path / "model.onnx").write_bytes(b"\x00\x01\x02\x03")
+    write_test_export_config(
+        tmp_path,
+        model_type="smolvla",
+        action_chunk_size=50,
+        expert={"expert_hidden": 720, "action_dim": 32, "num_layers": 16},
+    )
     return tmp_path
 
 

--- a/tests/test_policy_versioning_cli.py
+++ b/tests/test_policy_versioning_cli.py
@@ -14,6 +14,7 @@ import pytest
 from typer.testing import CliRunner
 
 from tether.cli import app
+from tests.export_config_factory import write_test_export_config
 
 
 runner = CliRunner()
@@ -23,8 +24,7 @@ runner = CliRunner()
 def fake_export(tmp_path):
     p = tmp_path / "export"
     p.mkdir()
-    (p / "model.onnx").write_bytes(b"fake")
-    (p / "tether_config.json").write_text("{}")
+    write_test_export_config(p, model_type="smolvla", action_dim=7)
     return p
 
 
@@ -32,8 +32,7 @@ def fake_export(tmp_path):
 def fake_export_b(tmp_path):
     p = tmp_path / "export_b"
     p.mkdir()
-    (p / "model.onnx").write_bytes(b"fake")
-    (p / "tether_config.json").write_text("{}")
+    write_test_export_config(p, model_type="smolvla", action_dim=7)
     return p
 
 
@@ -170,8 +169,7 @@ def test_shadow_policy_surfaces_active_banner(fake_export, tmp_path, monkeypatch
     active shadow-rollout banner before handing off to uvicorn."""
     shadow = tmp_path / "shadow"
     shadow.mkdir()
-    (shadow / "model.onnx").write_bytes(b"fake")
-    (shadow / "tether_config.json").write_text("{}")
+    write_test_export_config(shadow, model_type="smolvla", action_dim=7)
     monkeypatch.setitem(
         sys.modules,
         "onnxruntime",

--- a/tests/test_pro_serve_integration.py
+++ b/tests/test_pro_serve_integration.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import threading
 import time
 from datetime import datetime, timedelta, timezone
@@ -13,16 +12,13 @@ import pytest
 
 from tether.pro.license import LicenseCorrupt, LicenseHeartbeatStale, issue_dev_license
 from tether.runtime import server as runtime_server
+from tests.export_config_factory import write_test_export_config
 
 
 def _export_dir(tmp_path):
     path = tmp_path / "export"
     path.mkdir()
-    (path / "model.onnx").write_bytes(b"stub")
-    (path / "tether_config.json").write_text(json.dumps({
-        "model_type": "gr00t",
-        "action_dim": 7,
-    }))
+    write_test_export_config(path, model_type="gr00t", action_dim=7)
     return path
 
 

--- a/tests/test_request_id_header.py
+++ b/tests/test_request_id_header.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from tests.export_config_factory import write_test_export_config
 
 
 class _StubServer:
@@ -34,6 +35,7 @@ def app(tmp_path, monkeypatch):
     monkeypatch.setattr(runtime_server, "TetherServer", _StubServer)
     export_dir = tmp_path / "export"
     export_dir.mkdir()
+    write_test_export_config(export_dir, model_type="gr00t", action_dim=7)
     app = runtime_server.create_app(str(export_dir), device="cpu")
 
     @app.get("/_test/request-id")

--- a/tests/test_runtime_num_steps_10.py
+++ b/tests/test_runtime_num_steps_10.py
@@ -24,6 +24,8 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
+from tests.export_config_factory import write_test_export_config
+
 
 def _mock_ort_session(input_names: list[str], output_shape: tuple = (1, 50, 32)):
     sess = MagicMock()
@@ -146,14 +148,13 @@ def test_pi05_server_uses_pi0_shape_without_state_input(tmp_path):
 def test_tether_server_uses_model_onnx_for_gr00t_monolithic(tmp_path, monkeypatch):
     from tether.runtime.server import TetherServer
 
-    (tmp_path / "model.onnx").write_bytes(b"fake")
-    (tmp_path / "tether_config.json").write_text(json.dumps({
-        "model_type": "gr00t",
-        "export_kind": "monolithic",
-        "chunk_size": 50,
-        "action_dim": 64,
-        "num_denoising_steps": 4,
-    }))
+    write_test_export_config(
+        tmp_path,
+        model_type="gr00t",
+        action_dim=64,
+        num_denoising_steps=4,
+        chunk_size=50,
+    )
 
     loaded = {}
 
@@ -182,16 +183,10 @@ def test_create_app_dispatch_monolithic(tmp_path, monkeypatch):
     from tether.runtime import server as server_module
 
     # Write a fake model.onnx + config so _find_onnx_path succeeds
-    (tmp_path / "model.onnx").write_bytes(b"fake")
-    (tmp_path / "tether_config.json").write_text(json.dumps({
-        "model_type": "smolvla",
-        "export_kind": "monolithic",
-        "num_denoising_steps": 10,
-    }))
+    write_test_export_config(tmp_path, model_type="smolvla")
 
     # Stub SmolVLAOnnxServer so we don't actually load the fake ONNX
     from tether.runtime import smolvla_onnx_server as smolvla_server_module
-    original_server_cls = smolvla_server_module.SmolVLAOnnxServer
     instances = []
 
     class StubSmolVLA:
@@ -208,6 +203,6 @@ def test_create_app_dispatch_monolithic(tmp_path, monkeypatch):
 
     monkeypatch.setattr(smolvla_server_module, "SmolVLAOnnxServer", StubSmolVLA)
 
-    app = server_module.create_app(str(tmp_path), device="cpu")
+    server_module.create_app(str(tmp_path), device="cpu")
     # The dispatch happened — we got a SmolVLA stub instance
     assert len(instances) >= 1, "create_app did not instantiate SmolVLAOnnxServer"

--- a/tests/test_serve_http_roundtrip.py
+++ b/tests/test_serve_http_roundtrip.py
@@ -16,12 +16,13 @@ from __future__ import annotations
 
 import base64
 import io
-import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+
+from tests.export_config_factory import write_test_export_config
 
 
 def _stub_ort_session(input_names: list[str], output_shape=(1, 50, 32)):
@@ -37,16 +38,13 @@ def _stub_ort_session(input_names: list[str], output_shape=(1, 50, 32)):
 def _make_export_dir(tmp_path: Path, model_type: str = "smolvla") -> Path:
     export_dir = tmp_path / "export"
     export_dir.mkdir()
-    (export_dir / "model.onnx").write_bytes(b"stub")
-    (export_dir / "tether_config.json").write_text(json.dumps({
-        "model_type": model_type,
-        "export_kind": "monolithic",
-        "num_denoising_steps": 10,
-        "chunk_size": 50,
-        "action_chunk_size": 50,
-        "action_dim": 32,
-        "max_state_dim": 32,
-    }))
+    write_test_export_config(
+        export_dir,
+        model_type=model_type,
+        chunk_size=50,
+        action_chunk_size=50,
+        max_state_dim=32,
+    )
     return export_dir
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,5 @@
 """Tests for the VLA inference server."""
 
-import json
 import time
 from unittest.mock import patch, MagicMock
 
@@ -8,23 +7,25 @@ import numpy as np
 import pytest
 
 from tether.runtime.server import TetherServer
+from tests.export_config_factory import write_test_export_config
 
 
 @pytest.fixture
 def mock_export_dir(tmp_path):
     """Create a mock export directory with config."""
-    config = {
-        "model_id": "lerobot/smolvla_base",
-        "target": "desktop",
-        "action_chunk_size": 50,
-        "expert": {
+    write_test_export_config(
+        tmp_path,
+        model_type="smolvla",
+        model_id="lerobot/smolvla_base",
+        export_kind="decomposed_onnx",
+        artifacts=["expert_stack.onnx"],
+        action_chunk_size=50,
+        expert={
             "expert_hidden": 720,
             "action_dim": 32,
             "num_layers": 16,
         },
-    }
-    config_path = tmp_path / "tether_config.json"
-    config_path.write_text(json.dumps(config))
+    )
     return tmp_path
 
 
@@ -44,9 +45,9 @@ class TestTetherServer:
         assert "error" in result
 
     def test_loads_with_missing_onnx(self, mock_export_dir):
-        server = TetherServer(mock_export_dir, device="cpu")
-        server.load()
-        assert not server.ready  # No ONNX file, so not ready
+        (mock_export_dir / "expert_stack.onnx").unlink()
+        with pytest.raises(ValueError, match="is missing"):
+            TetherServer(mock_export_dir, device="cpu")
 
 
 class TestTetherServerWithMockORT:
@@ -276,6 +277,108 @@ class TestCreateApp:
             assert app.title == "Tether VLA Server"
         except ImportError:
             pytest.skip("fastapi not installed")
+
+    def test_native_override_rejects_non_smolvla_layout(self, tmp_path, monkeypatch):
+        from tether.runtime.server import create_app
+
+        write_test_export_config(
+            tmp_path,
+            model_type="pi0",
+            export_kind="monolithic_onnx",
+            artifacts=["model.onnx"],
+        )
+        monkeypatch.setenv("TETHER_NATIVE", "1")
+
+        with pytest.raises(ValueError, match="requires a SmolVLA expert_stack"):
+            create_app(str(tmp_path), device="cpu")
+
+    def test_split_layout_dispatches_to_pi05_server(self, tmp_path, monkeypatch):
+        from tether.runtime.decomposed_server import Pi05DecomposedServer
+        from tether.runtime.server import create_app
+
+        monkeypatch.delenv("TETHER_NATIVE", raising=False)
+        write_test_export_config(
+            tmp_path,
+            model_type="pi05_decomposed",
+            export_kind="decomposed_onnx",
+            artifacts=["vlm_prefix.onnx", "expert_denoise.onnx"],
+        )
+
+        app = create_app(str(tmp_path), device="cpu")
+
+        assert isinstance(app.state.tether_server, Pi05DecomposedServer)
+
+    def test_smolvla_full_bundle_dispatches_to_tether_server(self, tmp_path, monkeypatch):
+        from tether.runtime.server import TetherServer, create_app
+
+        monkeypatch.delenv("TETHER_NATIVE", raising=False)
+        write_test_export_config(
+            tmp_path,
+            model_type="smolvla",
+            export_kind="decomposed_onnx",
+            artifacts=[
+                "expert_stack.onnx",
+                "vision_encoder.onnx",
+                "text_embedder.onnx",
+                "decoder_prefill.onnx",
+            ],
+        )
+
+        app = create_app(str(tmp_path), device="cpu")
+
+        assert isinstance(app.state.tether_server, TetherServer)
+
+    def test_native_override_accepts_smolvla_full_bundle(self, tmp_path, monkeypatch):
+        from tether.runtime.server import create_app
+        from tether.runtime.smolvla_native import SmolVLANativeServer
+
+        monkeypatch.setenv("TETHER_NATIVE", "1")
+        write_test_export_config(
+            tmp_path,
+            model_type="smolvla",
+            export_kind="decomposed_onnx",
+            artifacts=[
+                "expert_stack.onnx",
+                "vision_encoder.onnx",
+                "text_embedder.onnx",
+                "decoder_prefill.onnx",
+            ],
+        )
+
+        app = create_app(str(tmp_path), device="cpu")
+
+        assert isinstance(app.state.tether_server, SmolVLANativeServer)
+
+    def test_monolithic_gr00t_dispatches_to_tether_server(self, tmp_path, monkeypatch):
+        from tether.runtime.server import TetherServer, create_app
+
+        monkeypatch.delenv("TETHER_NATIVE", raising=False)
+        write_test_export_config(
+            tmp_path,
+            model_type="gr00t",
+            export_kind="monolithic_onnx",
+            artifacts=["model.onnx"],
+        )
+
+        app = create_app(str(tmp_path), device="cpu")
+
+        assert isinstance(app.state.tether_server, TetherServer)
+
+    def test_custom_decomposed_pipeline_is_rejected(self, tmp_path, monkeypatch):
+        from tether.export_config import UnsupportedExportPipelineError
+        from tether.runtime.server import create_app
+
+        monkeypatch.delenv("TETHER_NATIVE", raising=False)
+        write_test_export_config(
+            tmp_path,
+            model_type="pi0",
+            export_kind="decomposed_onnx",
+            artifacts=["expert_stack.onnx"],
+            pipeline="prefix_optimum + expert_custom",
+        )
+
+        with pytest.raises(UnsupportedExportPipelineError, match="unsupported decomposed"):
+            create_app(str(tmp_path), device="cpu")
 
 
 class TestStrictProviderMode:

--- a/tests/test_shadow_rollout.py
+++ b/tests/test_shadow_rollout.py
@@ -7,20 +7,23 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
+from tests.export_config_factory import write_test_export_config
+
 
 def _make_export_dir(tmp_path: Path, name: str) -> Path:
     export_dir = tmp_path / name
     export_dir.mkdir()
-    (export_dir / "model.onnx").write_bytes(b"stub")
-    (export_dir / "tether_config.json").write_text(json.dumps({
-        "model_type": "smolvla",
-        "export_kind": "monolithic",
-        "num_denoising_steps": 1,
-        "chunk_size": 2,
-        "action_chunk_size": 2,
-        "action_dim": 2,
-        "max_state_dim": 4,
-    }))
+    write_test_export_config(
+        export_dir,
+        model_type="smolvla",
+        export_kind="monolithic_onnx",
+        artifacts=["model.onnx"],
+        num_denoising_steps=1,
+        action_dim=2,
+        chunk_size=2,
+        action_chunk_size=2,
+        max_state_dim=4,
+    )
     return export_dir
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -15,10 +15,46 @@ from tether.smoke import (
 )
 
 
-def test_create_smoke_export_has_model_config_and_tokenizer(tmp_path):
-    pytest.importorskip("onnx")
-    pytest.importorskip("tokenizers")
-    pytest.importorskip("transformers")
+def _install_fake_tokenizer_dependencies(monkeypatch):
+    import numpy as np
+
+    onnx = pytest.importorskip("onnx")
+
+    class Tokenizer:
+        def __init__(self, _model):
+            self.pre_tokenizer = None
+
+    class WordLevel:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    class Whitespace:
+        pass
+
+    class PreTrainedTokenizerFast:
+        def __init__(self, **_kwargs):
+            pass
+
+        def save_pretrained(self, directory):
+            target = directory / "tokenizer.json"
+            target.write_text("{}")
+            return (str(target),)
+
+    monkeypatch.setattr(
+        "tether.smoke._require_smoke_export_deps",
+        lambda: (
+            np,
+            onnx,
+            Tokenizer,
+            WordLevel,
+            Whitespace,
+            PreTrainedTokenizerFast,
+        ),
+    )
+
+
+def test_create_smoke_export_has_model_config_and_tokenizer(tmp_path, monkeypatch):
+    _install_fake_tokenizer_dependencies(monkeypatch)
 
     export_dir = create_smoke_export(tmp_path / "export")
 
@@ -30,7 +66,25 @@ def test_create_smoke_export_has_model_config_and_tokenizer(tmp_path):
     assert config["smoke_export"] is True
     assert config["chunk_size"] == 50
     assert config["action_dim"] == 32
+    assert config["export_kind"] == "monolithic_onnx"
+    assert {item["path"] for item in config["artifacts"]} >= {
+        "model.onnx",
+        "tokenizer/tokenizer.json",
+    }
+    assert "stale.onnx" not in {item["path"] for item in config["artifacts"]}
     assert find_bundled_tokenizer_path(export_dir, config) == export_dir / "tokenizer"
+
+
+def test_smoke_export_does_not_manifest_stale_files(tmp_path, monkeypatch):
+    _install_fake_tokenizer_dependencies(monkeypatch)
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    (export_dir / "stale.onnx").write_bytes(b"stale")
+
+    create_smoke_export(export_dir)
+
+    config = json.loads((export_dir / "tether_config.json").read_text())
+    assert "stale.onnx" not in {item["path"] for item in config["artifacts"]}
 
 
 def test_smoke_formatters_report_key_receipt_fields():

--- a/tests/test_validate_roundtrip.py
+++ b/tests/test_validate_roundtrip.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 import torch
 
-from tether import _onnx_backend, _pytorch_backend, validate_roundtrip
+from tether import validate_roundtrip
 from tether.ci_template import emit_ci_template
 from tether.fixtures.vla_fixtures import load_fixtures
 from tether.validate_roundtrip import (
@@ -37,12 +37,23 @@ def _write_min_config(
 ) -> Path:
     """Write a minimal tether_config.json for orchestrator tests."""
     export_dir.mkdir(parents=True, exist_ok=True)
+    (export_dir / "expert_stack.onnx").write_bytes(b"test fixture")
     config = {
+        "schema_version": 1,
         "model_type": model_type,
         "model_id": "stub/none",
+        "export_kind": "decomposed_onnx",
         "action_chunk_size": chunk_size,
         "action_dim": action_dim,
         "num_denoising_steps": num_steps,
+        "opset": 17,
+        "artifacts": [{"path": "expert_stack.onnx", "role": "model"}],
+        "io_contract": {
+            "inputs": [{"name": "noise", "dtype": "float32", "shape": [1, chunk_size, action_dim]}],
+            "outputs": [
+                {"name": "actions", "dtype": "float32", "shape": [1, chunk_size, action_dim]}
+            ],
+        },
     }
     if extras:
         config.update(extras)
@@ -81,12 +92,8 @@ def _patch_backends(
 
     # Patch at the validate_roundtrip module level — that's where the
     # orchestrator imports the loaders from.
-    monkeypatch.setattr(
-        validate_roundtrip, "load_pytorch_backend", fake_load_pytorch
-    )
-    monkeypatch.setattr(
-        validate_roundtrip, "load_onnx_backend", fake_load_onnx
-    )
+    monkeypatch.setattr(validate_roundtrip, "load_pytorch_backend", fake_load_pytorch)
+    monkeypatch.setattr(validate_roundtrip, "load_onnx_backend", fake_load_onnx)
     return pt_stub, onnx_stub
 
 
@@ -150,9 +157,7 @@ def test_threshold_pass(tmp_path, monkeypatch):
     out = np.zeros((50, 6), dtype=np.float32)
     _patch_backends(monkeypatch, pytorch_out=out, onnx_out=out)
 
-    harness = ValidateRoundTrip(
-        export_dir=tmp_path, num_test_cases=2, seed=0, threshold=1e-4
-    )
+    harness = ValidateRoundTrip(export_dir=tmp_path, num_test_cases=2, seed=0, threshold=1e-4)
     result = harness.run()
 
     assert result["summary"]["passed"] is True
@@ -168,9 +173,7 @@ def test_threshold_fail(tmp_path, monkeypatch):
     onnx_out = np.ones((50, 6), dtype=np.float32)
     _patch_backends(monkeypatch, pytorch_out=pt_out, onnx_out=onnx_out)
 
-    harness = ValidateRoundTrip(
-        export_dir=tmp_path, num_test_cases=2, seed=0, threshold=1e-4
-    )
+    harness = ValidateRoundTrip(export_dir=tmp_path, num_test_cases=2, seed=0, threshold=1e-4)
     result = harness.run()
 
     assert result["summary"]["passed"] is False
@@ -184,40 +187,19 @@ def test_threshold_fail_then_pass_with_loose_threshold(tmp_path, monkeypatch):
     onnx_out = np.full((50, 6), 1e-5, dtype=np.float32)
     _patch_backends(monkeypatch, pytorch_out=pt_out, onnx_out=onnx_out)
 
-    strict = ValidateRoundTrip(
-        export_dir=tmp_path, num_test_cases=1, seed=0, threshold=1e-7
-    ).run()
-    loose = ValidateRoundTrip(
-        export_dir=tmp_path, num_test_cases=1, seed=0, threshold=1e-3
-    ).run()
+    strict = ValidateRoundTrip(export_dir=tmp_path, num_test_cases=1, seed=0, threshold=1e-7).run()
+    loose = ValidateRoundTrip(export_dir=tmp_path, num_test_cases=1, seed=0, threshold=1e-3).run()
 
     assert strict["summary"]["passed"] is False
     assert loose["summary"]["passed"] is True
 
 
 def test_missing_onnx_error(tmp_path, monkeypatch):
-    """Export dir with config but no ONNX file → FileNotFoundError on run().
-
-    Stub the PyTorch loader so we exercise only the ONNX-missing path
-    (loading a real checkpoint would hit the network and is out of scope).
-    """
+    """A declared but missing ONNX artifact fails before backend construction."""
     _write_min_config(tmp_path)
-    # No expert_stack.onnx written.
-
-    pt_stub = _StubBackend(np.zeros((50, 6), dtype=np.float32))
-    monkeypatch.setattr(
-        validate_roundtrip,
-        "load_pytorch_backend",
-        lambda export_dir, model_id, device: pt_stub,
-    )
-    # Leave load_onnx_backend un-patched — the real loader should raise
-    # FileNotFoundError because expert_stack.onnx is absent.
-
-    harness = ValidateRoundTrip(
-        export_dir=tmp_path, num_test_cases=1, seed=0
-    )
-    with pytest.raises(FileNotFoundError):
-        harness.run()
+    (tmp_path / "expert_stack.onnx").unlink()
+    with pytest.raises(ValueError, match="is missing"):
+        ValidateRoundTrip(export_dir=tmp_path, num_test_cases=1, seed=0)
 
 
 def test_unsupported_model_raises_pi05(tmp_path):
@@ -270,14 +252,10 @@ def test_seed_bridge_in_orchestrator(tmp_path, monkeypatch):
     out = np.zeros((50, 6), dtype=np.float32)
 
     pt1, onnx1 = _patch_backends(monkeypatch, pytorch_out=out, onnx_out=out)
-    ValidateRoundTrip(
-        export_dir=tmp_path, num_test_cases=2, seed=123
-    ).run()
+    ValidateRoundTrip(export_dir=tmp_path, num_test_cases=2, seed=123).run()
 
     pt2, onnx2 = _patch_backends(monkeypatch, pytorch_out=out, onnx_out=out)
-    ValidateRoundTrip(
-        export_dir=tmp_path, num_test_cases=2, seed=123
-    ).run()
+    ValidateRoundTrip(export_dir=tmp_path, num_test_cases=2, seed=123).run()
 
     # PyTorch and ONNX backends must have received the identical noise array
     # within a single run.

--- a/tests/test_validate_roundtrip.py
+++ b/tests/test_validate_roundtrip.py
@@ -92,8 +92,12 @@ def _patch_backends(
 
     # Patch at the validate_roundtrip module level — that's where the
     # orchestrator imports the loaders from.
-    monkeypatch.setattr(validate_roundtrip, "load_pytorch_backend", fake_load_pytorch)
-    monkeypatch.setattr(validate_roundtrip, "load_onnx_backend", fake_load_onnx)
+    monkeypatch.setattr(
+        validate_roundtrip, "load_pytorch_backend", fake_load_pytorch
+    )
+    monkeypatch.setattr(
+        validate_roundtrip, "load_onnx_backend", fake_load_onnx
+    )
     return pt_stub, onnx_stub
 
 
@@ -157,7 +161,9 @@ def test_threshold_pass(tmp_path, monkeypatch):
     out = np.zeros((50, 6), dtype=np.float32)
     _patch_backends(monkeypatch, pytorch_out=out, onnx_out=out)
 
-    harness = ValidateRoundTrip(export_dir=tmp_path, num_test_cases=2, seed=0, threshold=1e-4)
+    harness = ValidateRoundTrip(
+        export_dir=tmp_path, num_test_cases=2, seed=0, threshold=1e-4
+    )
     result = harness.run()
 
     assert result["summary"]["passed"] is True
@@ -173,7 +179,9 @@ def test_threshold_fail(tmp_path, monkeypatch):
     onnx_out = np.ones((50, 6), dtype=np.float32)
     _patch_backends(monkeypatch, pytorch_out=pt_out, onnx_out=onnx_out)
 
-    harness = ValidateRoundTrip(export_dir=tmp_path, num_test_cases=2, seed=0, threshold=1e-4)
+    harness = ValidateRoundTrip(
+        export_dir=tmp_path, num_test_cases=2, seed=0, threshold=1e-4
+    )
     result = harness.run()
 
     assert result["summary"]["passed"] is False
@@ -187,8 +195,12 @@ def test_threshold_fail_then_pass_with_loose_threshold(tmp_path, monkeypatch):
     onnx_out = np.full((50, 6), 1e-5, dtype=np.float32)
     _patch_backends(monkeypatch, pytorch_out=pt_out, onnx_out=onnx_out)
 
-    strict = ValidateRoundTrip(export_dir=tmp_path, num_test_cases=1, seed=0, threshold=1e-7).run()
-    loose = ValidateRoundTrip(export_dir=tmp_path, num_test_cases=1, seed=0, threshold=1e-3).run()
+    strict = ValidateRoundTrip(
+        export_dir=tmp_path, num_test_cases=1, seed=0, threshold=1e-7
+    ).run()
+    loose = ValidateRoundTrip(
+        export_dir=tmp_path, num_test_cases=1, seed=0, threshold=1e-3
+    ).run()
 
     assert strict["summary"]["passed"] is False
     assert loose["summary"]["passed"] is True
@@ -252,10 +264,14 @@ def test_seed_bridge_in_orchestrator(tmp_path, monkeypatch):
     out = np.zeros((50, 6), dtype=np.float32)
 
     pt1, onnx1 = _patch_backends(monkeypatch, pytorch_out=out, onnx_out=out)
-    ValidateRoundTrip(export_dir=tmp_path, num_test_cases=2, seed=123).run()
+    ValidateRoundTrip(
+        export_dir=tmp_path, num_test_cases=2, seed=123
+    ).run()
 
     pt2, onnx2 = _patch_backends(monkeypatch, pytorch_out=out, onnx_out=out)
-    ValidateRoundTrip(export_dir=tmp_path, num_test_cases=2, seed=123).run()
+    ValidateRoundTrip(
+        export_dir=tmp_path, num_test_cases=2, seed=123
+    ).run()
 
     # PyTorch and ONNX backends must have received the identical noise array
     # within a single run.

--- a/tests/test_vlm_prefix.py
+++ b/tests/test_vlm_prefix.py
@@ -15,11 +15,14 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from tests.export_config_factory import write_test_export_config
 import torch
 
 from tether.exporters.vlm_prefix_exporter import (
     DEFAULT_VLM_KV_DIM,
+    _update_vlm_manifest,
 )
+from tether.export_config import build_producer_config, load_tether_config, write_tether_config
 from tether.runtime.vlm_components import (
     HIDDEN_SIZE,
     MAX_STATE_DIM,
@@ -82,45 +85,46 @@ def tiny_expert_stack():
 @pytest.fixture
 def v02_export_dir(tmp_path):
     """Create a mock v0.2+ export dir with VLM ONNX files."""
-    config = {
-        "model_id": "lerobot/smolvla_base",
-        "target": "desktop",
-        "action_chunk_size": 10,
-        "export_version": "0.3",
-        "vlm_prefix_onnx": "vision_encoder.onnx",
-        "vlm_image_size": [512, 512],
-        "vlm_kv_dim": 960,
-        "vlm_prefix_seq_len": 50,
-        "expert": {
+    write_test_export_config(
+        tmp_path,
+        model_type="smolvla",
+        export_kind="decomposed_onnx",
+        artifacts=[
+            "expert_stack.onnx",
+            "vision_encoder.onnx",
+            "text_embedder.onnx",
+            "decoder_prefill.onnx",
+        ],
+        action_chunk_size=10,
+        export_version="0.3",
+        vlm_prefix_onnx="vision_encoder.onnx",
+        vlm_image_size=[512, 512],
+        vlm_kv_dim=960,
+        vlm_prefix_seq_len=50,
+        expert={
             "expert_hidden": 720,
             "action_dim": 32,
             "num_layers": 16,
         },
-    }
-    (tmp_path / "tether_config.json").write_text(json.dumps(config))
-    # Create placeholder ONNX files (real loading is mocked)
-    (tmp_path / "expert_stack.onnx").write_bytes(b"fake-onnx")
-    (tmp_path / "vision_encoder.onnx").write_bytes(b"fake-onnx")
-    (tmp_path / "text_embedder.onnx").write_bytes(b"fake-onnx")
-    (tmp_path / "decoder_prefill.onnx").write_bytes(b"fake-onnx")
+    )
     return tmp_path
 
 
 @pytest.fixture
 def v01_export_dir(tmp_path):
     """Create a mock v0.1 export dir (no vlm_prefix)."""
-    config = {
-        "model_id": "lerobot/smolvla_base",
-        "target": "desktop",
-        "action_chunk_size": 10,
-        "expert": {
+    write_test_export_config(
+        tmp_path,
+        model_type="smolvla",
+        export_kind="decomposed_onnx",
+        artifacts=["expert_stack.onnx"],
+        action_chunk_size=10,
+        expert={
             "expert_hidden": 720,
             "action_dim": 32,
             "num_layers": 16,
         },
-    }
-    (tmp_path / "tether_config.json").write_text(json.dumps(config))
-    (tmp_path / "expert_stack.onnx").write_bytes(b"fake-onnx")
+    )
     return tmp_path
 
 
@@ -423,6 +427,93 @@ class TestVLMPrefixExporterUpdatesConfig:
         # Original fields preserved
         assert updated_config["model_id"] == "lerobot/smolvla_base"
         assert updated_config["expert"]["action_dim"] == 32
+
+    def test_manifest_rebuild_tracks_external_data_and_drops_stale_owned_entries(
+        self, tmp_path
+    ):
+        onnx = pytest.importorskip("onnx")
+        from onnx import numpy_helper
+
+        from tests.export_config_factory import write_test_onnx
+
+        write_test_onnx(tmp_path / "expert_stack.onnx")
+        base = build_producer_config(
+            tmp_path,
+            producer="expert_stack",
+            model_id="org/smolvla",
+            model_type="smolvla",
+            action_dim=7,
+            num_denoising_steps=10,
+            opset=19,
+        )
+        write_tether_config(tmp_path, base)
+
+        source = onnx.helper.make_tensor_value_info(
+            "input", onnx.TensorProto.FLOAT, [1, 7]
+        )
+        target = onnx.helper.make_tensor_value_info(
+            "output", onnx.TensorProto.FLOAT, [1, 7]
+        )
+        weight = numpy_helper.from_array(np.ones((1, 7), dtype=np.float32), name="weight")
+        graph = onnx.helper.make_graph(
+            [onnx.helper.make_node("Add", ["input", "weight"], ["output"])],
+            "vision",
+            [source],
+            [target],
+            [weight],
+        )
+        model = onnx.helper.make_model(
+            graph, opset_imports=[onnx.helper.make_opsetid("", 19)]
+        )
+        onnx.save_model(
+            model,
+            tmp_path / "vision_encoder.onnx",
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="vision_encoder.onnx.data",
+            size_threshold=0,
+        )
+        write_test_onnx(tmp_path / "text_embedder.onnx")
+        write_test_onnx(tmp_path / "decoder_prefill.onnx")
+
+        _update_vlm_manifest(
+            tmp_path,
+            checkpoint_path_or_id="org/smolvla",
+            image_size=512,
+            vlm_hidden_size=960,
+            vlm_kv_dim=320,
+        )
+        first = load_tether_config(tmp_path)
+        first_roles = {item["path"]: item["role"] for item in first["artifacts"]}
+        assert first_roles["vision_encoder.onnx.data"] == "weights"
+        assert first["extensions"]["artifact_owners"]["smolvla_vlm"] == [
+            "vision_encoder.onnx",
+            "text_embedder.onnx",
+            "decoder_prefill.onnx",
+            "vision_encoder.onnx.data",
+        ]
+
+        # A rerun now emits an inline graph. The prior external data and any
+        # other path recorded as VLM-owned must disappear from the manifest.
+        write_test_onnx(tmp_path / "vision_encoder.onnx")
+        stale = tmp_path / "old-vlm-weights.bin"
+        stale.write_bytes(b"stale")
+        first["artifacts"].append({"path": stale.name, "role": "weights"})
+        first["extensions"]["artifact_owners"]["smolvla_vlm"].append(stale.name)
+        write_tether_config(tmp_path, first)
+
+        _update_vlm_manifest(
+            tmp_path,
+            checkpoint_path_or_id="org/smolvla",
+            image_size=512,
+            vlm_hidden_size=960,
+            vlm_kv_dim=320,
+        )
+        second = load_tether_config(tmp_path)
+        second_paths = {item["path"] for item in second["artifacts"]}
+        assert "expert_stack.onnx" in second_paths
+        assert "vision_encoder.onnx.data" not in second_paths
+        assert stale.name not in second_paths
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #269

## What changed
- adds strict Export Config v1 validation, atomic writes, safe legacy normalization, artifact path/digest checks, and explicit layout classification
- migrates all enumerated exporters plus smoke/VLM augmentation to canonical explicit manifests
- routes supported expert-stack, Pi0.5 split, monolithic GR00T, and exact SmolVLA full-bundle layouts without guessing; unsupported/custom layouts fail explicitly
- fixes GR00T raw action dimensions, DreamZero config-only metadata, legacy kind/step derivation, external ONNX data ownership, and stale-manifest cleanup
- adds producer-derived compatibility tests with real ONNX Runtime and PyTorch reader execution

## Validation
- independent review: APPROVE after four review rounds
- 165 focused tests passed, 2 skipped in final review
- changed semantic files/tests pass Ruff; existing CLI/server/replay lint debt is unchanged from main
- compile and git diff checks pass

No production deployment or external model/GPU execution is part of this PR.