### PR TITLE
fix: verify the actual exported inference artifact

### DIFF
--- a/.github/workflows/verify-artifact-receipt.yml
+++ b/.github/workflows/verify-artifact-receipt.yml
@@ -1,0 +1,42 @@
+name: Verify artifact execution receipt
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/tether/runtime/verify_inference.py"
+      - "src/tether/verify.py"
+      - "src/tether/smoke.py"
+      - "scripts/verify_artifact_receipt.py"
+      - ".github/workflows/verify-artifact-receipt.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  execute-export:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install runtime
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[onnx,serve]"
+      - name: Execute generated export
+        run: python scripts/verify_artifact_receipt.py --output verify-artifact-receipt.json
+      - name: Upload provenance receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-artifact-receipt-${{ github.sha }}
+          path: verify-artifact-receipt.json
+          if-no-files-found: error
+          retention-days: 90

--- a/scripts/verify_artifact_receipt.py
+++ b/scripts/verify_artifact_receipt.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Execute a real generated export and write a provenance receipt for #267."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import tempfile
+
+import numpy as np
+
+from tether.runtime.verify_inference import load_verification_inference
+from tether.smoke import create_smoke_export
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_smoke_actions(actions: np.ndarray, noise: np.ndarray) -> None:
+    """Fail the workflow unless the generated Constant export truly executed."""
+    expected = np.zeros_like(noise)
+    if not np.array_equal(actions, expected):
+        raise RuntimeError("smoke export actions do not match its declared constant graph")
+
+
+def build_receipt(output: Path) -> dict[str, object]:
+    event_name = os.environ.get("GITHUB_EVENT_NAME")
+    ref = os.environ.get("GITHUB_REF")
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        if event_name not in {"push", "workflow_dispatch"}:
+            raise RuntimeError(f"receipt event is not allowlisted: {event_name!r}")
+        if ref != "refs/heads/main":
+            raise RuntimeError(f"receipt must execute from protected main, got {ref!r}")
+        if os.environ.get("GITHUB_REF_PROTECTED") != "true":
+            raise RuntimeError("main is not reported as a protected ref")
+    with tempfile.TemporaryDirectory(prefix="tether-verify-artifact-") as temporary:
+        export_dir = create_smoke_export(Path(temporary) / "export")
+        inference = load_verification_inference(export_dir, device="cpu")
+        noise = np.arange(50 * 32, dtype=np.float32).reshape(1, 50, 32)
+        image = np.zeros((1, 3, 512, 512), dtype=np.float32)
+        mask = np.ones((1,), dtype=np.bool_)
+        actions = inference.predict_action_chunk(
+            img_base=image,
+            img_wrist_l=image,
+            img_wrist_r=image,
+            mask_base=mask,
+            mask_wrist_l=mask,
+            mask_wrist_r=mask,
+            lang_tokens=np.zeros((1, 16), dtype=np.int64),
+            lang_masks=np.ones((1, 16), dtype=np.bool_),
+            noise=noise,
+            state=np.zeros((1, 32), dtype=np.float32),
+            episode_id="receipt",
+        )
+        if actions.shape != noise.shape:
+            raise RuntimeError(f"unexpected action shape {actions.shape}; expected {noise.shape}")
+        _validate_smoke_actions(actions, noise)
+        receipt: dict[str, object] = {
+            "schema_version": 1,
+            "kind": "tether.verify_artifact_execution",
+            "source_sha": os.environ.get("GITHUB_SHA", "local"),
+            "workflow": os.environ.get("GITHUB_WORKFLOW", "local"),
+            "workflow_ref": os.environ.get("GITHUB_WORKFLOW_REF", "local"),
+            "repository": os.environ.get("GITHUB_REPOSITORY", "local"),
+            "event_name": event_name or "local",
+            "ref": ref or "local",
+            "run_id": os.environ.get("GITHUB_RUN_ID", "local"),
+            "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", "local"),
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "model_type": "smolvla",
+            "export_kind": "monolithic_onnx",
+            "backend": inference.get_stats().get("backend"),
+            "model_sha256": _sha256(export_dir / "model.onnx"),
+            "config_sha256": _sha256(export_dir / "tether_config.json"),
+            "actions_sha256": hashlib.sha256(actions.tobytes()).hexdigest(),
+            "python": platform.python_version(),
+            "passed": True,
+        }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    return receipt
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, default=Path("verify-artifact-receipt.json"))
+    args = parser.parse_args()
+    print(json.dumps(build_receipt(args.output), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tether/eval/libero_rollout.py
+++ b/src/tether/eval/libero_rollout.py
@@ -141,7 +141,6 @@ def run_libero_rollout(
     # Lazy imports — LIBERO + mujoco only needed at rollout time, not at module load.
     import collections
     import math
-    import time
     import traceback
     from pathlib import Path
 
@@ -450,12 +449,38 @@ def run_libero_rollout(
     return results
 
 
+def _load_exact_reference_policy(model_type: str, checkpoint: str) -> Any:
+    """Load the declared native family from the exact export provenance ref."""
+    import importlib
+
+    targets = {
+        "pi05": ("lerobot.policies.pi05.modeling_pi05", "PI05Policy"),
+        "pi05_decomposed": ("lerobot.policies.pi05.modeling_pi05", "PI05Policy"),
+        "pi0": ("lerobot.policies.pi0.modeling_pi0", "PI0Policy"),
+        "smolvla": ("lerobot.policies.smolvla.modeling_smolvla", "SmolVLAPolicy"),
+    }
+    if model_type == "pi05_decomposed_student":
+        module = importlib.import_module("tether.distill.snapflow_pi0_model")
+        return module.load_snapflow_student(checkpoint)
+    try:
+        module_name, class_name = targets[model_type]
+    except KeyError as exc:
+        raise ValueError(
+            f"unsupported native verification model_type={model_type!r}"
+        ) from exc
+    policy_class = getattr(importlib.import_module(module_name), class_name)
+    return policy_class.from_pretrained(checkpoint)
+
+
 def load_pi05_policy_and_processors(
     *,
     student_checkpoint: str,
     decomposed_dir: str,
     preprocessor_ref: str | None = None,
     force_teacher: bool = False,
+    model_type: str = "pi05",
+    require_exact_checkpoint: bool = False,
+    device: str = "cuda",
 ) -> tuple[Any, Any, Any]:
     """Load PyTorch policy (for config + _preprocess_images) + processor pipelines.
 
@@ -480,7 +505,10 @@ def load_pi05_policy_and_processors(
     )
 
     student_ckpt_path = Path(student_checkpoint)
-    if not force_teacher and (student_ckpt_path / "model.safetensors").exists():
+    if require_exact_checkpoint:
+        print(f"[load] Loading exact {model_type} reference from {student_checkpoint}")
+        policy = _load_exact_reference_policy(model_type, student_checkpoint)
+    elif not force_teacher and (student_ckpt_path / "model.safetensors").exists():
         print(f"[load] Loading SnapFlow student from {student_checkpoint}")
         from tether.distill.snapflow_pi0_model import load_snapflow_student
         policy = load_snapflow_student(student_checkpoint)
@@ -497,7 +525,7 @@ def load_pi05_policy_and_processors(
                 f"inference still runs through decomposed ONNX)"
             )
             policy = PI05Policy.from_pretrained(fallback)
-    policy.eval().to("cuda").to(torch.float32)
+    policy.eval().to(device).to(torch.float32)
 
     # Student-distillation checkpoints don't always ship the processor JSONs —
     # fall back to the teacher HF repo for baseline preprocessor + normalizer.
@@ -511,7 +539,7 @@ def load_pi05_policy_and_processors(
         config_filename="policy_preprocessor.json",
         to_transition=batch_to_transition,
         to_output=transition_to_batch,
-        overrides={"device_processor": {"device": "cuda"}},
+        overrides={"device_processor": {"device": device}},
     )
     postprocessor = PolicyProcessorPipeline.from_pretrained(
         pretrained_model_name_or_path=proc_ref,
@@ -532,7 +560,6 @@ def load_pi05_policy_and_processors(
         )
     if is_state_out_export:
         from tether.distill.pi05_state_out_processor import swap_prepare_step_in_pipeline
-        from lerobot.utils.constants import ACTION
         max_state_dim = policy.config.max_action_dim  # pi0.5: 32
         swap_prepare_step_in_pipeline(preprocessor, max_state_dim=max_state_dim)
         print(

--- a/src/tether/runtime/pi0_onnx_server.py
+++ b/src/tether/runtime/pi0_onnx_server.py
@@ -177,6 +177,7 @@ class Pi0OnnxServer:
         noise: np.ndarray | None = None,
         lang_tokens: np.ndarray | None = None,
         lang_masks: np.ndarray | None = None,
+        image_masks: list[np.ndarray] | None = None,
     ) -> dict[str, Any]:
         """Run one pi0 forward pass.
 
@@ -220,7 +221,12 @@ class Pi0OnnxServer:
         img_wrist_l = _prep_img(images_list[1])
         img_wrist_r = _prep_img(images_list[2])
 
-        mask = np.ones((1,), dtype=np.bool_)
+        masks_list = list(image_masks or [])
+        while len(masks_list) < 3:
+            masks_list.append(np.ones((1,), dtype=np.bool_))
+        mask_base, mask_wrist_l, mask_wrist_r = [
+            np.asarray(value, dtype=np.bool_).reshape(-1) for value in masks_list[:3]
+        ]
 
         # Lang: take externally-supplied tokens or tokenize the instruction
         if lang_tokens is None:
@@ -260,9 +266,9 @@ class Pi0OnnxServer:
             "img_base": img_base,
             "img_wrist_l": img_wrist_l,
             "img_wrist_r": img_wrist_r,
-            "mask_base": mask,
-            "mask_wrist_l": mask,
-            "mask_wrist_r": mask,
+            "mask_base": mask_base,
+            "mask_wrist_l": mask_wrist_l,
+            "mask_wrist_r": mask_wrist_r,
             "lang_tokens": lang_tokens,
             "lang_masks": lang_masks,
             "state": state_arr,

--- a/src/tether/runtime/smolvla_onnx_server.py
+++ b/src/tether/runtime/smolvla_onnx_server.py
@@ -175,6 +175,7 @@ class SmolVLAOnnxServer:
         noise: np.ndarray | None = None,
         lang_tokens: np.ndarray | None = None,
         lang_masks: np.ndarray | None = None,
+        image_masks: list[np.ndarray] | None = None,
     ) -> dict[str, Any]:
         """Run one SmolVLA forward pass. Accepts a single image or a list of 3."""
         if not self._ready:
@@ -207,7 +208,12 @@ class SmolVLAOnnxServer:
         img_cam2 = _prep_img(images_list[1])
         img_cam3 = _prep_img(images_list[2])
 
-        mask = np.ones((1,), dtype=np.bool_)
+        masks_list = list(image_masks or [])
+        while len(masks_list) < 3:
+            masks_list.append(np.ones((1,), dtype=np.bool_))
+        mask_cam1, mask_cam2, mask_cam3 = [
+            np.asarray(value, dtype=np.bool_).reshape(-1) for value in masks_list[:3]
+        ]
 
         # Lang: tokenize (SmolLM2 vocab ~49152) or use provided tokens
         if lang_tokens is None:
@@ -251,9 +257,9 @@ class SmolVLAOnnxServer:
             "img_cam1": img_cam1,
             "img_cam2": img_cam2,
             "img_cam3": img_cam3,
-            "mask_cam1": mask,
-            "mask_cam2": mask,
-            "mask_cam3": mask,
+            "mask_cam1": mask_cam1,
+            "mask_cam2": mask_cam2,
+            "mask_cam3": mask_cam3,
             "lang_tokens": lang_tokens,
             "lang_masks": lang_masks,
             "state": state_arr,

--- a/src/tether/runtime/verify_inference.py
+++ b/src/tether/runtime/verify_inference.py
@@ -1,0 +1,163 @@
+"""Load the exported artifact used by ``tether verify``.
+
+This module is intentionally fail-closed: verification never rebuilds an
+"optimized" runtime from native policy weights and never guesses that an
+unknown export layout is compatible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from tether.export_config import decomposed_layout, load_tether_config
+
+
+class UnsupportedVerificationBackend(RuntimeError):
+    """The export is valid, but no artifact-backed verifier supports it."""
+
+
+def _providers(device: str) -> list[str]:
+    if device.lower() == "cpu":
+        return ["CPUExecutionProvider"]
+    if device.lower() in {"cuda", "gpu"}:
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    raise UnsupportedVerificationBackend(f"unsupported verification device {device!r}")
+
+
+class MonolithicOnnxVerificationAdapter:
+    """Bridge a model-specific monolithic ONNX server to LIBERO inference."""
+
+    def __init__(self, server: Any) -> None:
+        self._server = server
+
+    def reset_cache(self) -> None:
+        return None
+
+    def get_stats(self) -> dict[str, Any]:
+        return {"backend": getattr(self._server, "_inference_mode", "monolithic_onnx")}
+
+    def predict_action_chunk(
+        self,
+        *,
+        img_base: Any,
+        img_wrist_l: Any,
+        img_wrist_r: Any,
+        mask_base: Any,
+        mask_wrist_l: Any,
+        mask_wrist_r: Any,
+        lang_tokens: Any,
+        lang_masks: Any,
+        noise: Any,
+        state: Any,
+        episode_id: str,
+    ) -> np.ndarray:
+        del episode_id
+        result = self._server.predict(
+            image=[img_base, img_wrist_l, img_wrist_r],
+            image_masks=[mask_base, mask_wrist_l, mask_wrist_r],
+            state=state,
+            noise=noise,
+            lang_tokens=np.asarray(lang_tokens),
+            lang_masks=np.asarray(lang_masks),
+        )
+        if "error" in result:
+            raise RuntimeError(f"exported monolithic inference failed: {result['error']}")
+        actions = np.asarray(result["actions"], dtype=np.float32)
+        return actions[None, ...] if actions.ndim == 2 else actions
+
+
+def _primary_model_artifact(config: dict[str, Any], root: Path) -> Path:
+    models = [
+        root / str(item["path"])
+        for item in config["artifacts"]
+        if item["role"] == "model" and str(item["path"]).endswith(".onnx")
+    ]
+    if len(models) != 1:
+        raise UnsupportedVerificationBackend(
+            "monolithic_onnx verification requires exactly one declared model ONNX artifact"
+        )
+    return models[0]
+
+
+def load_verification_inference(
+    export_dir: str | Path,
+    device: str = "cpu",
+) -> Any:
+    """Construct an inference object from the actual declared export artifacts."""
+    root = Path(export_dir)
+    config = load_tether_config(root, inspect_artifacts=True)
+    kind = config["export_kind"]
+    providers = _providers(device)
+
+    if kind == "monolithic_onnx":
+        onnx_path = _primary_model_artifact(config, root)
+        model_type = config["model_type"]
+        server: Any
+        if model_type == "pi0":
+            from tether.runtime.pi0_onnx_server import Pi0OnnxServer
+
+            server = Pi0OnnxServer(
+                root,
+                onnx_path=onnx_path,
+                providers=providers,
+                device=device,
+                strict_providers=True,
+            )
+        elif model_type == "smolvla":
+            from tether.runtime.smolvla_onnx_server import SmolVLAOnnxServer
+
+            server = SmolVLAOnnxServer(
+                root,
+                onnx_path=onnx_path,
+                providers=providers,
+                device=device,
+                strict_providers=True,
+            )
+        else:
+            raise UnsupportedVerificationBackend(
+                f"monolithic verifier does not support model_type={model_type!r}"
+            )
+        server.load()
+        return MonolithicOnnxVerificationAdapter(server)
+
+    if kind == "decomposed_onnx":
+        layout = decomposed_layout(config)
+        if layout == "pi05_split":
+            declared_models = {
+                str(item["path"]) for item in config["artifacts"] if item["role"] == "model"
+            }
+            decomposed = config.get("decomposed", {})
+            referenced_models = {
+                str(decomposed.get("vlm_prefix_onnx", "")),
+                str(decomposed.get("expert_denoise_onnx", "")),
+            }
+            if "" in referenced_models or referenced_models != declared_models:
+                raise UnsupportedVerificationBackend(
+                    "pi05_split secondary paths must exactly match the declared, "
+                    "integrity-checked model artifacts"
+                )
+            from tether.runtime.pi05_decomposed_server import Pi05DecomposedInference
+
+            return Pi05DecomposedInference(root, providers=providers)
+        if layout == "expert_stack":
+            raise UnsupportedVerificationBackend(
+                "expert_stack verification is disabled because that runtime does "
+                "not preserve image and language conditioning"
+            )
+        raise UnsupportedVerificationBackend(
+            f"decomposed verifier does not support layout={layout!r}"
+        )
+
+    raise UnsupportedVerificationBackend(
+        f"local verification does not support export_kind={kind!r}"
+    )
+
+
+__all__ = [
+    "MonolithicOnnxVerificationAdapter",
+    "UnsupportedVerificationBackend",
+    "load_verification_inference",
+]

--- a/src/tether/verify.py
+++ b/src/tether/verify.py
@@ -37,6 +37,7 @@ nothing. The scoring + aggregation layer is pure and fully mockable via the
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable
@@ -324,6 +325,7 @@ def gather_paired_samples(
     task_indices: list[int] | None,
     seed: int,
     preprocessor_ref: str | None = None,
+    verification_device: str = "cuda",
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Run the ORIGINAL (native PyTorch) and OPTIMIZED (ONNX/Triton) policies
     through the SAME LIBERO loop and return both rollout result dicts.
@@ -348,15 +350,21 @@ def gather_paired_samples(
         run_libero_rollout,
     )
 
-    # The "original" reference defaults to the same checkpoint as the export
-    # (native-PyTorch IS the reference for an export of itself). A caller may
-    # override --original to compare against a different baseline checkpoint.
-    original_checkpoint = original_ref or optimized_ref
+    from tether.export_config import load_tether_config
+
+    export_config = load_tether_config(optimized_ref, inspect_artifacts=True)
+    # The original reference comes from the export provenance unless the user
+    # explicitly selects a different baseline.  The export directory itself is
+    # never treated as a native checkpoint.
+    original_checkpoint = original_ref or str(export_config["model_id"])
 
     policy, preprocessor, postprocessor = load_pi05_policy_and_processors(
         student_checkpoint=original_checkpoint,
         decomposed_dir=optimized_ref,
         preprocessor_ref=preprocessor_ref,
+        model_type=str(export_config["model_type"]),
+        require_exact_checkpoint=True,
+        device=verification_device,
     )
 
     common = dict(
@@ -376,23 +384,13 @@ def gather_paired_samples(
         inference=None, use_native=True, label="ORIGINAL", **common,
     )
 
-    # ARM B — optimized: the exported ONNX/Triton inference object on the same
-    # loop. v0 uses the shipped Triton fast-kernels adapter
-    # (``TritonLIBEROAdapter``), which is exactly the optimized arm the proven
-    # side-by-side eval drives in scripts/modal_fast_kernels_l3_side_by_side.py.
-    # It builds the optimized runtime from the SAME policy weights, so the only
-    # difference between the two arms is the inference path (native vs Triton) —
-    # which is precisely the parity question.
-    #
-    # TODO(tether-verify): dispatch on the export's tether_config.json so a
-    # decomposed-ONNX export (Pi05DecomposedInference) or a future exporter
-    # (DreamZero, GR00T DiT) selects the matching InferenceProtocol object
-    # instead of always using the Triton adapter. v0 ships the Triton path
-    # because it is the one with a proven LIBERO adapter today.
-    logger.info("verify: running OPTIMIZED arm (Triton fast-kernels export)")
-    from tether.runtime.fast_inference.libero_adapter import TritonLIBEROAdapter
+    # ARM B — optimized: construct the runtime from the declared export files.
+    # Failure to load or support that artifact aborts verification; there is no
+    # native-weight fallback because that would make parity trivially pass.
+    logger.info("verify: loading and running OPTIMIZED export artifacts")
+    from tether.runtime.verify_inference import load_verification_inference
 
-    inference = TritonLIBEROAdapter.from_policy(policy)
+    inference = load_verification_inference(optimized_ref, device=verification_device)
     optimized_results = run_libero_rollout(
         inference=inference, use_native=False, label="OPTIMIZED", **common,
     )
@@ -439,10 +437,24 @@ def run_verify(
             f"{', '.join(SUPPORTED_SUITES)}."
         )
 
+    resolved_original_ref = original_ref
+    if resolved_original_ref is None:
+        config_path = Path(optimized_ref) / "tether_config.json"
+        if config_path.is_file():
+            from tether.export_config import load_tether_config
+
+            resolved_original_ref = str(
+                load_tether_config(optimized_ref, inspect_artifacts=True)["model_id"]
+            )
+        else:
+            # Synthetic gather functions used by callers may not have an export
+            # directory. Real verification always resolves from tether_config.
+            resolved_original_ref = optimized_ref
+
     gather = gather_fn or gather_paired_samples
     original_results, optimized_results = gather(
         optimized_ref=optimized_ref,
-        original_ref=original_ref,
+        original_ref=resolved_original_ref,
         suite=suite,
         task_suite_name=task_suite_name,
         num_episodes=num_episodes,
@@ -523,7 +535,7 @@ def run_verify(
         two_sample_episodes=n_cmp,
         eval_report=report,
         optimized_ref=optimized_ref,
-        original_ref=original_ref or optimized_ref,
+        original_ref=resolved_original_ref,
         suite=suite,
         target=target,
         n_episodes=len(candidate_samples),

--- a/tests/test_verify_artifact_loading.py
+++ b/tests/test_verify_artifact_loading.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tether.export_config import build_producer_config, write_tether_config
+from tether.runtime.verify_inference import (
+    MonolithicOnnxVerificationAdapter,
+    UnsupportedVerificationBackend,
+    load_verification_inference,
+)
+
+
+def _value_info(onnx, name: str, dtype: int, shape: list[int]):
+    return onnx.helper.make_tensor_value_info(name, dtype, shape)
+
+
+def _save_monolithic(root: Path) -> dict:
+    onnx = pytest.importorskip("onnx")
+    inputs = [
+        _value_info(onnx, name, onnx.TensorProto.FLOAT, [1, 3, 8, 8])
+        for name in ("img_base", "img_wrist_l", "img_wrist_r")
+    ]
+    inputs += [
+        _value_info(onnx, name, onnx.TensorProto.BOOL, [1])
+        for name in ("mask_base", "mask_wrist_l", "mask_wrist_r")
+    ]
+    inputs += [
+        _value_info(onnx, "lang_tokens", onnx.TensorProto.INT64, [1, 4]),
+        _value_info(onnx, "lang_masks", onnx.TensorProto.BOOL, [1, 4]),
+        _value_info(onnx, "state", onnx.TensorProto.FLOAT, [1, 2]),
+        _value_info(onnx, "noise", onnx.TensorProto.FLOAT, [1, 2, 2]),
+    ]
+    output = _value_info(onnx, "actions", onnx.TensorProto.FLOAT, [1, 2, 2])
+    graph = onnx.helper.make_graph(
+        [onnx.helper.make_node("Identity", ["noise"], ["actions"])],
+        "verify-monolithic",
+        inputs,
+        [output],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[onnx.helper.make_opsetid("", 17)],
+    )
+    model.ir_version = 8
+    onnx.save(model, root / "model.onnx")
+    config = build_producer_config(
+        root,
+        producer="monolithic",
+        model_id="org/native-reference",
+        model_type="pi0",
+        action_dim=2,
+        num_denoising_steps=1,
+        opset=17,
+        metadata={"chunk_size": 2, "action_chunk_size": 2, "max_state_dim": 2},
+    )
+    write_tether_config(root, config)
+    return config
+
+
+def _save_pi05_split(root: Path) -> dict:
+    onnx = pytest.importorskip("onnx")
+    image_inputs = [
+        _value_info(onnx, name, onnx.TensorProto.FLOAT, [1, 3, 8, 8])
+        for name in ("img_base", "img_wrist_l", "img_wrist_r")
+    ]
+    mask_inputs = [
+        _value_info(onnx, name, onnx.TensorProto.BOOL, [1])
+        for name in ("mask_base", "mask_wrist_l", "mask_wrist_r")
+    ]
+    prefix_inputs = (
+        image_inputs
+        + mask_inputs
+        + [
+            _value_info(onnx, "lang_tokens", onnx.TensorProto.INT64, [1, 4]),
+            _value_info(onnx, "lang_masks", onnx.TensorProto.BOOL, [1, 4]),
+        ]
+    )
+    prefix_outputs = [
+        _value_info(onnx, "past0", onnx.TensorProto.FLOAT, [1, 3, 8, 8]),
+        _value_info(onnx, "prefix_pad_masks", onnx.TensorProto.BOOL, [1]),
+    ]
+    prefix_graph = onnx.helper.make_graph(
+        [
+            onnx.helper.make_node("Identity", ["img_base"], ["past0"]),
+            onnx.helper.make_node("Identity", ["mask_base"], ["prefix_pad_masks"]),
+        ],
+        "verify-prefix",
+        prefix_inputs,
+        prefix_outputs,
+    )
+    prefix_model = onnx.helper.make_model(
+        prefix_graph,
+        opset_imports=[onnx.helper.make_opsetid("", 17)],
+    )
+    prefix_model.ir_version = 8
+    onnx.save(prefix_model, root / "vlm_prefix.onnx")
+
+    expert_inputs = [
+        _value_info(onnx, "past0", onnx.TensorProto.FLOAT, [1, 3, 8, 8]),
+        _value_info(onnx, "prefix_pad_masks", onnx.TensorProto.BOOL, [1]),
+        _value_info(onnx, "noise", onnx.TensorProto.FLOAT, [1, 2, 2]),
+    ]
+    expert_output = _value_info(onnx, "actions", onnx.TensorProto.FLOAT, [1, 2, 2])
+    expert_graph = onnx.helper.make_graph(
+        [onnx.helper.make_node("Identity", ["noise"], ["actions"])],
+        "verify-expert",
+        expert_inputs,
+        [expert_output],
+    )
+    expert_model = onnx.helper.make_model(
+        expert_graph,
+        opset_imports=[onnx.helper.make_opsetid("", 17)],
+    )
+    expert_model.ir_version = 8
+    onnx.save(expert_model, root / "expert_denoise.onnx")
+
+    config = build_producer_config(
+        root,
+        producer="pi05_split",
+        model_id="org/pi05-native",
+        model_type="pi05",
+        action_dim=2,
+        num_denoising_steps=1,
+        opset=17,
+        metadata={
+            "action_chunk_size": 2,
+            "decomposed": {
+                "vlm_prefix_onnx": "vlm_prefix.onnx",
+                "expert_denoise_onnx": "expert_denoise.onnx",
+                "past_kv_tensor_names": ["past0"],
+                "paligemma_layers": 1,
+                "per_step_expert": False,
+                "expert_takes_state": False,
+            },
+        },
+    )
+    write_tether_config(root, config)
+    return config
+
+
+def _protocol_inputs(noise: np.ndarray) -> dict:
+    image = np.zeros((1, 3, 8, 8), dtype=np.float32)
+    mask = np.ones((1,), dtype=np.bool_)
+    return {
+        "img_base": image,
+        "img_wrist_l": image,
+        "img_wrist_r": image,
+        "mask_base": mask,
+        "mask_wrist_l": mask,
+        "mask_wrist_r": mask,
+        "lang_tokens": np.zeros((1, 4), dtype=np.int64),
+        "lang_masks": np.ones((1, 4), dtype=np.bool_),
+        "noise": noise,
+        "state": np.zeros((1, 2), dtype=np.float32),
+        "episode_id": "episode-1",
+    }
+
+
+def test_monolithic_loader_executes_real_onnx_artifact(tmp_path):
+    pytest.importorskip("onnxruntime")
+    root = tmp_path / "monolithic"
+    root.mkdir()
+    _save_monolithic(root)
+    noise = np.arange(4, dtype=np.float32).reshape(1, 2, 2)
+
+    inference = load_verification_inference(root, device="cpu")
+    actions = inference.predict_action_chunk(**_protocol_inputs(noise))
+
+    np.testing.assert_array_equal(actions, noise)
+    assert inference.get_stats()["backend"] == "pi0_onnx_monolithic"
+
+
+def test_pi05_split_loader_executes_both_real_onnx_artifacts(tmp_path):
+    pytest.importorskip("onnxruntime")
+    root = tmp_path / "split"
+    root.mkdir()
+    _save_pi05_split(root)
+    noise = np.arange(4, dtype=np.float32).reshape(1, 2, 2)
+
+    inference = load_verification_inference(root, device="cpu")
+    actions = inference.predict_action_chunk(**_protocol_inputs(noise))
+
+    np.testing.assert_array_equal(actions, noise)
+    assert inference.get_stats()["misses"] == 1
+
+
+def test_monolithic_adapter_preserves_false_camera_masks():
+    calls = {}
+
+    class Server:
+        def predict(self, **kwargs):
+            calls.update(kwargs)
+            return {"actions": np.zeros((1, 2, 2), dtype=np.float32)}
+
+    inputs = _protocol_inputs(np.zeros((1, 2, 2), dtype=np.float32))
+    inputs["mask_wrist_r"] = np.zeros((1,), dtype=np.bool_)
+    MonolithicOnnxVerificationAdapter(Server()).predict_action_chunk(**inputs)
+
+    assert bool(calls["image_masks"][0][0]) is True
+    assert bool(calls["image_masks"][2][0]) is False
+
+
+def test_pi05_secondary_paths_must_match_hashed_manifest(tmp_path):
+    root = tmp_path / "split-path-swap"
+    root.mkdir()
+    config = _save_pi05_split(root)
+    (root / "undeclared.onnx").write_bytes((root / "expert_denoise.onnx").read_bytes())
+    config["decomposed"]["expert_denoise_onnx"] = "undeclared.onnx"
+    write_tether_config(root, config)
+
+    with pytest.raises(UnsupportedVerificationBackend, match="secondary paths"):
+        load_verification_inference(root)
+
+
+def test_expert_stack_is_rejected_until_conditioning_is_preserved(tmp_path):
+    root = tmp_path / "expert-stack"
+    root.mkdir()
+    (root / "expert_stack.onnx").write_bytes(b"placeholder")
+    write_tether_config(
+        root,
+        {
+            "schema_version": 1,
+            "model_id": "org/native",
+            "model_type": "smolvla",
+            "action_dim": 2,
+            "num_denoising_steps": 1,
+            "opset": 17,
+            "export_kind": "decomposed_onnx",
+            "artifacts": [{"path": "expert_stack.onnx", "role": "model"}],
+            "io_contract": {"inputs": [], "outputs": []},
+        },
+    )
+    with pytest.raises(UnsupportedVerificationBackend, match="image and language"):
+        load_verification_inference(root)
+
+
+def test_missing_and_digest_mismatched_artifacts_fail_before_runtime(tmp_path):
+    root = tmp_path / "missing"
+    root.mkdir()
+    config = _save_monolithic(root)
+    (root / "model.onnx").unlink()
+    with pytest.raises(ValueError, match="is missing"):
+        load_verification_inference(root)
+
+    mismatch = tmp_path / "mismatch"
+    mismatch.mkdir()
+    config = _save_monolithic(mismatch)
+    config["artifacts"][0]["sha256"] = hashlib.sha256(
+        (mismatch / "model.onnx").read_bytes()
+    ).hexdigest()
+    write_tether_config(mismatch, config)
+    with (mismatch / "model.onnx").open("ab") as stream:
+        stream.write(b"tampered")
+    with pytest.raises(ValueError, match="sha256 mismatch"):
+        load_verification_inference(mismatch)
+
+
+def test_corrupt_and_unsupported_artifacts_fail_loudly(tmp_path):
+    pytest.importorskip("onnxruntime")
+    corrupt = tmp_path / "corrupt"
+    corrupt.mkdir()
+    (corrupt / "model.onnx").write_bytes(b"not-onnx")
+    config = {
+        "schema_version": 1,
+        "model_id": "org/model",
+        "model_type": "pi0",
+        "action_dim": 2,
+        "num_denoising_steps": 1,
+        "opset": 17,
+        "export_kind": "monolithic_onnx",
+        "artifacts": [{"path": "model.onnx", "role": "model"}],
+        "io_contract": {"inputs": [], "outputs": []},
+    }
+    write_tether_config(corrupt, config)
+    with pytest.raises(Exception, match="INVALID_PROTOBUF|protobuf|Protobuf|model"):
+        load_verification_inference(corrupt)
+
+    unsupported = tmp_path / "unsupported"
+    unsupported.mkdir()
+    config.update(export_kind="config_only", artifacts=[])
+    write_tether_config(unsupported, config)
+    with pytest.raises(UnsupportedVerificationBackend, match="config_only"):
+        load_verification_inference(unsupported)
+
+    for export_kind in ("trt_engine", "triton_bundle"):
+        root = tmp_path / export_kind
+        root.mkdir()
+        artifact = root / "model.bin"
+        artifact.write_bytes(b"engine")
+        config.update(
+            export_kind=export_kind,
+            artifacts=[{"path": artifact.name, "role": "engine"}],
+        )
+        write_tether_config(root, config)
+        with pytest.raises(UnsupportedVerificationBackend, match=export_kind):
+            load_verification_inference(root)
+
+
+@pytest.mark.parametrize(
+    ("model_type", "module_name", "class_name"),
+    [
+        ("pi05", "lerobot.policies.pi05.modeling_pi05", "PI05Policy"),
+        ("pi05_decomposed", "lerobot.policies.pi05.modeling_pi05", "PI05Policy"),
+        ("pi0", "lerobot.policies.pi0.modeling_pi0", "PI0Policy"),
+        ("smolvla", "lerobot.policies.smolvla.modeling_smolvla", "SmolVLAPolicy"),
+    ],
+)
+def test_exact_native_loader_uses_declared_family_and_ref(
+    monkeypatch, model_type, module_name, class_name
+):
+    import importlib
+    from tether.eval.libero_rollout import _load_exact_reference_policy
+
+    seen = {}
+
+    class Policy:
+        @classmethod
+        def from_pretrained(cls, checkpoint):
+            seen["checkpoint"] = checkpoint
+            return cls()
+
+    def fake_import(name):
+        seen["module"] = name
+        return SimpleNamespace(**{class_name: Policy})
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    assert isinstance(_load_exact_reference_policy(model_type, "org/exact@sha"), Policy)
+    assert seen == {"module": module_name, "checkpoint": "org/exact@sha"}
+
+
+def test_exact_native_loader_preserves_snapflow_student_format(monkeypatch):
+    import importlib
+    from tether.eval.libero_rollout import _load_exact_reference_policy
+
+    seen = {}
+
+    def load_student(checkpoint):
+        seen["checkpoint"] = checkpoint
+        return "student"
+
+    def fake_import(name):
+        seen["module"] = name
+        return SimpleNamespace(load_snapflow_student=load_student)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    assert _load_exact_reference_policy("pi05_decomposed_student", "/exact/student") == "student"
+    assert seen == {
+        "module": "tether.distill.snapflow_pi0_model",
+        "checkpoint": "/exact/student",
+    }
+
+
+def test_receipt_smoke_action_validation_fails_closed():
+    from scripts.verify_artifact_receipt import _validate_smoke_actions
+
+    noise = np.arange(4, dtype=np.float32).reshape(1, 2, 2)
+    _validate_smoke_actions(np.zeros_like(noise), noise)
+    with pytest.raises(RuntimeError, match="constant graph"):
+        _validate_smoke_actions(np.ones_like(noise), noise)
+
+
+def test_gather_uses_config_model_id_and_never_native_optimized_factory(tmp_path, monkeypatch):
+    root = tmp_path / "export"
+    root.mkdir()
+    _save_monolithic(root)
+    import tether.eval.libero_rollout as rollout
+    from tether.runtime.fast_inference.libero_adapter import TritonLIBEROAdapter
+    from tether.verify import gather_paired_samples
+
+    calls: dict[str, object] = {}
+    policy = SimpleNamespace()
+
+    def fake_load(**kwargs):
+        calls["student_checkpoint"] = kwargs["student_checkpoint"]
+        calls["model_type"] = kwargs["model_type"]
+        calls["exact"] = kwargs["require_exact_checkpoint"]
+        return policy, "pre", "post"
+
+    def fake_rollout(*, use_native, inference, **kwargs):
+        calls["optimized_inference" if not use_native else "native_inference"] = inference
+        if use_native:
+            calls["native_actions"] = np.full((1, 2, 2), 7.0, dtype=np.float32)
+        else:
+            noise = np.arange(4, dtype=np.float32).reshape(1, 2, 2)
+            calls["optimized_actions"] = inference.predict_action_chunk(**_protocol_inputs(noise))
+        return {"per_task": []}
+
+    monkeypatch.setattr(rollout, "load_pi05_policy_and_processors", fake_load)
+    monkeypatch.setattr(rollout, "run_libero_rollout", fake_rollout)
+    monkeypatch.setattr(
+        TritonLIBEROAdapter,
+        "from_policy",
+        classmethod(lambda cls, policy: pytest.fail("native optimized fallback used")),
+    )
+
+    gather_paired_samples(
+        optimized_ref=str(root),
+        original_ref=None,
+        suite="libero",
+        task_suite_name="libero_10",
+        num_episodes=1,
+        task_indices=[0],
+        seed=1,
+        verification_device="cpu",
+    )
+
+    assert calls["student_checkpoint"] == "org/native-reference"
+    assert calls["model_type"] == "pi0"
+    assert calls["exact"] is True
+    assert calls["native_inference"] is None
+    np.testing.assert_array_equal(
+        calls["optimized_actions"], np.arange(4, dtype=np.float32).reshape(1, 2, 2)
+    )
+    assert not np.array_equal(calls["native_actions"], calls["optimized_actions"])
+
+
+@pytest.mark.parametrize(
+    "producer_model_type",
+    ["pi05_decomposed", "pi05_decomposed_student"],
+)
+def test_gather_accepts_real_pi05_producer_model_types(tmp_path, monkeypatch, producer_model_type):
+    pytest.importorskip("onnxruntime")
+    root = tmp_path / producer_model_type
+    root.mkdir()
+    config = _save_pi05_split(root)
+    config["model_type"] = producer_model_type
+    config["model_id"] = (
+        "/exact/student" if producer_model_type.endswith("_student") else "org/pi05@sha"
+    )
+    write_tether_config(root, config)
+
+    import tether.eval.libero_rollout as rollout
+    from tether.verify import gather_paired_samples
+
+    calls = {}
+
+    def fake_load(**kwargs):
+        calls.update(kwargs)
+        return SimpleNamespace(), "pre", "post"
+
+    def fake_rollout(*, use_native, inference, **kwargs):
+        if not use_native:
+            inference.predict_action_chunk(
+                **_protocol_inputs(np.zeros((1, 2, 2), dtype=np.float32))
+            )
+        return {"per_task": []}
+
+    monkeypatch.setattr(rollout, "load_pi05_policy_and_processors", fake_load)
+    monkeypatch.setattr(rollout, "run_libero_rollout", fake_rollout)
+    gather_paired_samples(
+        optimized_ref=str(root),
+        original_ref=None,
+        suite="libero",
+        task_suite_name="libero_10",
+        num_episodes=1,
+        task_indices=[0],
+        seed=1,
+        verification_device="cpu",
+    )
+
+    assert calls["student_checkpoint"] == config["model_id"]
+    assert calls["model_type"] == producer_model_type
+    assert calls["require_exact_checkpoint"] is True


### PR DESCRIPTION
Fixes #267.

- loads the declared, integrity-checked ONNX artifacts for the optimized arm
- binds the native arm to the exact exported model family and source reference
- rejects unsupported or conditioning-loss backends instead of falling back
- preserves camera masks and validates Pi0.5 secondary artifact paths
- adds protected-main artifact-execution receipts and real ONNX regressions

Independent review: APPROVE after three remediation rounds. Focused verifier suite, Ruff, compile checks, and diff checks pass.