### PR TITLE
ci: enforce provenance-bound parity receipts

### DIFF
--- a/.github/PARITY_RECEIPTS.md
+++ b/.github/PARITY_RECEIPTS.md
@@ -1,0 +1,47 @@
+# Parity receipt production controls
+
+The `parity-receipts.yml` workflow runs paid Modal A100 jobs and handles the
+credentials used to download the approved model. Its `produce` job is bound to
+the `parity-receipts-production` GitHub environment for every trigger:
+scheduled runs, `release/**` pushes, and manual dispatches.
+
+Repository administrators must configure that environment before enabling the
+workflow:
+
+1. Add at least one independent required reviewer and enable **Prevent
+   self-review**. The person who initiated or pushed the run must not be able to
+   approve their own deployment. Deselect **Allow administrators to bypass
+   configured protection rules**.
+2. Limit deployment branches/tags to protected `main` and protected
+   `release/**` branches. Those protections must require pull requests and
+   code-owner review for `.github/workflows/parity-receipts.yml`, this document,
+   and receipt verifier/producer code.
+3. Store `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`, and `HF_TOKEN` as environment
+   secrets, not repository secrets.
+4. Store these environment variables:
+   - `PARITY_RECEIPTS_ENVIRONMENT_PROTECTED=true`
+   - `PARITY_MODEL_DIGEST=<sha256>` where the digest is SHA-256 of
+     `huggingface:lerobot/pi05_libero_finetuned_v044@<immutable-hf-commit>`.
+5. Audit changes to reviewers, deployment branches, secrets, variables, and
+   administrator-bypass settings like code changes.
+
+The manual `authorize_paid_run` input records intent only. It cannot supply or
+override the approved model digest, credentials, environment, workflow, ref,
+or reviewer gate. Scheduled and release runs still wait for the same protected
+environment approval before any step can access secrets or start paid work.
+
+Each authorized run derives a canonical receipt namespace from the lowercase
+repository identity, checked-out commit SHA, GitHub run ID, and run attempt.
+The workflow passes that complete binding to every Modal producer. In receipt
+mode, Hugging Face caches, ONNX exports, benchmark inputs, and local result
+JSON files live only below `receipt_runs/<namespace>`; partial receipt metadata
+and non-canonical or path-like namespaces are rejected. Static legacy paths
+remain available only when no receipt metadata is supplied, outside this
+workflow. Retrying a run creates a new namespace and cannot reuse an earlier
+attempt's measured export directory.
+
+The same namespace is embedded in both GitHub artifact names. Consumers first
+select trusted server-returned workflow metadata, recompute that run attempt's
+namespace, and then accept exactly one matching manifest and payload artifact.
+Artifacts from earlier attempts, similarly named artifacts, and duplicate
+matches are rejected rather than selected heuristically.

--- a/.github/workflows/parity-receipts.yml
+++ b/.github/workflows/parity-receipts.yml
@@ -1,0 +1,258 @@
+name: Parity receipts
+
+on:
+  schedule:
+    - cron: "17 8 * * 1"
+  workflow_dispatch:
+    inputs:
+      authorize_paid_run:
+        description: Authorize the paid Modal A100 receipt producers
+        required: true
+        default: false
+        type: boolean
+  push:
+    branches:
+      - "release/**"
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: parity-receipts-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  produce:
+    name: Produce provenance-bound receipts
+    runs-on: ubuntu-latest
+    # This environment must require independent reviewers, prevent self-review,
+    # and allow only protected main/release/* deployment branches. See
+    # .github/PARITY_RECEIPTS.md. Environment secrets are unavailable until
+    # its protection rules approve this job.
+    environment: parity-receipts-production
+    timeout-minutes: 120
+    outputs:
+      authorized: ${{ steps.authorization.outputs.authorized }}
+      artifact_id: ${{ steps.payload.outputs.artifact-id }}
+      artifact_name: ${{ steps.namespace.outputs.payload_artifact_name }}
+      artifact_digest: ${{ steps.payload.outputs.artifact-digest }}
+      export_id: ${{ steps.manifest.outputs.export_id }}
+      export_digest: ${{ steps.manifest.outputs.export_digest }}
+      model_digest: ${{ steps.authorization.outputs.model_digest }}
+      receipt_namespace: ${{ steps.namespace.outputs.receipt_namespace }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Check authorization and required identities
+        id: authorization
+        env:
+          AUTHORIZED_INPUT: ${{ inputs.authorize_paid_run || false }}
+          CONFIGURED_MODEL_DIGEST: ${{ vars.PARITY_MODEL_DIGEST }}
+          PROTECTED_ENVIRONMENT_CONFIGURED: ${{ vars.PARITY_RECEIPTS_ENVIRONMENT_PROTECTED }}
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          model_digest="$CONFIGURED_MODEL_DIGEST"
+          authorized=true
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$AUTHORIZED_INPUT" != "true" ]; then
+            authorized=false
+          fi
+          if [ -z "$MODAL_TOKEN_ID" ] || [ -z "$MODAL_TOKEN_SECRET" ] || [ -z "$HF_TOKEN" ]; then
+            authorized=false
+          fi
+          if [ "$PROTECTED_ENVIRONMENT_CONFIGURED" != "true" ]; then
+            authorized=false
+          fi
+          if ! printf '%s' "$model_digest" | grep -Eq '^(sha256:)?[0-9a-fA-F]{64}$'; then
+            authorized=false
+          fi
+          echo "authorized=$authorized" >> "$GITHUB_OUTPUT"
+          echo "model_digest=$model_digest" >> "$GITHUB_OUTPUT"
+          if [ "$authorized" != "true" ]; then
+            echo "::notice::Parity receipt production skipped: protected-environment approval/configuration, authorization, secrets, or model digest unavailable."
+          fi
+
+      - name: Install producer client
+        if: steps.authorization.outputs.authorized == 'true'
+        run: python -m pip install --upgrade pip modal && python -m pip install -e .
+
+      - name: Derive immutable receipt namespace
+        if: steps.authorization.outputs.authorized == 'true'
+        id: namespace
+        run: >-
+          python -m tether.receipt_provenance namespace
+          --repository "${{ github.repository }}"
+          --source-sha "${{ github.sha }}"
+          --run-id "${{ github.run_id }}"
+          --run-attempt "${{ github.run_attempt }}"
+
+      - name: Run Modal parity producer
+        if: steps.authorization.outputs.authorized == 'true'
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: >-
+          modal run scripts/modal_per_step_parity.py
+          --receipt-namespace "${{ steps.namespace.outputs.receipt_namespace }}"
+          --source-repository "${{ github.repository }}"
+          --source-sha "${{ github.sha }}"
+          --workflow-run-id "${{ github.run_id }}"
+          --workflow-run-attempt "${{ github.run_attempt }}"
+
+      - name: Run Modal overhead producer
+        if: steps.authorization.outputs.authorized == 'true'
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: >-
+          modal run scripts/modal_per_step_overhead.py
+          --receipt-namespace "${{ steps.namespace.outputs.receipt_namespace }}"
+          --source-repository "${{ github.repository }}"
+          --source-sha "${{ github.sha }}"
+          --workflow-run-id "${{ github.run_id }}"
+          --workflow-run-attempt "${{ github.run_attempt }}"
+
+      - name: Run Modal end-to-end latency producer
+        if: steps.authorization.outputs.authorized == 'true'
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: >-
+          modal run scripts/modal_per_step_e2e_latency.py
+          --receipt-namespace "${{ steps.namespace.outputs.receipt_namespace }}"
+          --source-repository "${{ github.repository }}"
+          --source-sha "${{ github.sha }}"
+          --workflow-run-id "${{ github.run_id }}"
+          --workflow-run-attempt "${{ github.run_attempt }}"
+
+      - name: Collect receipt payload
+        if: steps.authorization.outputs.authorized == 'true'
+        env:
+          RECEIPT_SOURCE: ${{ github.workspace }}/../reflex_context
+          RECEIPT_NAMESPACE: ${{ steps.namespace.outputs.receipt_namespace }}
+        run: |
+          mkdir receipt-payload
+          namespace_source="$RECEIPT_SOURCE/receipt_runs/$RECEIPT_NAMESPACE"
+          cp "$namespace_source/per_step_parity_last_run.json" receipt-payload/
+          cp "$namespace_source/per_step_overhead_last_run.json" receipt-payload/
+          cp "$namespace_source/per_step_e2e_latency_last_run.json" receipt-payload/
+
+      - name: Upload hashed receipt payload
+        if: steps.authorization.outputs.authorized == 'true'
+        id: payload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.namespace.outputs.payload_artifact_name }}
+          path: receipt-payload/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Build provenance manifest
+        if: steps.authorization.outputs.authorized == 'true'
+        id: manifest
+        run: >-
+          python -m tether.receipt_provenance build
+          --payload-dir receipt-payload
+          --repository "${{ github.repository }}"
+          --source-sha "${{ github.sha }}"
+          --source-ref "${{ github.ref }}"
+          --run-id "${{ github.run_id }}"
+          --run-attempt "${{ github.run_attempt }}"
+          --receipt-namespace "${{ steps.namespace.outputs.receipt_namespace }}"
+          --event "${{ github.event_name }}"
+          --artifact-id "${{ steps.payload.outputs.artifact-id }}"
+          --artifact-name "${{ steps.namespace.outputs.payload_artifact_name }}"
+          --artifact-digest "${{ steps.payload.outputs.artifact-digest }}"
+          --model-id "lerobot/pi05_libero_finetuned_v044"
+          --model-digest "${{ steps.authorization.outputs.model_digest }}"
+          --expires-in-hours 168
+          --output receipt-manifest/receipt-manifest.json
+
+      - name: Upload provenance manifest
+        if: steps.authorization.outputs.authorized == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.namespace.outputs.manifest_artifact_name }}
+          path: receipt-manifest/receipt-manifest.json
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Release branches require receipt authorization
+        if: >-
+          always() && startsWith(github.ref, 'refs/heads/release/') &&
+          steps.authorization.outputs.authorized != 'true'
+        run: |
+          echo "::error::Release receipt gate cannot run without the protected receipt environment, Modal/HF secrets, and PARITY_MODEL_DIGEST."
+          exit 1
+
+  consume:
+    name: Verify and enforce receipt gates
+    needs: produce
+    if: needs.produce.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install receipt verifier
+        run: python -m pip install -e ".[dev]"
+
+      - name: Download payload by server-assigned artifact id
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ needs.produce.outputs.artifact_id }}
+          path: receipt-payload
+
+      - name: Download named provenance manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: parity-receipt-manifest-${{ github.sha }}
+          path: receipt-manifest
+
+      - name: Verify receipt provenance and internal hashes
+        run: >-
+          python -m tether.receipt_provenance verify-local
+          --manifest receipt-manifest/receipt-manifest.json
+          --payload-dir receipt-payload
+          --repository "${{ github.repository }}"
+          --source-sha "${{ github.sha }}"
+          --source-ref "${{ github.ref }}"
+          --run-id "${{ github.run_id }}"
+          --run-attempt "${{ github.run_attempt }}"
+          --event "${{ github.event_name }}"
+          --artifact-id "${{ needs.produce.outputs.artifact_id }}"
+          --artifact-name "${{ needs.produce.outputs.artifact_name }}"
+          --artifact-digest "${{ needs.produce.outputs.artifact_digest }}"
+          --model-id "lerobot/pi05_libero_finetuned_v044"
+          --model-digest "${{ needs.produce.outputs.model_digest }}"
+          --export-id "${{ needs.produce.outputs.export_id }}"
+          --export-digest "${{ needs.produce.outputs.export_digest }}"
+
+      - name: Run fail-loud receipt gates
+        env:
+          TETHER_RECEIPT_DIR: ${{ github.workspace }}/receipt-payload
+          TETHER_REQUIRE_RECEIPTS: "1"
+        run: >-
+          pytest -v
+          tests/test_decomposed_per_step_parity.py
+          tests/test_decomposed_per_step_overhead.py
+          tests/test_decomposed_per_step_e2e_latency.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -355,4 +355,5 @@ asyncio_mode = "strict"
 markers = [
     "asyncio: mark a coroutine test for pytest-asyncio (strict mode)",
     "hardware: requires a physical robot wired in; skipped unless RUN_HARDWARE_TESTS=1",
+    "receipt: validates a signed or provenance-bound operational receipt",
 ]

--- a/receipt_test_support.py
+++ b/receipt_test_support.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def receipt_path(filename: str) -> Path:
+    configured = os.environ.get("TETHER_RECEIPT_DIR")
+    if configured:
+        return (Path(configured) / filename).resolve()
+    return (Path(__file__).parent.parent / "reflex_context" / filename).resolve()
+
+
+def require_receipt(path: Path, producer: str) -> None:
+    if path.is_file():
+        return
+    message = f"No trusted receipt at {path}; run {producer}"
+    ref_name = os.environ.get("GITHUB_REF_NAME", "")
+    fail_loud = os.environ.get("TETHER_REQUIRE_RECEIPTS") == "1" or ref_name.startswith("release/")
+    if fail_loud:
+        pytest.fail(message, pytrace=False)
+    pytest.skip(message)

--- a/scripts/modal_per_step_e2e_latency.py
+++ b/scripts/modal_per_step_e2e_latency.py
@@ -33,6 +33,7 @@ Cost: ~$1.50-2 Modal (2 × A100-80GB ~5 min each).
 Usage:
     HF_TOKEN=<token> modal run --detach scripts/modal_per_step_e2e_latency.py
 """
+
 from __future__ import annotations
 
 import json
@@ -91,17 +92,27 @@ image = (
         copy=True,
         ignore=["**/__pycache__/**", "**/*.pyc"],
     )
-    .add_local_file(os.path.join(REPO_ROOT, "pyproject.toml"), remote_path="/root/tether-vla/pyproject.toml", copy=True)
-    .add_local_file(os.path.join(REPO_ROOT, "README.md"), remote_path="/root/tether-vla/README.md", copy=True)
-    .add_local_file(os.path.join(REPO_ROOT, "LICENSE"), remote_path="/root/tether-vla/LICENSE", copy=True)
+    .add_local_file(
+        os.path.join(REPO_ROOT, "pyproject.toml"),
+        remote_path="/root/tether-vla/pyproject.toml",
+        copy=True,
+    )
+    .add_local_file(
+        os.path.join(REPO_ROOT, "README.md"), remote_path="/root/tether-vla/README.md", copy=True
+    )
+    .add_local_file(
+        os.path.join(REPO_ROOT, "LICENSE"), remote_path="/root/tether-vla/LICENSE", copy=True
+    )
     .run_commands(
         f'echo "build_bust={_BUST}"',
         'pip install -e "/root/tether-vla[monolithic]"',
     )
-    .env({
-        "HF_HOME": HF_CACHE,
-        "TRANSFORMERS_CACHE": f"{HF_CACHE}/transformers",
-    })
+    .env(
+        {
+            "HF_HOME": HF_CACHE,
+            "TRANSFORMERS_CACHE": f"{HF_CACHE}/transformers",
+        }
+    )
 )
 
 
@@ -116,17 +127,59 @@ N_BENCH = 200
     volumes={HF_CACHE: hf_cache, ONNX_OUT: onnx_output},
     secrets=[_hf_secret()],
 )
-def bench_one(export_dir: str, label: str) -> dict:
+def bench_one(
+    export_dir: str,
+    label: str,
+    receipt_namespace: str = "",
+    source_repository: str = "",
+    source_sha: str = "",
+    workflow_run_id: int = 0,
+    workflow_run_attempt: int = 0,
+) -> dict:
     """Bench exactly ONE Pi05DecomposedInference instance. Each invocation
     is a fresh GPU rental → clean L2 cache → no cross-session contention."""
     import logging
     import time
     import numpy as np
 
-    from tether.runtime.pi05_decomposed_server import Pi05DecomposedInference
+    from tether.receipt_provenance import (
+        hash_export_set,
+        receipt_mode_binding,
+        receipt_run_dir,
+        require_cuda_provider_lists,
+    )
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
     log = logging.getLogger(__name__)
+
+    namespace_binding = receipt_mode_binding(
+        receipt_namespace=receipt_namespace,
+        repository=source_repository,
+        source_sha=source_sha,
+        workflow_run_id=workflow_run_id,
+        workflow_run_attempt=workflow_run_attempt,
+    )
+    if namespace_binding is not None:
+        relative_dirs = {
+            "baked": "per_step_parity/pi05_teacher_n10_baked",
+            "per_step": "per_step_parity/pi05_teacher_n10_per_step",
+        }
+        if label not in relative_dirs:
+            raise ValueError(f"unsupported receipt benchmark label: {label!r}")
+        namespace = str(namespace_binding["value"])
+        expected_dir = receipt_run_dir(Path(ONNX_OUT), namespace) / relative_dirs[label]
+        if Path(export_dir) != expected_dir:
+            raise ValueError(
+                f"receipt benchmark export directory must be {expected_dir}, got {export_dir}"
+            )
+        cache_root = receipt_run_dir(Path(HF_CACHE), namespace)
+        cache_root.mkdir(parents=True, exist_ok=True)
+        os.environ["HF_HOME"] = str(cache_root)
+        os.environ["TRANSFORMERS_CACHE"] = str(cache_root / "transformers")
+
+    # The runtime imports Transformers, which reads its cache configuration
+    # during import. Receipt mode must configure the immutable cache first.
+    from tether.runtime.pi05_decomposed_server import Pi05DecomposedInference
 
     if not (Path(export_dir) / "expert_denoise.onnx").exists():
         raise FileNotFoundError(f"Export missing at {export_dir}. Run gate 3 first.")
@@ -142,7 +195,14 @@ def bench_one(export_dir: str, label: str) -> dict:
         "CPUExecutionProvider",
     ]
     inf = Pi05DecomposedInference(
-        export_dir=export_dir, cache_level="none", providers=providers,
+        export_dir=export_dir,
+        cache_level="none",
+        providers=providers,
+    )
+    prefix_session = getattr(inf._sess_prefix, "session", inf._sess_prefix)
+    expert_session = getattr(inf._sess_expert, "session", inf._sess_expert)
+    prefix_providers, expert_providers = require_cuda_provider_lists(
+        list(prefix_session.get_providers()), list(expert_session.get_providers())
     )
 
     B = 1
@@ -214,33 +274,78 @@ def bench_one(export_dir: str, label: str) -> dict:
     total_stats = stats(totals)
     vlm_stats = stats(vlms)
     expert_stats = stats(experts)
-    log.info("[%s] E2E    median=%.2fms p99=%.2fms", label, total_stats["median_ms"], total_stats["p99_ms"])
-    log.info("[%s] vlm    median=%.2fms p99=%.2fms", label, vlm_stats["median_ms"], vlm_stats["p99_ms"])
-    log.info("[%s] expert median=%.2fms p99=%.2fms", label, expert_stats["median_ms"], expert_stats["p99_ms"])
+    log.info(
+        "[%s] E2E    median=%.2fms p99=%.2fms",
+        label,
+        total_stats["median_ms"],
+        total_stats["p99_ms"],
+    )
+    log.info(
+        "[%s] vlm    median=%.2fms p99=%.2fms", label, vlm_stats["median_ms"], vlm_stats["p99_ms"]
+    )
+    log.info(
+        "[%s] expert median=%.2fms p99=%.2fms",
+        label,
+        expert_stats["median_ms"],
+        expert_stats["p99_ms"],
+    )
 
-    return {
+    result = {
         "label": label,
+        "export": hash_export_set(Path(export_dir)),
+        "providers": {
+            "vlm_prefix": prefix_providers,
+            "expert_denoise": expert_providers,
+        },
         "n_warmup": N_WARMUP,
         "n_bench": N_BENCH,
         "total": total_stats,
         "vlm": vlm_stats,
         "expert": expert_stats,
     }
+    if namespace_binding is not None:
+        result["receipt_namespace"] = namespace_binding
+    return result
 
 
 @app.local_entrypoint()
-def main():
+def main(
+    receipt_namespace: str = "",
+    source_repository: str = "",
+    source_sha: str = "",
+    workflow_run_id: int = 0,
+    workflow_run_attempt: int = 0,
+):
+    from tether.receipt_provenance import receipt_mode_binding, receipt_run_dir
+
+    namespace_binding = receipt_mode_binding(
+        receipt_namespace=receipt_namespace,
+        repository=source_repository,
+        source_sha=source_sha,
+        workflow_run_id=workflow_run_id,
+        workflow_run_attempt=workflow_run_attempt,
+    )
     print("=" * 60)
     print("Per-step E2E chunk-latency bench (gate 5, isolated invocations)")
     print("=" * 60)
 
-    baked_dir = f"{ONNX_OUT}/per_step_parity/pi05_teacher_n10_baked"
-    per_step_dir = f"{ONNX_OUT}/per_step_parity/pi05_teacher_n10_per_step"
+    onnx_root = Path(ONNX_OUT)
+    if namespace_binding is not None:
+        onnx_root = receipt_run_dir(onnx_root, str(namespace_binding["value"]))
+    baked_dir = str(onnx_root / "per_step_parity/pi05_teacher_n10_baked")
+    per_step_dir = str(onnx_root / "per_step_parity/pi05_teacher_n10_per_step")
 
-    print(f"\nFiring baked bench (sequential, isolated GPU rental)...")
-    baked = bench_one.remote(baked_dir, "baked")
-    print(f"\nFiring per-step bench (sequential, isolated GPU rental)...")
-    per_step = bench_one.remote(per_step_dir, "per_step")
+    print("\nFiring baked bench (sequential, isolated GPU rental)...")
+    remote_args = (
+        receipt_namespace,
+        source_repository,
+        source_sha,
+        workflow_run_id,
+        workflow_run_attempt,
+    )
+    baked = bench_one.remote(baked_dir, "baked", *remote_args)
+    print("\nFiring per-step bench (sequential, isolated GPU rental)...")
+    per_step = bench_one.remote(per_step_dir, "per_step", *remote_args)
 
     median_pct = (per_step["total"]["median_ms"] / baked["total"]["median_ms"]) - 1.0
     p99_ratio = per_step["total"]["p99_ms"] / baked["total"]["p99_ms"]
@@ -254,9 +359,13 @@ def main():
         "passes_overall": passes_overall,
         "thresholds": {"median_overhead_pct_max": 0.20, "p99_ratio_max": 1.30},
     }
+    if namespace_binding is not None:
+        result["receipt_namespace"] = namespace_binding
 
-    receipt_path = Path(REPO_ROOT) / ".." / "reflex_context" / "per_step_e2e_latency_last_run.json"
-    receipt_path = receipt_path.resolve()
+    receipt_root = (Path(REPO_ROOT) / ".." / "reflex_context").resolve()
+    if namespace_binding is not None:
+        receipt_root = receipt_run_dir(receipt_root, str(namespace_binding["value"]))
+    receipt_path = receipt_root / "per_step_e2e_latency_last_run.json"
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     receipt_path.write_text(json.dumps(result, indent=2))
     print(f"\nReceipt: {receipt_path}")
@@ -265,8 +374,14 @@ def main():
     print("RESULTS (isolated invocations — production-relevant)")
     print("=" * 60)
     for label, r in [("baked", baked), ("per-step", per_step)]:
-        print(f"  {label:9} E2E    median={r['total']['median_ms']:.2f}ms  p99={r['total']['p99_ms']:.2f}ms")
-        print(f"  {label:9} vlm    median={r['vlm']['median_ms']:.2f}ms  p99={r['vlm']['p99_ms']:.2f}ms")
-        print(f"  {label:9} expert median={r['expert']['median_ms']:.2f}ms  p99={r['expert']['p99_ms']:.2f}ms")
+        print(
+            f"  {label:9} E2E    median={r['total']['median_ms']:.2f}ms  p99={r['total']['p99_ms']:.2f}ms"
+        )
+        print(
+            f"  {label:9} vlm    median={r['vlm']['median_ms']:.2f}ms  p99={r['vlm']['p99_ms']:.2f}ms"
+        )
+        print(
+            f"  {label:9} expert median={r['expert']['median_ms']:.2f}ms  p99={r['expert']['p99_ms']:.2f}ms"
+        )
     print(f"\n  E2E overhead: median {median_pct * 100:+.1f}%  p99 {p99_ratio:.2f}x")
     print(f"  Overall: {'PASS' if passes_overall else 'FAIL'} (median≤+20%, p99≤1.30x)")

--- a/scripts/modal_per_step_overhead.py
+++ b/scripts/modal_per_step_overhead.py
@@ -35,6 +35,7 @@ Usage:
     modal profile activate suranjana-jain
     HF_TOKEN=<token> modal run --detach scripts/modal_per_step_overhead.py
 """
+
 from __future__ import annotations
 
 import json
@@ -116,10 +117,12 @@ image = (
         f'echo "build_bust={_BUST}"',
         'pip install -e "/root/tether-vla[monolithic]"',
     )
-    .env({
-        "HF_HOME": HF_CACHE,
-        "TRANSFORMERS_CACHE": f"{HF_CACHE}/transformers",
-    })
+    .env(
+        {
+            "HF_HOME": HF_CACHE,
+            "TRANSFORMERS_CACHE": f"{HF_CACHE}/transformers",
+        }
+    )
 )
 
 
@@ -135,11 +138,43 @@ NUM_STEPS = 10  # baked loop steps == per-step Python loop iters
     volumes={HF_CACHE: hf_cache, ONNX_OUT: onnx_output},
     secrets=[_hf_secret()],
 )
-def overhead_bench() -> dict:
+def overhead_bench(
+    receipt_namespace: str = "",
+    source_repository: str = "",
+    source_sha: str = "",
+    workflow_run_id: int = 0,
+    workflow_run_attempt: int = 0,
+) -> dict:
     import logging
     import time
     import numpy as np
     import onnxruntime as ort
+
+    from tether.receipt_provenance import (
+        hash_export_set,
+        receipt_mode_binding,
+        receipt_run_dir,
+    )
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    log = logging.getLogger(__name__)
+
+    namespace_binding = receipt_mode_binding(
+        receipt_namespace=receipt_namespace,
+        repository=source_repository,
+        source_sha=source_sha,
+        workflow_run_id=workflow_run_id,
+        workflow_run_attempt=workflow_run_attempt,
+    )
+    if namespace_binding is None:
+        onnx_root = Path(ONNX_OUT)
+    else:
+        namespace = str(namespace_binding["value"])
+        onnx_root = receipt_run_dir(Path(ONNX_OUT), namespace)
+        cache_root = receipt_run_dir(Path(HF_CACHE), namespace)
+        cache_root.mkdir(parents=True, exist_ok=True)
+        os.environ["HF_HOME"] = str(cache_root)
+        os.environ["TRANSFORMERS_CACHE"] = str(cache_root / "transformers")
 
     from tether.exporters.decomposed import (
         PI05_HEAD_DIM,
@@ -147,11 +182,10 @@ def overhead_bench() -> dict:
         PI05_PALIGEMMA_LAYERS,
     )
 
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
-    log = logging.getLogger(__name__)
-
-    baked_path = Path(ONNX_OUT) / "per_step_parity/pi05_teacher_n10_baked/expert_denoise.onnx"
-    per_step_path = Path(ONNX_OUT) / "per_step_parity/pi05_teacher_n10_per_step/expert_denoise.onnx"
+    baked_dir = onnx_root / "per_step_parity/pi05_teacher_n10_baked"
+    per_step_dir = onnx_root / "per_step_parity/pi05_teacher_n10_per_step"
+    baked_path = baked_dir / "expert_denoise.onnx"
+    per_step_path = per_step_dir / "expert_denoise.onnx"
 
     if not baked_path.exists():
         raise FileNotFoundError(f"Baked ONNX missing: {baked_path}. Re-run gate 3 first.")
@@ -317,21 +351,37 @@ def overhead_bench() -> dict:
     naive_gate = gate_eval(naive_stats)
     iob_gate = gate_eval(iob_stats)
 
-    log.info("BAKED                median=%.2fms p99=%.2fms", baked_stats["median_ms"], baked_stats["p99_ms"])
-    log.info("PER-STEP NAIVE       median=%.2fms p99=%.2fms (overhead %+.1f%%, p99 %.2fx, gate %s)",
-             naive_stats["median_ms"], naive_stats["p99_ms"],
-             naive_gate["median_overhead_pct"] * 100, naive_gate["p99_ratio"],
-             "PASS" if naive_gate["passes_overall"] else "FAIL")
-    log.info("PER-STEP IOBINDING   median=%.2fms p99=%.2fms (overhead %+.1f%%, p99 %.2fx, gate %s)",
-             iob_stats["median_ms"], iob_stats["p99_ms"],
-             iob_gate["median_overhead_pct"] * 100, iob_gate["p99_ratio"],
-             "PASS" if iob_gate["passes_overall"] else "FAIL")
+    log.info(
+        "BAKED                median=%.2fms p99=%.2fms",
+        baked_stats["median_ms"],
+        baked_stats["p99_ms"],
+    )
+    log.info(
+        "PER-STEP NAIVE       median=%.2fms p99=%.2fms (overhead %+.1f%%, p99 %.2fx, gate %s)",
+        naive_stats["median_ms"],
+        naive_stats["p99_ms"],
+        naive_gate["median_overhead_pct"] * 100,
+        naive_gate["p99_ratio"],
+        "PASS" if naive_gate["passes_overall"] else "FAIL",
+    )
+    log.info(
+        "PER-STEP IOBINDING   median=%.2fms p99=%.2fms (overhead %+.1f%%, p99 %.2fx, gate %s)",
+        iob_stats["median_ms"],
+        iob_stats["p99_ms"],
+        iob_gate["median_overhead_pct"] * 100,
+        iob_gate["p99_ratio"],
+        "PASS" if iob_gate["passes_overall"] else "FAIL",
+    )
 
-    return {
+    result = {
         "n_warmup": N_WARMUP,
         "n_bench": N_BENCH,
         "num_steps": NUM_STEPS,
         "providers": {"baked": actual_baked, "per_step": actual_per_step},
+        "exports": {
+            "baked": hash_export_set(baked_dir),
+            "per_step": hash_export_set(per_step_dir),
+        },
         "baked": baked_stats,
         "per_step_naive": naive_stats,
         "per_step_iobinding": iob_stats,
@@ -342,17 +392,43 @@ def overhead_bench() -> dict:
         # what production runtime should adopt if it passes.
         "passes_overall": iob_gate["passes_overall"],
     }
+    if namespace_binding is not None:
+        result["receipt_namespace"] = namespace_binding
+    return result
 
 
 @app.local_entrypoint()
-def main():
+def main(
+    receipt_namespace: str = "",
+    source_repository: str = "",
+    source_sha: str = "",
+    workflow_run_id: int = 0,
+    workflow_run_attempt: int = 0,
+):
+    from tether.receipt_provenance import receipt_mode_binding, receipt_run_dir
+
+    namespace_binding = receipt_mode_binding(
+        receipt_namespace=receipt_namespace,
+        repository=source_repository,
+        source_sha=source_sha,
+        workflow_run_id=workflow_run_id,
+        workflow_run_attempt=workflow_run_attempt,
+    )
     print("=" * 60)
     print("Per-step ORT call overhead bench (gate 4)")
     print("=" * 60)
-    result = overhead_bench.remote()
+    result = overhead_bench.remote(
+        receipt_namespace,
+        source_repository,
+        source_sha,
+        workflow_run_id,
+        workflow_run_attempt,
+    )
 
-    receipt_path = Path(REPO_ROOT) / ".." / "reflex_context" / "per_step_overhead_last_run.json"
-    receipt_path = receipt_path.resolve()
+    receipt_root = (Path(REPO_ROOT) / ".." / "reflex_context").resolve()
+    if namespace_binding is not None:
+        receipt_root = receipt_run_dir(receipt_root, str(namespace_binding["value"]))
+    receipt_path = receipt_root / "per_step_overhead_last_run.json"
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     receipt_path.write_text(json.dumps(result, indent=2))
     print(f"\nReceipt: {receipt_path}")
@@ -362,11 +438,17 @@ def main():
     print("=" * 60)
     b, n_, i_ = result["baked"], result["per_step_naive"], result["per_step_iobinding"]
     print(f"  baked              median={b['median_ms']:.2f}ms  p99={b['p99_ms']:.2f}ms")
-    print(f"  per-step naive     median={n_['median_ms']:.2f}ms  p99={n_['p99_ms']:.2f}ms  "
-          f"({result['naive_gate']['median_overhead_pct'] * 100:+.1f}%, p99 {result['naive_gate']['p99_ratio']:.2f}x) "
-          f"{'PASS' if result['naive_gate']['passes_overall'] else 'FAIL'}")
-    print(f"  per-step IOBinding median={i_['median_ms']:.2f}ms  p99={i_['p99_ms']:.2f}ms  "
-          f"({result['iobinding_gate']['median_overhead_pct'] * 100:+.1f}%, p99 {result['iobinding_gate']['p99_ratio']:.2f}x) "
-          f"{'PASS' if result['iobinding_gate']['passes_overall'] else 'FAIL'}")
-    print(f"\n  Production-relevant gate (IOBinding): "
-          f"{'PASS' if result['passes_overall'] else 'FAIL'} (median≤+20%, p99≤1.30x)")
+    print(
+        f"  per-step naive     median={n_['median_ms']:.2f}ms  p99={n_['p99_ms']:.2f}ms  "
+        f"({result['naive_gate']['median_overhead_pct'] * 100:+.1f}%, p99 {result['naive_gate']['p99_ratio']:.2f}x) "
+        f"{'PASS' if result['naive_gate']['passes_overall'] else 'FAIL'}"
+    )
+    print(
+        f"  per-step IOBinding median={i_['median_ms']:.2f}ms  p99={i_['p99_ms']:.2f}ms  "
+        f"({result['iobinding_gate']['median_overhead_pct'] * 100:+.1f}%, p99 {result['iobinding_gate']['p99_ratio']:.2f}x) "
+        f"{'PASS' if result['iobinding_gate']['passes_overall'] else 'FAIL'}"
+    )
+    print(
+        f"\n  Production-relevant gate (IOBinding): "
+        f"{'PASS' if result['passes_overall'] else 'FAIL'} (median≤+20%, p99≤1.30x)"
+    )

--- a/scripts/modal_per_step_parity.py
+++ b/scripts/modal_per_step_parity.py
@@ -25,11 +25,12 @@ Usage:
     modal profile activate suranjana-jain
     HF_TOKEN=<token> modal run scripts/modal_per_step_parity.py
 """
+
 from __future__ import annotations
 
+import hashlib
 import json
 import os
-import subprocess
 import time
 from pathlib import Path
 
@@ -105,10 +106,12 @@ image = (
         f'echo "build_bust={_BUST}"',
         'pip install -e "/root/tether-vla[monolithic]"',
     )
-    .env({
-        "HF_HOME": HF_CACHE,
-        "TRANSFORMERS_CACHE": f"{HF_CACHE}/transformers",
-    })
+    .env(
+        {
+            "HF_HOME": HF_CACHE,
+            "TRANSFORMERS_CACHE": f"{HF_CACHE}/transformers",
+        }
+    )
 )
 
 
@@ -142,12 +145,46 @@ CELLS = [
     volumes={HF_CACHE: hf_cache, ONNX_OUT: onnx_output},
     secrets=[_hf_secret()],
 )
-def parity_test() -> dict:
+def parity_test(
+    receipt_namespace: str = "",
+    source_repository: str = "",
+    source_sha: str = "",
+    workflow_run_id: int = 0,
+    workflow_run_attempt: int = 0,
+) -> dict:
     """Build baked + per-step exports for each cell, run both on shared
     seeded inputs, compute cos + max_abs."""
     import logging
     import numpy as np
     import onnxruntime as ort
+    from tether.receipt_provenance import (
+        hash_export_set,
+        receipt_mode_binding,
+        receipt_run_dir,
+    )
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    log = logging.getLogger(__name__)
+
+    namespace_binding = receipt_mode_binding(
+        receipt_namespace=receipt_namespace,
+        repository=source_repository,
+        source_sha=source_sha,
+        workflow_run_id=workflow_run_id,
+        workflow_run_attempt=workflow_run_attempt,
+    )
+    if namespace_binding is None:
+        onnx_root = Path(ONNX_OUT)
+    else:
+        namespace = str(namespace_binding["value"])
+        onnx_root = receipt_run_dir(Path(ONNX_OUT), namespace)
+        cache_root = receipt_run_dir(Path(HF_CACHE), namespace)
+        cache_root.mkdir(parents=True, exist_ok=True)
+        os.environ["HF_HOME"] = str(cache_root)
+        os.environ["TRANSFORMERS_CACHE"] = str(cache_root / "transformers")
+
+    # Hugging Face/Transformers read cache configuration at import time.
+    from huggingface_hub import model_info
 
     from tether.exporters.decomposed import (
         PI05_HEAD_DIM,
@@ -156,18 +193,29 @@ def parity_test() -> dict:
         export_pi05_decomposed,
     )
 
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
-    log = logging.getLogger(__name__)
-
     results: dict[str, dict] = {}
+    model_identities: dict[str, tuple[str, str]] = {}
 
     for cell in CELLS:
         log.info("=" * 60)
         log.info("CELL: %s", cell["label"])
         log.info("=" * 60)
 
-        baked_dir = Path(ONNX_OUT) / f"{cell['subdir']}_baked"
-        per_step_dir = Path(ONNX_OUT) / f"{cell['subdir']}_per_step"
+        if cell["model_id"] not in model_identities:
+            revision = model_info(cell["model_id"], token=os.environ.get("HF_TOKEN")).sha
+            if not revision:
+                raise RuntimeError(
+                    f"Hugging Face returned no immutable revision for {cell['model_id']}"
+                )
+            identity = f"huggingface:{cell['model_id']}@{revision}".encode()
+            model_identities[cell["model_id"]] = (
+                revision,
+                hashlib.sha256(identity).hexdigest(),
+            )
+        model_revision, model_digest = model_identities[cell["model_id"]]
+
+        baked_dir = onnx_root / f"{cell['subdir']}_baked"
+        per_step_dir = onnx_root / f"{cell['subdir']}_per_step"
         baked_dir.mkdir(parents=True, exist_ok=True)
         per_step_dir.mkdir(parents=True, exist_ok=True)
 
@@ -175,6 +223,7 @@ def parity_test() -> dict:
         log.info("[%s] building baked-loop export → %s", cell["label"], baked_dir)
         export_pi05_decomposed(
             model_id=cell["model_id"],
+            revision=model_revision,
             output_dir=str(baked_dir),
             num_steps=cell["num_steps"],
             student_checkpoint=cell["student_checkpoint"],
@@ -187,6 +236,7 @@ def parity_test() -> dict:
         log.info("[%s] building per-step export → %s", cell["label"], per_step_dir)
         export_pi05_decomposed(
             model_id=cell["model_id"],
+            revision=model_revision,
             output_dir=str(per_step_dir),
             num_steps=cell["num_steps"],
             student_checkpoint=cell["student_checkpoint"],
@@ -211,7 +261,9 @@ def parity_test() -> dict:
         actual_per_step = sess_per_step.get_providers()[0]
         log.info(
             "[%s] providers: baked=%s, per_step=%s",
-            cell["label"], actual_baked, actual_per_step,
+            cell["label"],
+            actual_baked,
+            actual_per_step,
         )
 
         # Seeded shared inputs for parity comparison
@@ -266,14 +318,25 @@ def parity_test() -> dict:
         max_abs = float(np.max(np.abs(actions_baked - actions_per_step)))
         mean_abs = float(np.mean(np.abs(actions_baked - actions_per_step)))
 
+        current_revision = model_info(cell["model_id"], token=os.environ.get("HF_TOKEN")).sha
+        if current_revision != model_revision:
+            raise RuntimeError(
+                f"Model revision changed during export: {model_revision} -> {current_revision}"
+            )
+
         log.info(
             "[%s] cos=%.10f, max_abs=%.3e, mean_abs=%.3e",
-            cell["label"], cos, max_abs, mean_abs,
+            cell["label"],
+            cos,
+            max_abs,
+            mean_abs,
         )
 
         results[cell["label"]] = {
             "cell": cell["label"],
             "model_id": cell["model_id"],
+            "model_revision": model_revision,
+            "model_digest": model_digest,
             "num_steps": cell["num_steps"],
             "cos": cos,
             "max_abs": max_abs,
@@ -281,6 +344,10 @@ def parity_test() -> dict:
             "actions_shape": list(actions_baked.shape),
             "used_provider_baked": actual_baked,
             "used_provider_per_step": actual_per_step,
+            "exports": {
+                "baked": hash_export_set(baked_dir),
+                "per_step": hash_export_set(per_step_dir),
+            },
             # Acceptance gate per research sidecar Lens 5
             "passes_cos_gate": cos >= 0.99999,
             "passes_max_abs_gate": max_abs <= 1e-5,
@@ -290,13 +357,17 @@ def parity_test() -> dict:
         # Free GPU memory before next cell
         del sess_baked, sess_per_step
         import gc
+
         gc.collect()
 
-    return {
+    result = {
         "cells": results,
         "all_passed": all(r["passes_overall"] for r in results.values()),
         "thresholds": {"cos_min": 0.99999, "max_abs_max": 1e-5},
     }
+    if namespace_binding is not None:
+        result["receipt_namespace"] = namespace_binding
+    return result
 
 
 def _past_kv_names(num_layers: int) -> list[str]:
@@ -310,15 +381,38 @@ def _past_kv_names(num_layers: int) -> list[str]:
 
 
 @app.local_entrypoint()
-def main():
+def main(
+    receipt_namespace: str = "",
+    source_repository: str = "",
+    source_sha: str = "",
+    workflow_run_id: int = 0,
+    workflow_run_attempt: int = 0,
+):
+    from tether.receipt_provenance import receipt_mode_binding, receipt_run_dir
+
+    namespace_binding = receipt_mode_binding(
+        receipt_namespace=receipt_namespace,
+        repository=source_repository,
+        source_sha=source_sha,
+        workflow_run_id=workflow_run_id,
+        workflow_run_attempt=workflow_run_attempt,
+    )
     print("=" * 60)
     print("Per-step expert ONNX parity test (gate 3)")
     print("=" * 60)
-    result = parity_test.remote()
+    result = parity_test.remote(
+        receipt_namespace,
+        source_repository,
+        source_sha,
+        workflow_run_id,
+        workflow_run_attempt,
+    )
 
     # Write receipt
-    receipt_path = Path(REPO_ROOT) / ".." / "reflex_context" / "per_step_parity_last_run.json"
-    receipt_path = receipt_path.resolve()
+    receipt_root = (Path(REPO_ROOT) / ".." / "reflex_context").resolve()
+    if namespace_binding is not None:
+        receipt_root = receipt_run_dir(receipt_root, str(namespace_binding["value"]))
+    receipt_path = receipt_root / "per_step_parity_last_run.json"
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     receipt_path.write_text(json.dumps(result, indent=2))
     print(f"\nReceipt written: {receipt_path}")

--- a/src/tether/exporters/decomposed.py
+++ b/src/tether/exporters/decomposed.py
@@ -52,6 +52,7 @@ is invoked here to get the shared denoise-step + cache-freeze patches.
 - Does NOT handle pi0 (the non-.5 variant). pi0 decomposed export is
   a separate future goal (pi0 has state_proj, different suffix shape).
 """
+
 from __future__ import annotations
 
 from concurrent.futures import ProcessPoolExecutor
@@ -84,13 +85,14 @@ _PI05_VISION_PATCHES_PER_VIEW: int = 256
 # pi0.5 path has historically produced roughly 13 GiB of ONNX/external data.
 # Using that estimate keeps auto on the sequential baseline for most hardware,
 # while still allowing explicit or truly high-VRAM parallel runs.
-_PI05_ESTIMATED_ONNX_BYTES: int = int(13.0 * 1024 ** 3)
+_PI05_ESTIMATED_ONNX_BYTES: int = int(13.0 * 1024**3)
 
 
 def export_pi05_decomposed(
     model_id: str,
     output_dir: str | Path,
     *,
+    revision: str | None = None,
     num_steps: int = 1,
     target: str = "desktop",
     student_checkpoint: str | Path | None = None,
@@ -104,6 +106,8 @@ def export_pi05_decomposed(
         model_id: HF repo id for the pi0.5 base/variant (e.g.
             ``"lerobot/pi05_libero_finetuned_v044"``). Ignored if
             ``student_checkpoint`` is provided.
+        revision: immutable Hugging Face commit used for both config and
+            weight loading. Receipt-producing exports must provide this.
         output_dir: where to write the two ONNX files + tether_config.json.
         num_steps: denoising steps baked into expert_denoise.onnx.
             1 for distilled students (target_time=1 path); 10 for the
@@ -140,6 +144,7 @@ def export_pi05_decomposed(
     if decision.mode == ExportMode.PARALLEL:
         return _export_pi05_decomposed_parallel(
             model_id=model_id,
+            revision=revision,
             output_dir=output_dir,
             num_steps=num_steps,
             target=target,
@@ -151,6 +156,7 @@ def export_pi05_decomposed(
 
     return _export_pi05_decomposed_sequential(
         model_id=model_id,
+        revision=revision,
         output_dir=output_dir,
         num_steps=num_steps,
         target=target,
@@ -164,6 +170,7 @@ def export_pi05_decomposed(
 def _export_pi05_decomposed_sequential(
     *,
     model_id: str,
+    revision: str | None = None,
     output_dir: Path,
     num_steps: int,
     target: str,
@@ -173,7 +180,7 @@ def _export_pi05_decomposed_sequential(
     per_step_expert: bool = False,
 ) -> dict[str, Any]:
     """Historical pi0.5 decomposed export path: one policy load, two passes."""
-    policy = _load_pi05_policy(model_id, num_steps, student_checkpoint, variant)
+    policy = _load_pi05_policy(model_id, num_steps, student_checkpoint, variant, revision=revision)
     past_kv_names = _past_kv_names()
     prefix_seq_len = _prefix_seq_len()
 
@@ -182,6 +189,7 @@ def _export_pi05_decomposed_sequential(
     # Free the prefix wrapper before building the expert — on A100-80GB we
     # OOM'd with both loaded + a second prefix forward for dummy inputs.
     import gc
+
     gc.collect()
 
     expert_meta = _export_pi05_expert_pass(
@@ -197,6 +205,7 @@ def _export_pi05_decomposed_sequential(
 
     return _write_decomposed_export_result(
         model_id=model_id,
+        revision=revision,
         output_dir=output_dir,
         num_steps=num_steps,
         target=target,
@@ -214,6 +223,7 @@ def _export_pi05_decomposed_sequential(
 def _export_pi05_decomposed_parallel(
     *,
     model_id: str,
+    revision: str | None = None,
     output_dir: Path,
     num_steps: int,
     target: str,
@@ -227,6 +237,7 @@ def _export_pi05_decomposed_parallel(
     prefix_seq_len = _prefix_seq_len()
     prefix_meta, expert_meta = _run_parallel_pi05_exports(
         model_id=model_id,
+        revision=revision,
         output_dir=output_dir,
         num_steps=num_steps,
         student_checkpoint=student_checkpoint,
@@ -239,6 +250,7 @@ def _export_pi05_decomposed_parallel(
 
     return _write_decomposed_export_result(
         model_id=model_id,
+        revision=revision,
         output_dir=output_dir,
         num_steps=num_steps,
         target=target,
@@ -256,6 +268,7 @@ def _export_pi05_decomposed_parallel(
 def _run_parallel_pi05_exports(
     *,
     model_id: str,
+    revision: str | None = None,
     output_dir: Path,
     num_steps: int,
     student_checkpoint: str | Path | None,
@@ -271,6 +284,7 @@ def _run_parallel_pi05_exports(
         prefix_future = pool.submit(
             _export_pi05_prefix_worker,
             model_id,
+            revision,
             str(output_dir),
             num_steps,
             student,
@@ -280,6 +294,7 @@ def _run_parallel_pi05_exports(
         expert_future = pool.submit(
             _export_pi05_expert_worker,
             model_id,
+            revision,
             str(output_dir),
             num_steps,
             student,
@@ -293,18 +308,20 @@ def _run_parallel_pi05_exports(
 
 def _export_pi05_prefix_worker(
     model_id: str,
+    revision: str | None,
     output_dir: str,
     num_steps: int,
     student_checkpoint: str | None,
     variant: str,
     past_kv_names: list[str],
 ) -> dict[str, Any]:
-    policy = _load_pi05_policy(model_id, num_steps, student_checkpoint, variant)
+    policy = _load_pi05_policy(model_id, num_steps, student_checkpoint, variant, revision=revision)
     return _export_pi05_prefix_pass(policy, Path(output_dir), past_kv_names)
 
 
 def _export_pi05_expert_worker(
     model_id: str,
+    revision: str | None,
     output_dir: str,
     num_steps: int,
     student_checkpoint: str | None,
@@ -313,7 +330,7 @@ def _export_pi05_expert_worker(
     prefix_seq_len: int,
     per_step_expert: bool = False,
 ) -> dict[str, Any]:
-    policy = _load_pi05_policy(model_id, num_steps, student_checkpoint, variant)
+    policy = _load_pi05_policy(model_id, num_steps, student_checkpoint, variant, revision=revision)
     return _export_pi05_expert_pass(
         policy=policy,
         output_dir=Path(output_dir),
@@ -330,6 +347,8 @@ def _load_pi05_policy(
     num_steps: int,
     student_checkpoint: str | Path | None,
     variant: str,
+    *,
+    revision: str | None = None,
 ):
     """Load and patch the pi0.5 policy exactly once for one export process."""
     _require_decomposed_deps()
@@ -355,6 +374,7 @@ def _load_pi05_policy(
                 f"got num_steps={num_steps}"
             )
         from tether.distill.snapflow_pi0_model import load_snapflow_student
+
         logger.info("[decomposed] Loading SnapFlow student from %s", student_checkpoint)
         policy = load_snapflow_student(student_checkpoint)
         if variant == "state_out":
@@ -363,18 +383,20 @@ def _load_pi05_policy(
             # SnapFlowPI05Pytorch; reset class then upgrade.
             from lerobot.policies.pi05.modeling_pi05 import PI05Pytorch
             from tether.distill.snapflow_pi0_model import enable_snapflow_state_out
+
             policy.model.__class__ = PI05Pytorch
             enable_snapflow_state_out(policy.model)
             logger.info("[decomposed] enabled state-out variant on student")
     else:
         from lerobot.policies.pi05.modeling_pi05 import PI05Policy
+
         logger.info("[decomposed] Loading %s", model_id)
         # Apply the same torch.compile suppression as monolithic export
         # — LIBERO-finetuned pi0.5 configs set compile_model=True.
         _orig_compile = torch.compile
-        torch.compile = lambda fn=None, *a, **kw: (fn if fn is not None else (lambda f: f))
+        torch.compile = lambda fn=None, *a, **kw: fn if fn is not None else (lambda f: f)
         try:
-            policy = PI05Policy.from_pretrained(model_id)
+            policy = PI05Policy.from_pretrained(model_id, revision=revision)
         finally:
             torch.compile = _orig_compile
 
@@ -426,14 +448,18 @@ def _export_pi05_prefix_pass(
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep_prefix = torch.export.export(
-            prefix_wrapper, tuple(prefix_dummy.values()),
-            dynamic_shapes=None, strict=False,
+            prefix_wrapper,
+            tuple(prefix_dummy.values()),
+            dynamic_shapes=None,
+            strict=False,
         )
     logger.info("[decomposed] prefix torch.export: %.1fs", time.time() - t0)
 
     t0 = time.time()
     torch.onnx.export(
-        ep_prefix, tuple(prefix_dummy.values()), str(prefix_path),
+        ep_prefix,
+        tuple(prefix_dummy.values()),
+        str(prefix_path),
         input_names=list(prefix_dummy.keys()),
         output_names=prefix_output_names,
         opset_version=19,
@@ -493,8 +519,7 @@ def _export_pi05_expert_pass(
     # torch.export Dim — deferred until parity is green.)
     past_kv_shape = (B, PI05_KV_HEADS, prefix_seq_len, PI05_HEAD_DIM)
     past_kv_dummies = [
-        torch.randn(past_kv_shape, dtype=torch.float32)
-        for _ in range(PI05_PALIGEMMA_LAYERS * 2)
+        torch.randn(past_kv_shape, dtype=torch.float32) for _ in range(PI05_PALIGEMMA_LAYERS * 2)
     ]
     prefix_pad_masks_dummy = torch.ones(B, prefix_seq_len, dtype=torch.bool)
 
@@ -527,13 +552,17 @@ def _export_pi05_expert_pass(
     expert_path = output_dir / "expert_denoise.onnx"
     shape_label = "per-step" if per_step_expert else f"baked num_steps={num_steps}"
     logger.info(
-        "[decomposed] Exporting expert (%s) → %s", shape_label, expert_path,
+        "[decomposed] Exporting expert (%s) → %s",
+        shape_label,
+        expert_path,
     )
     t0 = time.time()
     with torch_export_patches(patch_transformers=True):
         ep_expert = torch.export.export(
-            expert_wrapper, tuple(expert_dummy.values()),
-            dynamic_shapes=None, strict=False,
+            expert_wrapper,
+            tuple(expert_dummy.values()),
+            dynamic_shapes=None,
+            strict=False,
         )
     logger.info("[decomposed] expert torch.export: %.1fs", time.time() - t0)
 
@@ -553,7 +582,9 @@ def _export_pi05_expert_pass(
     # Reproduced + isolated 2026-04-30; see
     # 03_experiments/2026-04-30-per-step-parity-modal-a100.md.
     torch.onnx.export(
-        ep_expert, tuple(expert_dummy.values()), str(expert_path),
+        ep_expert,
+        tuple(expert_dummy.values()),
+        str(expert_path),
         input_names=list(expert_dummy.keys()),
         output_names=output_names,
         opset_version=19,
@@ -577,6 +608,7 @@ def _export_pi05_expert_pass(
 def _write_decomposed_export_result(
     *,
     model_id: str,
+    revision: str | None = None,
     output_dir: Path,
     num_steps: int,
     target: str,
@@ -594,6 +626,7 @@ def _write_decomposed_export_result(
 
     tether_cfg = {
         "model_id": model_id if student_checkpoint is None else str(student_checkpoint),
+        "model_revision": revision if student_checkpoint is None else None,
         "model_type": "pi05_decomposed_student" if student_checkpoint else "pi05_decomposed",
         "target": target,
         "num_denoising_steps": num_steps,
@@ -625,18 +658,29 @@ def _write_decomposed_export_result(
     canonical = build_producer_config(
         output_dir,
         producer="pi05_split",
-        model_id=tether_cfg["model_id"],
-        model_type=tether_cfg["model_type"],
+        model_id=str(tether_cfg["model_id"]),
+        model_type=str(tether_cfg["model_type"]),
         action_dim=action_dim,
         num_denoising_steps=num_steps,
         opset=19,
-        metadata={key: value for key, value in tether_cfg.items() if key not in {
-            "model_id", "model_type", "action_dim", "num_denoising_steps", "opset", "export_kind"
-        }},
+        metadata={
+            key: value
+            for key, value in tether_cfg.items()
+            if key
+            not in {
+                "model_id",
+                "model_type",
+                "action_dim",
+                "num_denoising_steps",
+                "opset",
+                "export_kind",
+            }
+        },
     )
     write_tether_config(output_dir, canonical)
     try:
         from tether.verification_report import write_verification_report
+
         write_verification_report(output_dir, parity=None)
     except Exception:
         pass
@@ -692,6 +736,7 @@ class Pi05PrefixWrapper:
     Defined as a lazy class built on first instantiation so we don't
     force lerobot import at module load. See ``_build_prefix_class``.
     """
+
     def __new__(cls, pi05_model):
         impl = _build_prefix_class()
         return impl(pi05_model)
@@ -702,6 +747,7 @@ class Pi05ExpertWrapper:
     + prefix_pad_masks + noise, runs the Euler loop (num_steps iterations;
     1 for SnapFlow students with target_time=1), returns actions.
     """
+
     def __new__(cls, pi05_model, num_steps):
         impl = _build_expert_class()
         return impl(pi05_model, num_steps)
@@ -724,6 +770,7 @@ class Pi05ExpertPerStepWrapper:
     See features/03_export/per-step-expert-export.md for the spec.
     Used when ``export_pi05_decomposed(..., per_step_expert=True)``.
     """
+
     def __new__(cls, pi05_model):
         impl = _build_expert_per_step_class()
         return impl(pi05_model)
@@ -750,15 +797,23 @@ def _build_prefix_class():
 
         def forward(
             self,
-            img_base, img_wrist_l, img_wrist_r,
-            mask_base, mask_wrist_l, mask_wrist_r,
-            lang_tokens, lang_masks,
+            img_base,
+            img_wrist_l,
+            img_wrist_r,
+            mask_base,
+            mask_wrist_l,
+            mask_wrist_r,
+            lang_tokens,
+            lang_masks,
         ):
             images = [img_base, img_wrist_l, img_wrist_r]
             img_masks = [mask_base, mask_wrist_l, mask_wrist_r]
 
             prefix_embs, prefix_pad_masks, prefix_att_masks = self.model.embed_prefix(
-                images, img_masks, lang_tokens, lang_masks,
+                images,
+                img_masks,
+                lang_tokens,
+                lang_masks,
             )
             prefix_att_2d = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
             prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
@@ -830,7 +885,7 @@ def _build_expert_class():
         def forward(self, *args):
             # args layout (default): 36 past_kv tensors + prefix_pad_masks + noise.
             # args layout (state_out): same + state tensor (last position).
-            past_flat = args[:PI05_PALIGEMMA_LAYERS * 2]
+            past_flat = args[: PI05_PALIGEMMA_LAYERS * 2]
             prefix_pad_masks = args[PI05_PALIGEMMA_LAYERS * 2]
             noise = args[PI05_PALIGEMMA_LAYERS * 2 + 1]
             state = args[PI05_PALIGEMMA_LAYERS * 2 + 2] if self._is_state_out else None
@@ -843,6 +898,7 @@ def _build_expert_class():
             # real DynamicCache (isinstance check) so we can't pass a
             # shim.
             from transformers.cache_utils import DynamicCache
+
             past_kv = DynamicCache()
             for i in range(PI05_PALIGEMMA_LAYERS):
                 past_kv.update(
@@ -861,8 +917,10 @@ def _build_expert_class():
             for step in range(self.n_steps):
                 time_val = 1.0 + step * dt
                 time_tensor = torch.full(
-                    (x_t.shape[0],), time_val,
-                    dtype=torch.float32, device=x_t.device,
+                    (x_t.shape[0],),
+                    time_val,
+                    dtype=torch.float32,
+                    device=x_t.device,
                 )
                 # State-out variant: pass state= to denoise_step. Default
                 # path leaves it unset.
@@ -931,7 +989,7 @@ def _build_expert_per_step_class():
         def forward(self, *args):
             # args layout (default):    36 past_kv + prefix_pad_masks + x_t + t.
             # args layout (state_out):  same + state tensor (last position).
-            past_flat = args[:PI05_PALIGEMMA_LAYERS * 2]
+            past_flat = args[: PI05_PALIGEMMA_LAYERS * 2]
             prefix_pad_masks = args[PI05_PALIGEMMA_LAYERS * 2]
             x_t = args[PI05_PALIGEMMA_LAYERS * 2 + 1]
             t = args[PI05_PALIGEMMA_LAYERS * 2 + 2]
@@ -941,6 +999,7 @@ def _build_expert_per_step_class():
             # (see _Pi05ExpertWrapper above) — same source of past_kv, same
             # layer-by-layer .update() pattern. Bit-for-bit equivalent.
             from transformers.cache_utils import DynamicCache
+
             past_kv = DynamicCache()
             for i in range(PI05_PALIGEMMA_LAYERS):
                 past_kv.update(
@@ -989,6 +1048,7 @@ class _FlatCache:
     — the only attributes pi_gemma's forward path reads from past_kv
     under our denoise_step patch.
     """
+
     def __init__(self, flat: tuple, num_layers: int):
         self.key_cache = [flat[2 * i] for i in range(num_layers)]
         self.value_cache = [flat[2 * i + 1] for i in range(num_layers)]
@@ -1006,6 +1066,7 @@ class _FlatCache:
 def _require_decomposed_deps() -> None:
     """Decomposed export shares the monolithic ``[monolithic]`` extra."""
     from tether.exporters.monolithic import _require_monolithic_deps
+
     _require_monolithic_deps()
 
 

--- a/src/tether/receipt_provenance.py
+++ b/src/tether/receipt_provenance.py
@@ -1,0 +1,1162 @@
+"""Trusted production and consumption of hardware parity receipts.
+
+The receipt payload and its manifest are separate GitHub artifacts.  That
+allows the manifest to bind the payload's server-assigned artifact id and
+digest without making the manifest self-referential.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import urllib.parse
+import urllib.request
+import zipfile
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+WORKFLOW_PATH = ".github/workflows/parity-receipts.yml"
+REQUIRED_PARITY_CELLS = frozenset({"pi05_teacher_n1", "pi05_teacher_n10"})
+EXPORT_FILES = (
+    "tether_config.json",
+    "vlm_prefix.onnx",
+    "expert_denoise.onnx",
+)
+PAYLOAD_FILES = (
+    "per_step_parity_last_run.json",
+    "per_step_overhead_last_run.json",
+    "per_step_e2e_latency_last_run.json",
+)
+ALLOWED_EVENTS = frozenset({"schedule", "workflow_dispatch", "push"})
+RECEIPT_RUNS_DIR = "receipt_runs"
+_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_RECEIPT_NAMESPACE_RE = re.compile(
+    r"^gh-[0-9a-f]{32}-sha-(?:[0-9a-f]{40}|[0-9a-f]{64})-"
+    r"run-[1-9][0-9]*-attempt-[1-9][0-9]*$"
+)
+
+
+class ReceiptVerificationError(ValueError):
+    """Raised when a receipt or its GitHub provenance is not trusted."""
+
+
+def build_receipt_namespace(
+    repository: str, source_sha: str, workflow_run_id: int, workflow_run_attempt: int
+) -> str:
+    """Build the immutable, path-safe namespace for one GitHub run attempt."""
+    if not isinstance(repository, str) or not _REPOSITORY_RE.fullmatch(repository):
+        raise ReceiptVerificationError("repository must be an owner/name slug")
+    normalized_sha = source_sha.lower() if isinstance(source_sha, str) else ""
+    if len(normalized_sha) not in {40, 64} or any(
+        char not in "0123456789abcdef" for char in normalized_sha
+    ):
+        raise ReceiptVerificationError("source_sha must be an immutable Git SHA")
+    if (
+        isinstance(workflow_run_id, bool)
+        or not isinstance(workflow_run_id, int)
+        or workflow_run_id <= 0
+    ):
+        raise ReceiptVerificationError("workflow_run_id must be a positive integer")
+    if (
+        isinstance(workflow_run_attempt, bool)
+        or not isinstance(workflow_run_attempt, int)
+        or workflow_run_attempt <= 0
+    ):
+        raise ReceiptVerificationError("workflow_run_attempt must be a positive integer")
+    repository_digest = _sha256_bytes(repository.lower().encode())[:32]
+    return (
+        f"gh-{repository_digest}-sha-{normalized_sha}-"
+        f"run-{workflow_run_id}-attempt-{workflow_run_attempt}"
+    )
+
+
+def receipt_namespace_binding(
+    *,
+    receipt_namespace: str,
+    repository: str,
+    source_sha: str,
+    workflow_run_id: int,
+    workflow_run_attempt: int,
+) -> dict[str, object]:
+    """Validate and serialize the complete namespace provenance binding."""
+    expected = build_receipt_namespace(
+        repository, source_sha, workflow_run_id, workflow_run_attempt
+    )
+    if receipt_namespace != expected:
+        raise ReceiptVerificationError(
+            f"receipt namespace does not match immutable run binding: {receipt_namespace!r}"
+        )
+    return {
+        "value": expected,
+        "repository": repository,
+        "source_sha": source_sha.lower(),
+        "workflow_run_id": workflow_run_id,
+        "workflow_run_attempt": workflow_run_attempt,
+    }
+
+
+def receipt_mode_binding(
+    *,
+    receipt_namespace: str = "",
+    repository: str = "",
+    source_sha: str = "",
+    workflow_run_id: int = 0,
+    workflow_run_attempt: int = 0,
+) -> dict[str, object] | None:
+    """Return a binding for receipt mode or explicit legacy mode outside it."""
+    supplied = (
+        bool(receipt_namespace),
+        bool(repository),
+        bool(source_sha),
+        workflow_run_id != 0,
+        workflow_run_attempt != 0,
+    )
+    if not any(supplied):
+        return None
+    if not all(supplied):
+        raise ReceiptVerificationError(
+            "receipt mode requires namespace, repository, SHA, run id, and run attempt"
+        )
+    return receipt_namespace_binding(
+        receipt_namespace=receipt_namespace,
+        repository=repository,
+        source_sha=source_sha,
+        workflow_run_id=workflow_run_id,
+        workflow_run_attempt=workflow_run_attempt,
+    )
+
+
+def receipt_run_dir(root: Path, receipt_namespace: str) -> Path:
+    """Resolve a namespace beneath a run root without accepting path syntax."""
+    if not isinstance(receipt_namespace, str) or not _RECEIPT_NAMESPACE_RE.fullmatch(
+        receipt_namespace
+    ):
+        raise ReceiptVerificationError("receipt namespace is unsafe or non-canonical")
+    return root / RECEIPT_RUNS_DIR / receipt_namespace
+
+
+def receipt_artifact_names(receipt_namespace: str) -> tuple[str, str]:
+    """Return the exact payload and manifest artifact names for one attempt."""
+    if not isinstance(receipt_namespace, str) or not _RECEIPT_NAMESPACE_RE.fullmatch(
+        receipt_namespace
+    ):
+        raise ReceiptVerificationError("receipt namespace is unsafe or non-canonical")
+    return (
+        f"parity-receipts-payload-{receipt_namespace}",
+        f"parity-receipt-manifest-{receipt_namespace}",
+    )
+
+
+def _validate_namespace_binding(value: object, expected: Mapping[str, object], field: str) -> None:
+    binding = _require_mapping(value, field)
+    if set(binding) != set(expected) or dict(binding) != dict(expected):
+        raise ReceiptVerificationError(f"{field} does not match immutable run namespace")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_time(value: object, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise ReceiptVerificationError(f"{field} must be an ISO-8601 string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ReceiptVerificationError(f"{field} is not valid ISO-8601") from exc
+    if parsed.tzinfo is None:
+        raise ReceiptVerificationError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _isoformat(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def hash_export_set(export_dir: Path) -> dict[str, dict[str, object]]:
+    """Hash the complete runtime export set used by receipt producers."""
+    result: dict[str, dict[str, object]] = {}
+    for name in EXPORT_FILES:
+        path = export_dir / name
+        if not path.is_file() or path.is_symlink():
+            raise ReceiptVerificationError(f"required export file is missing: {path}")
+        result[name] = {
+            "path": name,
+            "sha256": sha256_file(path),
+            "size": path.stat().st_size,
+        }
+    return result
+
+
+def require_cuda_provider_lists(
+    prefix_providers: object, expert_providers: object
+) -> tuple[list[str], list[str]]:
+    """Require CUDA to be the active provider for both decomposed sessions."""
+    if not isinstance(prefix_providers, list) or not all(
+        isinstance(provider, str) for provider in prefix_providers
+    ):
+        raise ReceiptVerificationError("prefix provider list is invalid")
+    if not isinstance(expert_providers, list) or not all(
+        isinstance(provider, str) for provider in expert_providers
+    ):
+        raise ReceiptVerificationError("expert provider list is invalid")
+    if not prefix_providers or prefix_providers[0] != "CUDAExecutionProvider":
+        raise ReceiptVerificationError(
+            f"vlm_prefix did not use CUDAExecutionProvider: {prefix_providers!r}"
+        )
+    if not expert_providers or expert_providers[0] != "CUDAExecutionProvider":
+        raise ReceiptVerificationError(
+            f"expert_denoise did not use CUDAExecutionProvider: {expert_providers!r}"
+        )
+    return list(prefix_providers), list(expert_providers)
+
+
+def _canonical_digest(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return _sha256_bytes(encoded)
+
+
+def _normalize_digest(value: object, field: str, *, required: bool = True) -> str:
+    if not isinstance(value, str):
+        if required:
+            raise ReceiptVerificationError(f"{field} must be a SHA-256 digest")
+        return ""
+    digest = value.removeprefix("sha256:").lower()
+    if not digest and not required:
+        return ""
+    if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+        raise ReceiptVerificationError(f"{field} must be a SHA-256 digest")
+    return digest
+
+
+def _require_mapping(value: object, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ReceiptVerificationError(f"{field} must be an object")
+    return value
+
+
+def _safe_relative_path(value: object) -> PurePosixPath:
+    if not isinstance(value, str):
+        raise ReceiptVerificationError("receipt file path must be a string")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or not path.parts:
+        raise ReceiptVerificationError(f"unsafe receipt file path: {value!r}")
+    return path
+
+
+def _read_payload(payload_dir: Path) -> dict[str, dict[str, Any]]:
+    measurements: dict[str, dict[str, Any]] = {}
+    for name in PAYLOAD_FILES:
+        path = payload_dir / name
+        if not path.is_file() or path.is_symlink():
+            raise ReceiptVerificationError(f"required payload file is missing: {name}")
+        try:
+            value = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ReceiptVerificationError(f"invalid JSON payload: {name}") from exc
+        if not isinstance(value, dict):
+            raise ReceiptVerificationError(f"payload must be a JSON object: {name}")
+        measurements[name] = value
+    return measurements
+
+
+def _validate_payload_namespace(
+    measurements: Mapping[str, Mapping[str, Any]], expected: Mapping[str, object]
+) -> None:
+    for name in PAYLOAD_FILES:
+        measurement = _require_mapping(measurements.get(name), name)
+        _validate_namespace_binding(
+            measurement.get("receipt_namespace"), expected, f"{name}.receipt_namespace"
+        )
+    e2e = _require_mapping(
+        measurements.get("per_step_e2e_latency_last_run.json"), "e2e measurement"
+    )
+    for variant in ("baked", "per_step"):
+        nested = _require_mapping(e2e.get(variant), f"e2e {variant}")
+        _validate_namespace_binding(
+            nested.get("receipt_namespace"),
+            expected,
+            f"e2e {variant}.receipt_namespace",
+        )
+
+
+def _normalize_export_set(value: object, field: str) -> dict[str, str]:
+    export_set = _require_mapping(value, field)
+    if set(export_set) != set(EXPORT_FILES):
+        raise ReceiptVerificationError(f"{field} must contain exactly {', '.join(EXPORT_FILES)}")
+    normalized: dict[str, str] = {}
+    for name in EXPORT_FILES:
+        file_info = _require_mapping(export_set.get(name), f"{field}.{name}")
+        if file_info.get("path") != name:
+            raise ReceiptVerificationError(f"{field}.{name}.path is not canonical")
+        if not isinstance(file_info.get("size"), int) or int(file_info["size"]) <= 0:
+            raise ReceiptVerificationError(f"{field}.{name}.size must be positive")
+        normalized[name] = _normalize_digest(file_info.get("sha256"), f"{field}.{name}.sha256")
+    return normalized
+
+
+def _export_identity(measurements: Mapping[str, Mapping[str, Any]]) -> tuple[str, str]:
+    parity = _require_mapping(
+        measurements.get("per_step_parity_last_run.json"), "parity measurement"
+    )
+    cells = _require_mapping(parity.get("cells"), "parity cells")
+    if set(cells) != REQUIRED_PARITY_CELLS:
+        raise ReceiptVerificationError(
+            "parity receipt cells must be exactly "
+            f"{sorted(REQUIRED_PARITY_CELLS)!r}; got {sorted(str(key) for key in cells)!r}"
+        )
+    artifacts: dict[str, Any] = {}
+    for label, raw_cell in sorted(cells.items()):
+        cell = _require_mapping(raw_cell, f"parity cell {label}")
+        for provider_field in ("used_provider_baked", "used_provider_per_step"):
+            if cell.get(provider_field) != "CUDAExecutionProvider":
+                raise ReceiptVerificationError(
+                    f"parity cell {label}.{provider_field} did not use CUDA"
+                )
+        cell_exports = _require_mapping(cell.get("exports"), f"parity cell {label}.exports")
+        normalized: dict[str, dict[str, str]] = {}
+        for variant in ("baked", "per_step"):
+            normalized[variant] = _normalize_export_set(
+                cell_exports.get(variant), f"parity cell {label}.exports.{variant}"
+            )
+        artifacts[str(label)] = normalized
+
+    expected_runtime_exports = artifacts.get("pi05_teacher_n10")
+    if not isinstance(expected_runtime_exports, Mapping):
+        raise ReceiptVerificationError("parity receipt has no pi05_teacher_n10 exports")
+    overhead = _require_mapping(
+        measurements.get("per_step_overhead_last_run.json"), "overhead measurement"
+    )
+    overhead_exports = _require_mapping(overhead.get("exports"), "overhead exports")
+    overhead_providers = _require_mapping(overhead.get("providers"), "overhead providers")
+    e2e_identity: dict[str, Any] = {}
+    for variant in ("baked", "per_step"):
+        if overhead_providers.get(variant) != "CUDAExecutionProvider":
+            raise ReceiptVerificationError(f"overhead {variant} did not use CUDA")
+    e2e = _require_mapping(
+        measurements.get("per_step_e2e_latency_last_run.json"), "e2e measurement"
+    )
+    for variant in ("baked", "per_step"):
+        overhead_export = _normalize_export_set(
+            overhead_exports.get(variant), f"overhead exports.{variant}"
+        )
+        e2e_variant = _require_mapping(e2e.get(variant), f"e2e {variant}")
+        e2e_export = _normalize_export_set(e2e_variant.get("export"), f"e2e {variant}.export")
+        expected_export = expected_runtime_exports[variant]
+        if overhead_export != expected_export:
+            raise ReceiptVerificationError(
+                f"overhead {variant} export does not match parity export"
+            )
+        if e2e_export != expected_export:
+            raise ReceiptVerificationError(f"e2e {variant} export does not match parity export")
+        e2e_providers = _require_mapping(e2e_variant.get("providers"), f"e2e {variant}.providers")
+        require_cuda_provider_lists(
+            e2e_providers.get("vlm_prefix"),
+            e2e_providers.get("expert_denoise"),
+        )
+        e2e_identity[variant] = {
+            "export": e2e_export,
+            "receipt_namespace": dict(
+                _require_mapping(
+                    e2e_variant.get("receipt_namespace"),
+                    f"e2e {variant}.receipt_namespace",
+                )
+            ),
+        }
+    return "pi05-per-step-expert", _canonical_digest(
+        {"parity_exports": artifacts, "e2e": e2e_identity}
+    )
+
+
+def _measurement_model_ids(
+    measurements: Mapping[str, Mapping[str, Any]],
+) -> set[str]:
+    parity = _require_mapping(
+        measurements.get("per_step_parity_last_run.json"), "parity measurement"
+    )
+    cells = _require_mapping(parity.get("cells"), "parity cells")
+    model_ids: set[str] = set()
+    for label, raw_cell in cells.items():
+        cell = _require_mapping(raw_cell, f"parity cell {label}")
+        model_id = cell.get("model_id")
+        if not isinstance(model_id, str) or not model_id:
+            raise ReceiptVerificationError(f"parity cell {label} has no model_id")
+        model_ids.add(model_id)
+    return model_ids
+
+
+def _measurement_model_digests(
+    measurements: Mapping[str, Mapping[str, Any]],
+) -> set[str]:
+    parity = _require_mapping(
+        measurements.get("per_step_parity_last_run.json"), "parity measurement"
+    )
+    cells = _require_mapping(parity.get("cells"), "parity cells")
+    return {
+        _normalize_digest(
+            _require_mapping(raw_cell, f"parity cell {label}").get("model_digest"),
+            f"parity cell {label}.model_digest",
+        )
+        for label, raw_cell in cells.items()
+    }
+
+
+def _measurement_model_revision(
+    measurements: Mapping[str, Mapping[str, Any]],
+) -> str:
+    parity = _require_mapping(
+        measurements.get("per_step_parity_last_run.json"), "parity measurement"
+    )
+    cells = _require_mapping(parity.get("cells"), "parity cells")
+    raw_revisions = [
+        _require_mapping(raw_cell, f"parity cell {label}").get("model_revision")
+        for label, raw_cell in cells.items()
+    ]
+    if any(not isinstance(revision, str) for revision in raw_revisions):
+        raise ReceiptVerificationError("payload model revision must be a string")
+    revisions = set(raw_revisions)
+    if len(revisions) != 1:
+        raise ReceiptVerificationError("payload has inconsistent model revisions")
+    revision = revisions.pop()
+    if (
+        not isinstance(revision, str)
+        or len(revision) not in {40, 64}
+        or any(char not in "0123456789abcdef" for char in revision.lower())
+    ):
+        raise ReceiptVerificationError("payload model revision is not an immutable hash")
+    return revision.lower()
+
+
+def build_receipt_manifest(
+    *,
+    payload_dir: Path,
+    repository: str,
+    source_sha: str,
+    source_ref: str,
+    workflow_run_id: int,
+    workflow_run_attempt: int,
+    receipt_namespace: str,
+    event: str,
+    payload_artifact_id: int,
+    payload_artifact_name: str,
+    payload_artifact_digest: str,
+    model_id: str,
+    model_digest: str,
+    expires_in_hours: int = 168,
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a manifest after the payload artifact has been uploaded."""
+    if expires_in_hours <= 0:
+        raise ReceiptVerificationError("expires_in_hours must be positive")
+    if event not in ALLOWED_EVENTS:
+        raise ReceiptVerificationError(f"untrusted producer event: {event}")
+    if not _allowed_ref(source_ref):
+        raise ReceiptVerificationError(f"untrusted producer ref: {source_ref}")
+
+    namespace = receipt_namespace_binding(
+        receipt_namespace=receipt_namespace,
+        repository=repository,
+        source_sha=source_sha,
+        workflow_run_id=workflow_run_id,
+        workflow_run_attempt=workflow_run_attempt,
+    )
+    expected_payload_name, _ = receipt_artifact_names(receipt_namespace)
+    if payload_artifact_name != expected_payload_name:
+        raise ReceiptVerificationError(
+            "payload artifact name does not match immutable run namespace"
+        )
+    measurements = _read_payload(payload_dir)
+    _validate_payload_namespace(measurements, namespace)
+    found_model_ids = _measurement_model_ids(measurements)
+    if found_model_ids != {model_id}:
+        raise ReceiptVerificationError(
+            f"payload model ids {sorted(found_model_ids)!r} do not match {model_id!r}"
+        )
+    normalized_model_digest = _normalize_digest(model_digest, "model.digest")
+    model_revision = _measurement_model_revision(measurements)
+    derived_model_digest = _sha256_bytes(f"huggingface:{model_id}@{model_revision}".encode())
+    if normalized_model_digest != derived_model_digest:
+        raise ReceiptVerificationError(
+            "approved model digest does not bind the payload model revision"
+        )
+    if _measurement_model_digests(measurements) != {normalized_model_digest}:
+        raise ReceiptVerificationError(
+            "payload model digest does not match the approved model digest"
+        )
+    export_id, export_digest = _export_identity(measurements)
+    generated = (generated_at or _utc_now()).astimezone(timezone.utc)
+
+    files = []
+    for name in PAYLOAD_FILES:
+        path = payload_dir / name
+        files.append({"path": name, "sha256": sha256_file(path), "size": path.stat().st_size})
+
+    thresholds = {name: value.get("thresholds", {}) for name, value in measurements.items()}
+    try:
+        modal_version = importlib.metadata.version("modal")
+    except importlib.metadata.PackageNotFoundError:
+        modal_version = "unknown"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": {"repository": repository, "sha": source_sha, "ref": source_ref},
+        "receipt_namespace": namespace,
+        "producer": {
+            "workflow_path": WORKFLOW_PATH,
+            "workflow_run_id": workflow_run_id,
+            "workflow_run_attempt": workflow_run_attempt,
+            "event": event,
+        },
+        "artifact": {
+            "id": payload_artifact_id,
+            "name": payload_artifact_name,
+            "digest": f"sha256:{_normalize_digest(payload_artifact_digest, 'artifact.digest')}",
+        },
+        "generated_at": _isoformat(generated),
+        "expires_at": _isoformat(generated + timedelta(hours=expires_in_hours)),
+        "model": {
+            "id": model_id,
+            "revision": model_revision,
+            "digest": f"sha256:{normalized_model_digest}",
+        },
+        "export": {"id": export_id, "digest": f"sha256:{export_digest}"},
+        "hardware": {"provider": "Modal", "accelerator": "A100-80GB"},
+        "backend": {
+            "runtime": "onnxruntime-gpu",
+            "execution_provider": "CUDAExecutionProvider",
+        },
+        "thresholds": thresholds,
+        "measurements": measurements,
+        "files": files,
+        "producer_tools": {
+            "python": sys.version.split()[0],
+            "modal": modal_version,
+            "upload_artifact": "actions/upload-artifact@v4",
+        },
+    }
+
+
+def _branch_from_ref(ref: str) -> str:
+    prefix = "refs/heads/"
+    return ref[len(prefix) :] if ref.startswith(prefix) else ref
+
+
+def _allowed_ref(ref: str) -> bool:
+    branch = _branch_from_ref(ref)
+    return branch == "main" or branch.startswith("release/")
+
+
+def validate_trusted_run(
+    run: Mapping[str, Any], *, expected_repository: str, expected_sha: str
+) -> None:
+    """Validate server-returned run metadata before trusting a run id."""
+    if run.get("head_sha") != expected_sha:
+        raise ReceiptVerificationError("workflow run head_sha does not match target SHA")
+    if run.get("event") not in ALLOWED_EVENTS or run.get("event") == "pull_request":
+        raise ReceiptVerificationError("workflow run event is not allowlisted")
+    if run.get("status") != "completed" or run.get("conclusion") != "success":
+        raise ReceiptVerificationError("workflow run did not complete successfully")
+    path = run.get("path")
+    if not isinstance(path, str) or path.split("@", 1)[0] != WORKFLOW_PATH:
+        raise ReceiptVerificationError("workflow run path is not the allowlisted producer")
+    branch = run.get("head_branch")
+    if not isinstance(branch, str) or not _allowed_ref(branch):
+        raise ReceiptVerificationError("workflow run ref is not allowlisted")
+    event = run.get("event")
+    if event == "schedule" and branch != "main":
+        raise ReceiptVerificationError("scheduled receipts must be produced from main")
+    if event == "push" and not branch.startswith("release/"):
+        raise ReceiptVerificationError("push receipts are allowed only on release branches")
+    head_repo = _require_mapping(run.get("head_repository"), "workflow head_repository")
+    if head_repo.get("full_name") != expected_repository:
+        raise ReceiptVerificationError("workflow run came from an untrusted repository")
+    if not isinstance(run.get("id"), int) or int(run["id"]) <= 0:
+        raise ReceiptVerificationError("workflow run id is invalid")
+    if not isinstance(run.get("run_attempt"), int) or int(run["run_attempt"]) <= 0:
+        raise ReceiptVerificationError("workflow run attempt is invalid")
+
+
+def select_trusted_run(
+    runs: Sequence[Mapping[str, Any]], *, expected_repository: str, expected_sha: str
+) -> Mapping[str, Any]:
+    trusted = []
+    for run in runs:
+        try:
+            validate_trusted_run(
+                run, expected_repository=expected_repository, expected_sha=expected_sha
+            )
+        except ReceiptVerificationError:
+            continue
+        trusted.append(run)
+    if not trusted:
+        raise ReceiptVerificationError(f"no trusted {WORKFLOW_PATH} run exists for {expected_sha}")
+    return max(
+        trusted,
+        key=lambda item: (
+            str(item.get("created_at", "")),
+            int(item.get("run_attempt", 0)),
+        ),
+    )
+
+
+def verify_receipt_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    payload_dir: Path,
+    trusted_run: Mapping[str, Any],
+    trusted_artifact: Mapping[str, Any],
+    expected_repository: str,
+    expected_sha: str,
+    expected_model_id: str,
+    expected_model_digest: str,
+    expected_export_id: str,
+    expected_export_digest: str,
+    now: datetime | None = None,
+) -> None:
+    """Verify provenance, freshness, identity, and every payload byte."""
+    validate_trusted_run(
+        trusted_run, expected_repository=expected_repository, expected_sha=expected_sha
+    )
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ReceiptVerificationError("unsupported receipt schema_version")
+
+    source = _require_mapping(manifest.get("source"), "source")
+    if source.get("repository") != expected_repository or source.get("sha") != expected_sha:
+        raise ReceiptVerificationError("receipt source does not match target")
+    branch = str(trusted_run.get("head_branch"))
+    if _branch_from_ref(str(source.get("ref", ""))) != branch:
+        raise ReceiptVerificationError("receipt source ref does not match workflow run")
+
+    producer = _require_mapping(manifest.get("producer"), "producer")
+    if producer.get("workflow_path") != WORKFLOW_PATH:
+        raise ReceiptVerificationError("receipt workflow is not allowlisted")
+    if producer.get("workflow_run_id") != trusted_run.get("id"):
+        raise ReceiptVerificationError("receipt contains a forged workflow run id")
+    if producer.get("workflow_run_attempt") != trusted_run.get("run_attempt"):
+        raise ReceiptVerificationError("receipt workflow run attempt does not match GitHub")
+    if producer.get("event") != trusted_run.get("event"):
+        raise ReceiptVerificationError("receipt event does not match workflow run")
+    namespace = receipt_namespace_binding(
+        receipt_namespace=str(
+            _require_mapping(manifest.get("receipt_namespace"), "receipt_namespace").get(
+                "value", ""
+            )
+        ),
+        repository=expected_repository,
+        source_sha=expected_sha,
+        workflow_run_id=int(trusted_run["id"]),
+        workflow_run_attempt=int(trusted_run["run_attempt"]),
+    )
+    _validate_namespace_binding(manifest.get("receipt_namespace"), namespace, "receipt_namespace")
+    expected_payload_name, _ = receipt_artifact_names(str(namespace["value"]))
+
+    generated_at = _parse_time(manifest.get("generated_at"), "generated_at")
+    expires_at = _parse_time(manifest.get("expires_at"), "expires_at")
+    current = (now or _utc_now()).astimezone(timezone.utc)
+    if expires_at <= generated_at:
+        raise ReceiptVerificationError("receipt expiry is not after generation")
+    if generated_at > current + timedelta(minutes=5):
+        raise ReceiptVerificationError("receipt generated_at is in the future")
+    if current >= expires_at:
+        raise ReceiptVerificationError("receipt has expired")
+
+    model = _require_mapping(manifest.get("model"), "model")
+    if model.get("id") != expected_model_id:
+        raise ReceiptVerificationError("receipt model id does not match expected model")
+    if _normalize_digest(model.get("digest"), "model.digest") != _normalize_digest(
+        expected_model_digest, "expected_model_digest"
+    ):
+        raise ReceiptVerificationError("receipt model digest does not match expected model")
+    model_revision = model.get("revision")
+    derived_model_digest = _sha256_bytes(
+        f"huggingface:{expected_model_id}@{model_revision}".encode()
+    )
+    if derived_model_digest != _normalize_digest(expected_model_digest, "expected_model_digest"):
+        raise ReceiptVerificationError("receipt model revision does not match model digest")
+
+    export = _require_mapping(manifest.get("export"), "export")
+    if export.get("id") != expected_export_id:
+        raise ReceiptVerificationError("receipt export id does not match expected export")
+    if _normalize_digest(export.get("digest"), "export.digest") != _normalize_digest(
+        expected_export_digest, "expected_export_digest"
+    ):
+        raise ReceiptVerificationError("receipt export digest does not match expected export")
+
+    artifact = _require_mapping(manifest.get("artifact"), "artifact")
+    if artifact.get("id") != trusted_artifact.get("id"):
+        raise ReceiptVerificationError("receipt payload artifact id does not match GitHub")
+    if artifact.get("name") != trusted_artifact.get("name"):
+        raise ReceiptVerificationError("receipt payload artifact name does not match GitHub")
+    if artifact.get("name") != expected_payload_name:
+        raise ReceiptVerificationError(
+            "receipt payload artifact name does not match immutable run namespace"
+        )
+    receipt_artifact_digest = _normalize_digest(artifact.get("digest"), "artifact.digest")
+    api_digest = _normalize_digest(
+        trusted_artifact.get("digest"), "GitHub artifact digest", required=False
+    )
+    if api_digest and receipt_artifact_digest != api_digest:
+        raise ReceiptVerificationError("receipt payload artifact digest does not match GitHub")
+
+    files = manifest.get("files")
+    if not isinstance(files, list):
+        raise ReceiptVerificationError("files must be a list")
+    expected_paths = set(PAYLOAD_FILES)
+    seen: set[str] = set()
+    for raw_file in files:
+        file_info = _require_mapping(raw_file, "files entry")
+        relative = _safe_relative_path(file_info.get("path"))
+        relative_name = relative.as_posix()
+        if relative_name in seen:
+            raise ReceiptVerificationError(f"duplicate receipt file: {relative_name}")
+        seen.add(relative_name)
+        path = payload_dir.joinpath(*relative.parts)
+        if not path.is_file() or path.is_symlink():
+            raise ReceiptVerificationError(f"receipt payload file is missing: {relative_name}")
+        if path.stat().st_size != file_info.get("size"):
+            raise ReceiptVerificationError(f"receipt payload size changed: {relative_name}")
+        expected_hash = _normalize_digest(file_info.get("sha256"), "file sha256")
+        if sha256_file(path) != expected_hash:
+            raise ReceiptVerificationError(f"receipt payload hash changed: {relative_name}")
+    if seen != expected_paths:
+        raise ReceiptVerificationError("receipt payload file set is incomplete or unexpected")
+
+    measurements = _read_payload(payload_dir)
+    _validate_payload_namespace(measurements, namespace)
+    actual_payload_files = {
+        path.relative_to(payload_dir).as_posix()
+        for path in payload_dir.rglob("*")
+        if path.is_file()
+    }
+    if actual_payload_files != expected_paths:
+        raise ReceiptVerificationError("receipt payload contains unexpected files")
+    if manifest.get("measurements") != measurements:
+        raise ReceiptVerificationError("receipt measurements do not match payload files")
+    expected_thresholds = {
+        name: value.get("thresholds", {}) for name, value in measurements.items()
+    }
+    if manifest.get("thresholds") != expected_thresholds:
+        raise ReceiptVerificationError("receipt thresholds do not match payload files")
+    payload_export_id, payload_export_digest = _export_identity(measurements)
+    if payload_export_id != expected_export_id or payload_export_digest != _normalize_digest(
+        expected_export_digest, "expected_export_digest"
+    ):
+        raise ReceiptVerificationError("payload export identity does not match expected export")
+    if _measurement_model_ids(measurements) != {expected_model_id}:
+        raise ReceiptVerificationError("payload model identity does not match expected model")
+    if _measurement_model_revision(measurements) != model_revision:
+        raise ReceiptVerificationError("payload model revision does not match receipt")
+    if _measurement_model_digests(measurements) != {
+        _normalize_digest(expected_model_digest, "expected_model_digest")
+    }:
+        raise ReceiptVerificationError("payload model digest does not match expected model")
+
+
+class GitHubActionsClient:
+    """Minimal GitHub Actions API client with an injectable transport."""
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        api_url: str = "https://api.github.com",
+        transport: Callable[[urllib.request.Request], bytes] | None = None,
+    ) -> None:
+        if not token:
+            raise ReceiptVerificationError("a GitHub token is required")
+        self._token = token
+        self._api_url = api_url.rstrip("/")
+        self._transport = transport or self._urlopen
+
+    @staticmethod
+    def _urlopen(request: urllib.request.Request) -> bytes:
+        with urllib.request.urlopen(request, timeout=60) as response:  # noqa: S310
+            return response.read()
+
+    def get_bytes(self, path: str, query: Mapping[str, str] | None = None) -> bytes:
+        url = f"{self._api_url}{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self._token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "tether-receipt-verifier",
+            },
+        )
+        return self._transport(request)
+
+    def get_json(self, path: str, query: Mapping[str, str] | None = None) -> dict[str, Any]:
+        try:
+            value = json.loads(self.get_bytes(path, query))
+        except json.JSONDecodeError as exc:
+            raise ReceiptVerificationError("GitHub returned invalid JSON") from exc
+        if not isinstance(value, dict):
+            raise ReceiptVerificationError("GitHub returned an unexpected response")
+        return value
+
+
+def _verify_download_digest(data: bytes, artifact: Mapping[str, Any]) -> None:
+    digest = _normalize_digest(artifact.get("digest"), "GitHub artifact digest", required=False)
+    if digest and _sha256_bytes(data) != digest:
+        raise ReceiptVerificationError("downloaded artifact digest does not match GitHub")
+
+
+def _extract_zip(data: bytes, destination: Path) -> None:
+    archive_path = destination / "artifact.zip"
+    archive_path.write_bytes(data)
+    with zipfile.ZipFile(archive_path) as archive:
+        for info in archive.infolist():
+            relative = _safe_relative_path(info.filename)
+            target = destination.joinpath(*relative.parts)
+            if info.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(info) as source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+    archive_path.unlink()
+
+
+def download_verified_receipts(
+    *,
+    repository: str,
+    expected_sha: str,
+    expected_model_id: str,
+    expected_model_digest: str,
+    expected_export_id: str,
+    expected_export_digest: str,
+    destination: Path,
+    token: str,
+    client: GitHubActionsClient | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Discover, download, and verify receipts for an exact target SHA."""
+    api = client or GitHubActionsClient(token)
+    encoded_workflow = urllib.parse.quote(WORKFLOW_PATH, safe="")
+    runs_response = api.get_json(
+        f"/repos/{repository}/actions/workflows/{encoded_workflow}/runs",
+        {
+            "head_sha": expected_sha,
+            "status": "success",
+            "exclude_pull_requests": "true",
+            "per_page": "100",
+        },
+    )
+    runs = runs_response.get("workflow_runs")
+    if not isinstance(runs, list):
+        raise ReceiptVerificationError("GitHub workflow run response is malformed")
+    run = select_trusted_run(runs, expected_repository=repository, expected_sha=expected_sha)
+    run_id = int(run["id"])
+    namespace = build_receipt_namespace(
+        repository,
+        expected_sha,
+        run_id,
+        int(run["run_attempt"]),
+    )
+    expected_payload_name, expected_manifest_name = receipt_artifact_names(namespace)
+    artifacts_response = api.get_json(
+        f"/repos/{repository}/actions/runs/{run_id}/artifacts", {"per_page": "100"}
+    )
+    artifacts = artifacts_response.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ReceiptVerificationError("GitHub artifact response is malformed")
+
+    manifest_candidates = [
+        item
+        for item in artifacts
+        if isinstance(item, Mapping)
+        and item.get("name") == expected_manifest_name
+        and not item.get("expired")
+    ]
+    if len(manifest_candidates) != 1:
+        raise ReceiptVerificationError("trusted run has no unique receipt manifest artifact")
+    manifest_artifact = manifest_candidates[0]
+
+    manifest_zip = api.get_bytes(
+        f"/repos/{repository}/actions/artifacts/{int(manifest_artifact['id'])}/zip"
+    )
+    _verify_download_digest(manifest_zip, manifest_artifact)
+
+    with tempfile.TemporaryDirectory(prefix="tether-receipt-") as temp_name:
+        temp = Path(temp_name)
+        manifest_dir = temp / "manifest"
+        manifest_dir.mkdir()
+        _extract_zip(manifest_zip, manifest_dir)
+        manifest_path = manifest_dir / "receipt-manifest.json"
+        if not manifest_path.is_file():
+            raise ReceiptVerificationError("manifest artifact has no receipt-manifest.json")
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ReceiptVerificationError("receipt manifest is invalid JSON") from exc
+        manifest = _require_mapping(manifest, "receipt manifest")
+        artifact_binding = _require_mapping(manifest.get("artifact"), "artifact")
+        if artifact_binding.get("name") != expected_payload_name:
+            raise ReceiptVerificationError(
+                "manifest payload artifact name does not match selected run namespace"
+            )
+        payload_candidates = [
+            item
+            for item in artifacts
+            if isinstance(item, Mapping)
+            and item.get("id") == artifact_binding.get("id")
+            and item.get("name") == expected_payload_name
+            and not item.get("expired")
+        ]
+        if len(payload_candidates) != 1:
+            raise ReceiptVerificationError("manifest payload artifact is absent or ambiguous")
+        payload_artifact = payload_candidates[0]
+        payload_zip = api.get_bytes(
+            f"/repos/{repository}/actions/artifacts/{int(payload_artifact['id'])}/zip"
+        )
+        _verify_download_digest(payload_zip, payload_artifact)
+        payload_dir = temp / "payload"
+        payload_dir.mkdir()
+        _extract_zip(payload_zip, payload_dir)
+        verify_receipt_manifest(
+            manifest,
+            payload_dir=payload_dir,
+            trusted_run=run,
+            trusted_artifact=payload_artifact,
+            expected_repository=repository,
+            expected_sha=expected_sha,
+            expected_model_id=expected_model_id,
+            expected_model_digest=expected_model_digest,
+            expected_export_id=expected_export_id,
+            expected_export_digest=expected_export_digest,
+            now=now,
+        )
+        destination.mkdir(parents=True, exist_ok=True)
+        for name in PAYLOAD_FILES:
+            shutil.copy2(payload_dir / name, destination / name)
+        return dict(manifest)
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def _build_command(args: argparse.Namespace) -> int:
+    manifest = build_receipt_manifest(
+        payload_dir=args.payload_dir,
+        repository=args.repository,
+        source_sha=args.source_sha,
+        source_ref=args.source_ref,
+        workflow_run_id=args.run_id,
+        workflow_run_attempt=args.run_attempt,
+        receipt_namespace=args.receipt_namespace,
+        event=args.event,
+        payload_artifact_id=args.artifact_id,
+        payload_artifact_name=args.artifact_name,
+        payload_artifact_digest=args.artifact_digest,
+        model_id=args.model_id,
+        model_digest=args.model_digest,
+        expires_in_hours=args.expires_in_hours,
+    )
+    _write_json(args.output, manifest)
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a") as output:
+            output.write(f"export_id={manifest['export']['id']}\n")
+            output.write(f"export_digest={manifest['export']['digest']}\n")
+    return 0
+
+
+def _namespace_command(args: argparse.Namespace) -> int:
+    namespace = build_receipt_namespace(
+        args.repository, args.source_sha, args.run_id, args.run_attempt
+    )
+    payload_name, manifest_name = receipt_artifact_names(namespace)
+    print(namespace)
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a") as output:
+            output.write(f"receipt_namespace={namespace}\n")
+            output.write(f"payload_artifact_name={payload_name}\n")
+            output.write(f"manifest_artifact_name={manifest_name}\n")
+    return 0
+
+
+def _verify_command(args: argparse.Namespace) -> int:
+    manifest = json.loads(args.manifest.read_text())
+    trusted_run = json.loads(args.trusted_run.read_text())
+    trusted_artifact = json.loads(args.trusted_artifact.read_text())
+    verify_receipt_manifest(
+        manifest,
+        payload_dir=args.payload_dir,
+        trusted_run=trusted_run,
+        trusted_artifact=trusted_artifact,
+        expected_repository=args.repository,
+        expected_sha=args.source_sha,
+        expected_model_id=args.model_id,
+        expected_model_digest=args.model_digest,
+        expected_export_id=args.export_id,
+        expected_export_digest=args.export_digest,
+    )
+    return 0
+
+
+def _verify_local_command(args: argparse.Namespace) -> int:
+    manifest = json.loads(args.manifest.read_text())
+    branch = _branch_from_ref(args.source_ref)
+    trusted_run = {
+        "id": args.run_id,
+        "path": f"{WORKFLOW_PATH}@{args.source_ref}",
+        "head_sha": args.source_sha,
+        "head_branch": branch,
+        "head_repository": {"full_name": args.repository},
+        "event": args.event,
+        "status": "completed",
+        "conclusion": "success",
+        "run_attempt": args.run_attempt,
+    }
+    trusted_artifact = {
+        "id": args.artifact_id,
+        "name": args.artifact_name,
+        "digest": args.artifact_digest,
+        "expired": False,
+    }
+    verify_receipt_manifest(
+        manifest,
+        payload_dir=args.payload_dir,
+        trusted_run=trusted_run,
+        trusted_artifact=trusted_artifact,
+        expected_repository=args.repository,
+        expected_sha=args.source_sha,
+        expected_model_id=args.model_id,
+        expected_model_digest=args.model_digest,
+        expected_export_id=args.export_id,
+        expected_export_digest=args.export_digest,
+    )
+    return 0
+
+
+def _download_command(args: argparse.Namespace) -> int:
+    download_verified_receipts(
+        repository=args.repository,
+        expected_sha=args.source_sha,
+        expected_model_id=args.model_id,
+        expected_model_digest=args.model_digest,
+        expected_export_id=args.export_id,
+        expected_export_digest=args.export_digest,
+        destination=args.destination,
+        token=args.token or os.environ.get("GITHUB_TOKEN", ""),
+    )
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    namespace = subparsers.add_parser(
+        "namespace", help="derive the immutable namespace for one workflow run"
+    )
+    namespace.add_argument("--repository", required=True)
+    namespace.add_argument("--source-sha", required=True)
+    namespace.add_argument("--run-id", type=int, required=True)
+    namespace.add_argument("--run-attempt", type=int, required=True)
+    namespace.set_defaults(handler=_namespace_command)
+
+    build = subparsers.add_parser("build", help="build a provenance manifest")
+    build.add_argument("--payload-dir", type=Path, required=True)
+    build.add_argument("--repository", required=True)
+    build.add_argument("--source-sha", required=True)
+    build.add_argument("--source-ref", required=True)
+    build.add_argument("--run-id", type=int, required=True)
+    build.add_argument("--run-attempt", type=int, required=True)
+    build.add_argument("--receipt-namespace", required=True)
+    build.add_argument("--event", choices=sorted(ALLOWED_EVENTS), required=True)
+    build.add_argument("--artifact-id", type=int, required=True)
+    build.add_argument("--artifact-name", required=True)
+    build.add_argument("--artifact-digest", required=True)
+    build.add_argument("--model-id", required=True)
+    build.add_argument("--model-digest", required=True)
+    build.add_argument("--expires-in-hours", type=int, default=168)
+    build.add_argument("--output", type=Path, required=True)
+    build.set_defaults(handler=_build_command)
+
+    verify = subparsers.add_parser("verify", help="verify local downloaded artifacts")
+    verify.add_argument("--manifest", type=Path, required=True)
+    verify.add_argument("--payload-dir", type=Path, required=True)
+    verify.add_argument("--trusted-run", type=Path, required=True)
+    verify.add_argument("--trusted-artifact", type=Path, required=True)
+    verify.add_argument("--repository", required=True)
+    verify.add_argument("--source-sha", required=True)
+    verify.add_argument("--model-id", required=True)
+    verify.add_argument("--model-digest", required=True)
+    verify.add_argument("--export-id", required=True)
+    verify.add_argument("--export-digest", required=True)
+    verify.set_defaults(handler=_verify_command)
+
+    verify_local = subparsers.add_parser(
+        "verify-local", help="verify artifacts downloaded from the current trusted run"
+    )
+    verify_local.add_argument("--manifest", type=Path, required=True)
+    verify_local.add_argument("--payload-dir", type=Path, required=True)
+    verify_local.add_argument("--repository", required=True)
+    verify_local.add_argument("--source-sha", required=True)
+    verify_local.add_argument("--source-ref", required=True)
+    verify_local.add_argument("--run-id", type=int, required=True)
+    verify_local.add_argument("--run-attempt", type=int, required=True)
+    verify_local.add_argument("--event", choices=sorted(ALLOWED_EVENTS), required=True)
+    verify_local.add_argument("--artifact-id", type=int, required=True)
+    verify_local.add_argument("--artifact-name", required=True)
+    verify_local.add_argument("--artifact-digest", required=True)
+    verify_local.add_argument("--model-id", required=True)
+    verify_local.add_argument("--model-digest", required=True)
+    verify_local.add_argument("--export-id", required=True)
+    verify_local.add_argument("--export-digest", required=True)
+    verify_local.set_defaults(handler=_verify_local_command)
+
+    download = subparsers.add_parser("download", help="download a trusted receipt from GitHub")
+    download.add_argument("--repository", required=True)
+    download.add_argument("--source-sha", required=True)
+    download.add_argument("--model-id", required=True)
+    download.add_argument("--model-digest", required=True)
+    download.add_argument("--export-id", required=True)
+    download.add_argument("--export-digest", required=True)
+    download.add_argument("--destination", type=Path, required=True)
+    download.add_argument("--token")
+    download.set_defaults(handler=_download_command)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except ReceiptVerificationError as exc:
+        print(f"receipt verification failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_decomposed_per_step_e2e_latency.py
+++ b/tests/test_decomposed_per_step_e2e_latency.py
@@ -11,26 +11,25 @@ Acceptance (matches gate 4):
 
 Pattern mirrors ``tests/test_decomposed_per_step_parity.py``.
 """
+
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
-RECEIPT = (
-    Path(__file__).parent.parent.parent
-    / "reflex_context"
-    / "per_step_e2e_latency_last_run.json"
-).resolve()
+from receipt_test_support import receipt_path, require_receipt
+
+pytestmark = pytest.mark.receipt
+
+RECEIPT = receipt_path("per_step_e2e_latency_last_run.json")
 
 MEDIAN_OVERHEAD_MAX = 0.20
 P99_RATIO_MAX = 1.30
 
 
-def _load_receipt() -> dict | None:
-    if not RECEIPT.exists():
-        return None
+def _load_receipt() -> dict:
+    require_receipt(RECEIPT, "scripts/modal_per_step_e2e_latency.py")
     return json.loads(RECEIPT.read_text())
 
 
@@ -38,15 +37,10 @@ class TestPerStepE2ELatencyReceipt:
     """Gate 5 receipt checks against the Modal-produced JSON."""
 
     def test_receipt_exists(self):
-        if not RECEIPT.exists():
-            pytest.skip(
-                f"Run scripts/modal_per_step_e2e_latency.py to populate {RECEIPT}"
-            )
+        require_receipt(RECEIPT, "scripts/modal_per_step_e2e_latency.py")
 
     def test_e2e_passes_gate(self):
         receipt = _load_receipt()
-        if receipt is None:
-            pytest.skip("No receipt — run Modal job")
         assert receipt["passes_overall"], (
             f"E2E overhead exceeds gate: "
             f"median={receipt['median_overhead_pct']:.1%} "
@@ -62,8 +56,6 @@ class TestPerStepE2ELatencyReceipt:
         diverges by 2x without cudnn_conv_algo_search=HEURISTIC pinning —
         if this assertion fails, the bench was likely run without the pin."""
         receipt = _load_receipt()
-        if receipt is None:
-            pytest.skip("No receipt — run Modal job")
         baked_vlm = receipt["baked"]["vlm"]["median_ms"]
         per_step_vlm = receipt["per_step"]["vlm"]["median_ms"]
         ratio = max(baked_vlm, per_step_vlm) / max(min(baked_vlm, per_step_vlm), 1e-9)
@@ -74,3 +66,10 @@ class TestPerStepE2ELatencyReceipt:
             f"cudnn_conv_algo_search wasn't pinned to HEURISTIC. See gate-5 "
             f"experiment note."
         )
+
+    def test_both_conditions_use_cuda_for_prefix_and_expert(self):
+        receipt = _load_receipt()
+        for condition in ("baked", "per_step"):
+            providers = receipt[condition]["providers"]
+            assert providers["vlm_prefix"][0] == "CUDAExecutionProvider"
+            assert providers["expert_denoise"][0] == "CUDAExecutionProvider"

--- a/tests/test_decomposed_per_step_overhead.py
+++ b/tests/test_decomposed_per_step_overhead.py
@@ -15,26 +15,25 @@ Pattern mirrors ``tests/test_decomposed_per_step_parity.py``.
 Skip if the receipt doesn't exist (CI runs this; locally you fire the
 Modal job first then re-run pytest).
 """
+
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
-RECEIPT = (
-    Path(__file__).parent.parent.parent
-    / "reflex_context"
-    / "per_step_overhead_last_run.json"
-).resolve()
+from receipt_test_support import receipt_path, require_receipt
+
+pytestmark = pytest.mark.receipt
+
+RECEIPT = receipt_path("per_step_overhead_last_run.json")
 
 MEDIAN_OVERHEAD_MAX = 0.20  # ≤ +20% median chunk overhead
-P99_RATIO_MAX = 1.30        # ≤ 1.30x p99
+P99_RATIO_MAX = 1.30  # ≤ 1.30x p99
 
 
-def _load_receipt() -> dict | None:
-    if not RECEIPT.exists():
-        return None
+def _load_receipt() -> dict:
+    require_receipt(RECEIPT, "scripts/modal_per_step_overhead.py")
     return json.loads(RECEIPT.read_text())
 
 
@@ -42,15 +41,10 @@ class TestPerStepOverheadReceipt:
     """Gate 4 receipt checks against the Modal-produced JSON."""
 
     def test_receipt_exists(self):
-        if not RECEIPT.exists():
-            pytest.skip(
-                f"Run scripts/modal_per_step_overhead.py to populate {RECEIPT}"
-            )
+        require_receipt(RECEIPT, "scripts/modal_per_step_overhead.py")
 
     def test_iobinding_path_passes_gate(self):
         receipt = _load_receipt()
-        if receipt is None:
-            pytest.skip("No receipt — run Modal job")
         gate = receipt["iobinding_gate"]
         assert gate["passes_overall"], (
             f"IOBinding overhead exceeds gate: median={gate['median_overhead_pct']:.1%} "
@@ -62,8 +56,6 @@ class TestPerStepOverheadReceipt:
         """The whole point of IOBinding is to skip per-iter past_kv copies.
         If naive matches IOBinding, IOBinding refactor is dead code."""
         receipt = _load_receipt()
-        if receipt is None:
-            pytest.skip("No receipt — run Modal job")
         naive_med = receipt["per_step_naive"]["median_ms"]
         iob_med = receipt["per_step_iobinding"]["median_ms"]
         assert iob_med < naive_med, (
@@ -76,8 +68,6 @@ class TestPerStepOverheadReceipt:
         """Both sessions must have actually used CUDAExecutionProvider, not
         silently fallen back to CPU. Mirrors gate 3 receipt's check."""
         receipt = _load_receipt()
-        if receipt is None:
-            pytest.skip("No receipt — run Modal job")
         providers = receipt["providers"]
         assert providers["baked"] == "CUDAExecutionProvider", (
             f"Baked session used {providers['baked']!r}, not CUDA — "

--- a/tests/test_decomposed_per_step_parity.py
+++ b/tests/test_decomposed_per_step_parity.py
@@ -17,23 +17,22 @@ Pattern mirrors ``tests/test_cuda_runtime_parity.py:17``.
 Skip if the receipt doesn't exist (CI runs this; locally you fire the
 Modal job first then re-run pytest).
 """
+
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
-RECEIPT = (
-    Path(__file__).parent.parent.parent
-    / "reflex_context"
-    / "per_step_parity_last_run.json"
-).resolve()
+from receipt_test_support import receipt_path, require_receipt
+
+pytestmark = pytest.mark.receipt
+
+RECEIPT = receipt_path("per_step_parity_last_run.json")
 
 
-def _load_receipt() -> dict | None:
-    if not RECEIPT.exists():
-        return None
+def _load_receipt() -> dict:
+    require_receipt(RECEIPT, "scripts/modal_per_step_parity.py")
     return json.loads(RECEIPT.read_text())
 
 
@@ -45,28 +44,17 @@ class TestPerStepParityReceipt:
     """Per-cell + overall gate checks against the Modal-produced receipt."""
 
     def test_receipt_exists(self):
-        if not RECEIPT.exists():
-            pytest.skip(
-                f"Run scripts/modal_per_step_parity.py to populate {RECEIPT}"
-            )
+        require_receipt(RECEIPT, "scripts/modal_per_step_parity.py")
 
     def test_all_cells_pass_overall_gate(self):
         receipt = _load_receipt()
-        if receipt is None:
-            pytest.skip("No receipt — run Modal job")
-        failed = [
-            label for label, r in receipt["cells"].items()
-            if not r["passes_overall"]
-        ]
+        failed = [label for label, r in receipt["cells"].items() if not r["passes_overall"]]
         assert not failed, (
-            f"Per-step parity failed for cells: {failed}. "
-            f"See {RECEIPT} for cos / max_abs values."
+            f"Per-step parity failed for cells: {failed}. See {RECEIPT} for cos / max_abs values."
         )
 
     def test_thresholds_are_correct(self):
         receipt = _load_receipt()
-        if receipt is None:
-            pytest.skip("No receipt — run Modal job")
         # The receipt must have used the tightened gates from research
         # sidecar Lens 5 — not the spec's looser cos≥0.999.
         assert receipt["thresholds"]["cos_min"] == COS_MIN, (
@@ -75,13 +63,17 @@ class TestPerStepParityReceipt:
         )
         assert receipt["thresholds"]["max_abs_max"] == MAX_ABS_MAX
 
+    def test_exact_required_cell_set(self):
+        receipt = _load_receipt()
+        assert set(receipt["cells"]) == {
+            "pi05_teacher_n10",
+            "pi05_teacher_n1",
+        }
+
     @pytest.mark.parametrize("expected_cell", ["pi05_teacher_n10", "pi05_teacher_n1"])
     def test_per_cell_cos(self, expected_cell):
         receipt = _load_receipt()
-        if receipt is None:
-            pytest.skip("No receipt — run Modal job")
-        if expected_cell not in receipt["cells"]:
-            pytest.skip(f"Cell {expected_cell} not in receipt")
+        assert expected_cell in receipt["cells"], f"required cell {expected_cell} missing"
         cell = receipt["cells"][expected_cell]
         assert cell["cos"] >= COS_MIN, (
             f"{expected_cell}: cos {cell['cos']} below threshold {COS_MIN}. "
@@ -92,10 +84,7 @@ class TestPerStepParityReceipt:
     @pytest.mark.parametrize("expected_cell", ["pi05_teacher_n10", "pi05_teacher_n1"])
     def test_per_cell_max_abs(self, expected_cell):
         receipt = _load_receipt()
-        if receipt is None:
-            pytest.skip("No receipt — run Modal job")
-        if expected_cell not in receipt["cells"]:
-            pytest.skip(f"Cell {expected_cell} not in receipt")
+        assert expected_cell in receipt["cells"], f"required cell {expected_cell} missing"
         cell = receipt["cells"][expected_cell]
         assert cell["max_abs"] <= MAX_ABS_MAX, (
             f"{expected_cell}: max_abs {cell['max_abs']:.3e} above threshold "
@@ -108,8 +97,6 @@ class TestPerStepParityReceipt:
         silently fallen back to CPU. Mirrors the existing parity-test
         provider check at tests/test_cuda_runtime_parity.py."""
         receipt = _load_receipt()
-        if receipt is None:
-            pytest.skip("No receipt — run Modal job")
         for label, cell in receipt["cells"].items():
             assert cell["used_provider_baked"] == "CUDAExecutionProvider", (
                 f"{label}: baked session used {cell['used_provider_baked']}, "

--- a/tests/test_export_mode.py
+++ b/tests/test_export_mode.py
@@ -2,9 +2,13 @@
 
 Mock-based — verifies auto-detection logic without needing real GPU.
 """
+
 from __future__ import annotations
 
 import json
+import sys
+import types
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -22,7 +26,7 @@ from tether.exporters._export_mode import (
 
 
 # 1.6 GB ONNX (typical SmolVLA monolithic) → 6.4 GB estimated VRAM per export
-SMOLVLA_ONNX_SIZE = int(1.6 * 1024 ** 3)
+SMOLVLA_ONNX_SIZE = int(1.6 * 1024**3)
 SMOLVLA_VRAM = estimate_model_vram_from_onnx(SMOLVLA_ONNX_SIZE)
 
 
@@ -51,16 +55,14 @@ def test_sequential_explicit_works_on_cpu():
 
 def test_parallel_explicit_fits_returns_parallel():
     """24 GB free, model needs ~14 GB combined → parallel."""
-    with patch("tether.exporters._export_mode.probe_free_vram",
-               return_value=24 * 1024 ** 3):
+    with patch("tether.exporters._export_mode.probe_free_vram", return_value=24 * 1024**3):
         decision = select_mode(ExportMode.PARALLEL, SMOLVLA_VRAM)
     assert decision.mode == ExportMode.PARALLEL
 
 
 def test_parallel_explicit_doesnt_fit_raises():
     """8 GB free (Orin Nano-ish), model needs ~14 GB combined → raise loudly."""
-    with patch("tether.exporters._export_mode.probe_free_vram",
-               return_value=8 * 1024 ** 3):
+    with patch("tether.exporters._export_mode.probe_free_vram", return_value=8 * 1024**3):
         with pytest.raises(InsufficientVRAMError, match="parallel needs"):
             select_mode(ExportMode.PARALLEL, SMOLVLA_VRAM)
 
@@ -84,8 +86,7 @@ def test_auto_no_gpu_picks_sequential():
 
 def test_auto_low_vram_picks_sequential():
     """Orin Nano 8 GB shared → sequential."""
-    with patch("tether.exporters._export_mode.probe_free_vram",
-               return_value=8 * 1024 ** 3):
+    with patch("tether.exporters._export_mode.probe_free_vram", return_value=8 * 1024**3):
         decision = select_mode(ExportMode.AUTO, SMOLVLA_VRAM)
     assert decision.mode == ExportMode.SEQUENTIAL
     assert "would need" in decision.reason.lower() or "8" in decision.reason
@@ -93,24 +94,21 @@ def test_auto_low_vram_picks_sequential():
 
 def test_auto_high_vram_picks_parallel():
     """RTX 5090 32 GB → parallel."""
-    with patch("tether.exporters._export_mode.probe_free_vram",
-               return_value=32 * 1024 ** 3):
+    with patch("tether.exporters._export_mode.probe_free_vram", return_value=32 * 1024**3):
         decision = select_mode(ExportMode.AUTO, SMOLVLA_VRAM)
     assert decision.mode == ExportMode.PARALLEL
 
 
 def test_auto_a10g_24gb_picks_parallel():
     """A10G 24 GB → parallel for SmolVLA (needs ~14 GB combined)."""
-    with patch("tether.exporters._export_mode.probe_free_vram",
-               return_value=24 * 1024 ** 3):
+    with patch("tether.exporters._export_mode.probe_free_vram", return_value=24 * 1024**3):
         decision = select_mode(ExportMode.AUTO, SMOLVLA_VRAM)
     assert decision.mode == ExportMode.PARALLEL
 
 
 def test_auto_t4_16gb_borderline():
     """T4 16 GB free is borderline for SmolVLA (~14 GB needed). Should go parallel."""
-    with patch("tether.exporters._export_mode.probe_free_vram",
-               return_value=16 * 1024 ** 3):
+    with patch("tether.exporters._export_mode.probe_free_vram", return_value=16 * 1024**3):
         decision = select_mode(ExportMode.AUTO, SMOLVLA_VRAM)
     # 16 > 14.6 (2 * 6.4 + 1.0), so parallel
     assert decision.mode == ExportMode.PARALLEL
@@ -119,22 +117,20 @@ def test_auto_t4_16gb_borderline():
 # ─── pi05 (much larger model) ────────────────────────────────────────────────
 
 
-PI05_ONNX_SIZE = int(13.0 * 1024 ** 3)  # ~13 GB monolithic
+PI05_ONNX_SIZE = int(13.0 * 1024**3)  # ~13 GB monolithic
 PI05_VRAM = estimate_model_vram_from_onnx(PI05_ONNX_SIZE)
 
 
 def test_auto_t4_picks_sequential_for_pi05():
     """T4 16 GB can't fit 2x pi05 (~104 GB needed) → sequential."""
-    with patch("tether.exporters._export_mode.probe_free_vram",
-               return_value=16 * 1024 ** 3):
+    with patch("tether.exporters._export_mode.probe_free_vram", return_value=16 * 1024**3):
         decision = select_mode(ExportMode.AUTO, PI05_VRAM)
     assert decision.mode == ExportMode.SEQUENTIAL
 
 
 def test_auto_a100_80gb_picks_sequential_for_pi05():
     """Even A100 80 GB can't fit 2x pi05 (104 GB needed) → sequential."""
-    with patch("tether.exporters._export_mode.probe_free_vram",
-               return_value=80 * 1024 ** 3):
+    with patch("tether.exporters._export_mode.probe_free_vram", return_value=80 * 1024**3):
         decision = select_mode(ExportMode.AUTO, PI05_VRAM)
     assert decision.mode == ExportMode.SEQUENTIAL
 
@@ -165,11 +161,13 @@ def test_pi05_decomposed_dispatches_to_sequential(monkeypatch, tmp_path):
     result = decomposed.export_pi05_decomposed(
         "lerobot/pi05_libero_finetuned_v044",
         tmp_path,
+        revision="abc123",
         export_mode=ExportMode.AUTO,
     )
 
     assert result["export_mode"] == "sequential"
     assert calls[0]["output_dir"] == tmp_path
+    assert calls[0]["revision"] == "abc123"
     assert calls[0]["export_mode_reason"] == "test seq"
 
 
@@ -209,8 +207,8 @@ def test_pi05_decomposed_sequential_reuses_single_policy(monkeypatch, tmp_path):
     load_calls = []
     pass_order = []
 
-    def fake_load_policy(model_id, num_steps, student_checkpoint, variant):
-        load_calls.append((model_id, num_steps, student_checkpoint, variant))
+    def fake_load_policy(model_id, num_steps, student_checkpoint, variant, *, revision=None):
+        load_calls.append((model_id, num_steps, student_checkpoint, variant, revision))
         return policy
 
     def fake_prefix_pass(policy_arg, output_dir, past_kv_names):
@@ -231,6 +229,7 @@ def test_pi05_decomposed_sequential_reuses_single_policy(monkeypatch, tmp_path):
 
     result = decomposed._export_pi05_decomposed_sequential(
         model_id="lerobot/pi05_libero_finetuned_v044",
+        revision="deadbeef",
         output_dir=tmp_path,
         num_steps=10,
         target="desktop",
@@ -240,10 +239,55 @@ def test_pi05_decomposed_sequential_reuses_single_policy(monkeypatch, tmp_path):
     )
 
     cfg = json.loads((tmp_path / "tether_config.json").read_text())
-    assert load_calls == [("lerobot/pi05_libero_finetuned_v044", 10, None, "default")]
+    assert load_calls == [("lerobot/pi05_libero_finetuned_v044", 10, None, "default", "deadbeef")]
     assert pass_order == ["prefix", "expert"]
     assert result["export_mode"] == "sequential"
     assert cfg["export_mode"] == "sequential"
+
+
+def test_pi05_policy_load_receives_exact_immutable_revision(monkeypatch):
+    seen = {}
+
+    class FakePolicy:
+        def __init__(self):
+            self.model = SimpleNamespace()
+
+        def eval(self):
+            return self
+
+        def to(self, *args, **kwargs):
+            return self
+
+    class FakePI05Policy:
+        @classmethod
+        def from_pretrained(cls, model_id, *, revision=None):
+            seen.update(model_id=model_id, revision=revision)
+            return FakePolicy()
+
+    fake_modeling = types.ModuleType("lerobot.policies.pi05.modeling_pi05")
+    fake_modeling.PI05Policy = FakePI05Policy
+    monkeypatch.setitem(sys.modules, "lerobot.policies.pi05.modeling_pi05", fake_modeling)
+    monkeypatch.setattr(decomposed, "_require_decomposed_deps", lambda: None)
+
+    import tether.exporters.monolithic as monolithic
+
+    monkeypatch.setattr(monolithic, "apply_export_patches", lambda: None)
+    monkeypatch.setattr(monolithic, "_force_eager_attn", lambda model: None)
+    monkeypatch.setattr(monolithic, "_apply_pi05_denoise_step_patch", lambda: None)
+
+    result = decomposed._load_pi05_policy(
+        "lerobot/pi05_libero_finetuned_v044",
+        10,
+        None,
+        "default",
+        revision="a" * 40,
+    )
+
+    assert isinstance(result, FakePolicy)
+    assert seen == {
+        "model_id": "lerobot/pi05_libero_finetuned_v044",
+        "revision": "a" * 40,
+    }
 
 
 def test_run_parallel_pi05_exports_submits_both_workers(monkeypatch, tmp_path):
@@ -284,6 +328,7 @@ def test_run_parallel_pi05_exports_submits_both_workers(monkeypatch, tmp_path):
 
     prefix_meta, expert_meta = decomposed._run_parallel_pi05_exports(
         model_id="lerobot/pi05_libero_finetuned_v044",
+        revision="deadbeef",
         output_dir=tmp_path,
         num_steps=10,
         student_checkpoint=None,
@@ -295,12 +340,12 @@ def test_run_parallel_pi05_exports_submits_both_workers(monkeypatch, tmp_path):
     assert prefix_meta["prefix_seq_len"] == 968
     assert expert_meta["prefix_seq_len"] == 968
     assert [call[0] for call in calls] == ["prefix", "expert"]
-    assert calls[0][1][1] == str(tmp_path)
+    assert calls[0][1][1] == "deadbeef"
+    assert calls[0][1][2] == str(tmp_path)
     # _export_pi05_expert_worker signature:
-    # (model_id, output_dir, num_steps, student_checkpoint, variant,
-    #  past_kv_names, prefix_seq_len, per_step_expert)
-    # prefix_seq_len is positional arg 6 (0-indexed).
-    assert calls[1][1][6] == 968
+    # (model_id, revision, output_dir, num_steps, student_checkpoint,
+    #  variant, past_kv_names, prefix_seq_len, per_step_expert)
+    assert calls[1][1][7] == 968
 
 
 def test_write_decomposed_result_records_export_mode(tmp_path):
@@ -309,6 +354,7 @@ def test_write_decomposed_result_records_export_mode(tmp_path):
 
     result = decomposed._write_decomposed_export_result(
         model_id="lerobot/pi05_libero_finetuned_v044",
+        revision="deadbeef",
         output_dir=tmp_path,
         num_steps=10,
         target="desktop",
@@ -325,3 +371,4 @@ def test_write_decomposed_result_records_export_mode(tmp_path):
     assert result["export_mode"] == "parallel"
     assert cfg["export_mode"] == "parallel"
     assert cfg["export_mode_reason"] == "test reason"
+    assert cfg["model_revision"] == "deadbeef"

--- a/tests/test_pro_consent.py
+++ b/tests/test_pro_consent.py
@@ -4,12 +4,11 @@ Per ADR 2026-04-25-self-distilling-serve-architecture decision #1: data
 collection is EXPLICIT opt-in via TTY prompt; non-interactive contexts
 without an existing receipt fail loud.
 """
+
 from __future__ import annotations
 
 import json
 import os
-import stat
-from pathlib import Path
 
 import pytest
 
@@ -133,7 +132,7 @@ def test_consent_raises_required_on_decline(tmp_path):
 
 
 def test_consent_writes_receipt_on_accept(tmp_path):
-    consent = ProConsent.load_or_prompt(
+    ProConsent.load_or_prompt(
         customer_id="acme",
         pii_options=_mk_pii(),
         path=tmp_path / "consent.json",
@@ -160,7 +159,7 @@ def test_consent_silent_pass_on_existing_valid_receipt(tmp_path):
         return True
 
     # First call — prompt fires
-    consent1 = ProConsent.load_or_prompt(
+    ProConsent.load_or_prompt(
         customer_id="acme",
         pii_options=_mk_pii(),
         path=tmp_path / "consent.json",
@@ -231,17 +230,21 @@ def test_consent_mismatch_on_corrupted_receipt(tmp_path):
 def test_consent_mismatch_on_consent_version_drift(tmp_path):
     """Old-version receipt → re-prompt required."""
     path = tmp_path / "consent.json"
-    path.write_text(json.dumps({
-        "consent_version": 99,  # future version
-        "customer_id": "acme",
-        "accepted_at": "2026-04-25T10:00:00Z",
-        "accepted_terms_version": "old",
-        "pii_options": {
-            "face_blur_mode": "blur",
-            "instruction_mode": "hashed",
-            "state_mode": "raw",
-        },
-    }))
+    path.write_text(
+        json.dumps(
+            {
+                "consent_version": 99,  # future version
+                "customer_id": "acme",
+                "accepted_at": "2026-04-25T10:00:00Z",
+                "accepted_terms_version": "old",
+                "pii_options": {
+                    "face_blur_mode": "blur",
+                    "instruction_mode": "hashed",
+                    "state_mode": "raw",
+                },
+            }
+        )
+    )
     with pytest.raises(ConsentMismatch, match="consent_version"):
         ProConsent.load_or_prompt(
             customer_id="acme",

--- a/tests/test_receipt_provenance.py
+++ b/tests/test_receipt_provenance.py
@@ -1,0 +1,863 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import io
+import json
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tether.receipt_provenance import (
+    EXPORT_FILES,
+    WORKFLOW_PATH,
+    ReceiptVerificationError,
+    build_receipt_namespace,
+    build_receipt_manifest,
+    download_verified_receipts,
+    hash_export_set,
+    receipt_artifact_names,
+    receipt_mode_binding,
+    receipt_namespace_binding,
+    receipt_run_dir,
+    select_trusted_run,
+    verify_receipt_manifest,
+)
+from receipt_test_support import require_receipt
+
+
+NOW = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+REPOSITORY = "FastCrest/tether"
+SOURCE_SHA = "1" * 40
+MODEL_ID = "lerobot/pi05_libero_finetuned_v044"
+MODEL_REVISION = "a" * 40
+MODEL_DIGEST = hashlib.sha256(f"huggingface:{MODEL_ID}@{MODEL_REVISION}".encode()).hexdigest()
+ARTIFACT_DIGEST = "3" * 64
+RECEIPT_NAMESPACE = build_receipt_namespace(REPOSITORY, SOURCE_SHA, 101, 1)
+RECEIPT_NAMESPACE_BINDING = receipt_namespace_binding(
+    receipt_namespace=RECEIPT_NAMESPACE,
+    repository=REPOSITORY,
+    source_sha=SOURCE_SHA,
+    workflow_run_id=101,
+    workflow_run_attempt=1,
+)
+PAYLOAD_ARTIFACT_NAME, MANIFEST_ARTIFACT_NAME = receipt_artifact_names(RECEIPT_NAMESPACE)
+
+
+def _export_set(seed: int) -> dict:
+    names = ("tether_config.json", "vlm_prefix.onnx", "expert_denoise.onnx")
+    return {
+        name: {
+            "path": name,
+            "sha256": format((seed + index) % 16, "x") * 64,
+            "size": 100 + index,
+        }
+        for index, name in enumerate(names)
+    }
+
+
+def _write_payload(
+    path: Path,
+    namespace_binding: dict[str, object] = RECEIPT_NAMESPACE_BINDING,
+) -> None:
+    path.mkdir()
+    n10_baked = _export_set(4)
+    n10_per_step = _export_set(8)
+    parity = {
+        "receipt_namespace": namespace_binding,
+        "cells": {
+            "pi05_teacher_n10": {
+                "model_id": MODEL_ID,
+                "model_revision": MODEL_REVISION,
+                "model_digest": MODEL_DIGEST,
+                "exports": {
+                    "baked": n10_baked,
+                    "per_step": n10_per_step,
+                },
+                "cos": 0.999999,
+                "used_provider_baked": "CUDAExecutionProvider",
+                "used_provider_per_step": "CUDAExecutionProvider",
+                "passes_overall": True,
+            },
+            "pi05_teacher_n1": {
+                "model_id": MODEL_ID,
+                "model_revision": MODEL_REVISION,
+                "model_digest": MODEL_DIGEST,
+                "exports": {
+                    "baked": _export_set(12),
+                    "per_step": _export_set(16),
+                },
+                "cos": 1.0,
+                "used_provider_baked": "CUDAExecutionProvider",
+                "used_provider_per_step": "CUDAExecutionProvider",
+                "passes_overall": True,
+            },
+        },
+        "thresholds": {"cos_min": 0.99999, "max_abs_max": 1e-5},
+    }
+    overhead = {
+        "receipt_namespace": namespace_binding,
+        "iobinding_gate": {"passes_overall": True},
+        "providers": {
+            "baked": "CUDAExecutionProvider",
+            "per_step": "CUDAExecutionProvider",
+        },
+        "exports": {
+            "baked": n10_baked,
+            "per_step": n10_per_step,
+        },
+        "thresholds": {"median_overhead_pct_max": 0.2, "p99_ratio_max": 1.3},
+    }
+    e2e = {
+        "receipt_namespace": namespace_binding,
+        "baked": {
+            "receipt_namespace": namespace_binding,
+            "export": n10_baked,
+            "providers": {
+                "vlm_prefix": ["CUDAExecutionProvider", "CPUExecutionProvider"],
+                "expert_denoise": ["CUDAExecutionProvider", "CPUExecutionProvider"],
+            },
+        },
+        "per_step": {
+            "receipt_namespace": namespace_binding,
+            "export": n10_per_step,
+            "providers": {
+                "vlm_prefix": ["CUDAExecutionProvider", "CPUExecutionProvider"],
+                "expert_denoise": ["CUDAExecutionProvider", "CPUExecutionProvider"],
+            },
+        },
+        "passes_overall": True,
+        "thresholds": {"median_overhead_pct_max": 0.2, "p99_ratio_max": 1.3},
+    }
+    values = {
+        "per_step_parity_last_run.json": parity,
+        "per_step_overhead_last_run.json": overhead,
+        "per_step_e2e_latency_last_run.json": e2e,
+    }
+    for name, value in values.items():
+        (path / name).write_text(json.dumps(value, sort_keys=True))
+
+
+def test_hash_export_set_binds_config_prefix_and_expert(tmp_path):
+    for index, name in enumerate(EXPORT_FILES, start=1):
+        (tmp_path / name).write_bytes(bytes([index]) * index)
+
+    result = hash_export_set(tmp_path)
+
+    assert set(result) == set(EXPORT_FILES)
+    for name in EXPORT_FILES:
+        assert result[name]["path"] == name
+        assert result[name]["size"] == (tmp_path / name).stat().st_size
+        assert len(str(result[name]["sha256"])) == 64
+
+
+def test_immutable_namespaces_separate_runs_and_attempts(tmp_path):
+    run_101 = build_receipt_namespace(REPOSITORY, SOURCE_SHA, 101, 1)
+    run_102 = build_receipt_namespace(REPOSITORY, SOURCE_SHA, 102, 1)
+    attempt_2 = build_receipt_namespace(REPOSITORY, SOURCE_SHA, 101, 2)
+
+    assert len({run_101, run_102, attempt_2}) == 3
+    assert receipt_run_dir(tmp_path, run_101) != receipt_run_dir(tmp_path, run_102)
+    assert receipt_run_dir(tmp_path, run_101) != receipt_run_dir(tmp_path, attempt_2)
+
+
+@pytest.mark.parametrize(
+    "unsafe_namespace",
+    ["../other-run", "/tmp/receipt", "gh-invalid", RECEIPT_NAMESPACE + "/x"],
+)
+def test_receipt_run_dir_rejects_unsafe_or_noncanonical_namespaces(tmp_path, unsafe_namespace):
+    with pytest.raises(ReceiptVerificationError, match="namespace"):
+        receipt_run_dir(tmp_path, unsafe_namespace)
+
+
+def test_receipt_mode_has_explicit_legacy_mode_and_rejects_partial_binding():
+    assert receipt_mode_binding() is None
+    with pytest.raises(ReceiptVerificationError, match="receipt mode requires"):
+        receipt_mode_binding(receipt_namespace=RECEIPT_NAMESPACE)
+
+
+def test_export_measurement_hashes_are_confined_to_each_namespace(tmp_path):
+    other_namespace = build_receipt_namespace(REPOSITORY, SOURCE_SHA, 102, 1)
+    hashes = []
+    directories = []
+    for namespace, byte in (
+        (RECEIPT_NAMESPACE, b"a"),
+        (other_namespace, b"b"),
+    ):
+        export_dir = receipt_run_dir(tmp_path, namespace) / "export"
+        export_dir.mkdir(parents=True)
+        for name in EXPORT_FILES:
+            (export_dir / name).write_bytes(byte + name.encode())
+        directories.append(export_dir)
+        hashes.append(hash_export_set(export_dir))
+
+    assert directories[0] != directories[1]
+    assert hashes[0] != hashes[1]
+
+
+def test_build_rejects_payload_from_a_different_run_namespace(tmp_path):
+    payload_dir = tmp_path / "payload"
+    _write_payload(payload_dir)
+    other_namespace = build_receipt_namespace(REPOSITORY, SOURCE_SHA, 102, 1)
+    parity_path = payload_dir / "per_step_parity_last_run.json"
+    parity = json.loads(parity_path.read_text())
+    parity["receipt_namespace"] = receipt_namespace_binding(
+        receipt_namespace=other_namespace,
+        repository=REPOSITORY,
+        source_sha=SOURCE_SHA,
+        workflow_run_id=102,
+        workflow_run_attempt=1,
+    )
+    parity_path.write_text(json.dumps(parity))
+
+    with pytest.raises(ReceiptVerificationError, match="receipt_namespace"):
+        build_receipt_manifest(
+            payload_dir=payload_dir,
+            receipt_namespace=RECEIPT_NAMESPACE,
+            repository=REPOSITORY,
+            source_sha=SOURCE_SHA,
+            source_ref="refs/heads/main",
+            workflow_run_id=101,
+            workflow_run_attempt=1,
+            event="schedule",
+            payload_artifact_id=202,
+            payload_artifact_name=PAYLOAD_ARTIFACT_NAME,
+            payload_artifact_digest=ARTIFACT_DIGEST,
+            model_id=MODEL_ID,
+            model_digest=MODEL_DIGEST,
+            generated_at=NOW,
+        )
+
+
+@pytest.mark.parametrize("mutation", ["missing", "partial", "forged", "cross_run"])
+def test_build_rejects_invalid_nested_e2e_namespace(tmp_path, mutation):
+    payload_dir = tmp_path / mutation
+    _write_payload(payload_dir)
+    e2e_path = payload_dir / "per_step_e2e_latency_last_run.json"
+    e2e = json.loads(e2e_path.read_text())
+    if mutation == "missing":
+        del e2e["baked"]["receipt_namespace"]
+    elif mutation == "partial":
+        e2e["baked"]["receipt_namespace"] = {"value": RECEIPT_NAMESPACE}
+    elif mutation == "forged":
+        e2e["baked"]["receipt_namespace"]["workflow_run_id"] = 999
+    else:
+        other_namespace = build_receipt_namespace(REPOSITORY, SOURCE_SHA, 102, 1)
+        e2e["baked"]["receipt_namespace"] = receipt_namespace_binding(
+            receipt_namespace=other_namespace,
+            repository=REPOSITORY,
+            source_sha=SOURCE_SHA,
+            workflow_run_id=102,
+            workflow_run_attempt=1,
+        )
+    e2e_path.write_text(json.dumps(e2e))
+
+    with pytest.raises(ReceiptVerificationError, match=r"e2e baked\.receipt_namespace"):
+        build_receipt_manifest(
+            payload_dir=payload_dir,
+            receipt_namespace=RECEIPT_NAMESPACE,
+            repository=REPOSITORY,
+            source_sha=SOURCE_SHA,
+            source_ref="refs/heads/main",
+            workflow_run_id=101,
+            workflow_run_attempt=1,
+            event="schedule",
+            payload_artifact_id=202,
+            payload_artifact_name=PAYLOAD_ARTIFACT_NAME,
+            payload_artifact_digest=ARTIFACT_DIGEST,
+            model_id=MODEL_ID,
+            model_digest=MODEL_DIGEST,
+            generated_at=NOW,
+        )
+
+
+def test_nested_e2e_namespace_is_part_of_export_identity(tmp_path):
+    first_dir = tmp_path / "first"
+    _write_payload(first_dir)
+    first = build_receipt_manifest(
+        payload_dir=first_dir,
+        receipt_namespace=RECEIPT_NAMESPACE,
+        repository=REPOSITORY,
+        source_sha=SOURCE_SHA,
+        source_ref="refs/heads/main",
+        workflow_run_id=101,
+        workflow_run_attempt=1,
+        event="schedule",
+        payload_artifact_id=202,
+        payload_artifact_name=PAYLOAD_ARTIFACT_NAME,
+        payload_artifact_digest=ARTIFACT_DIGEST,
+        model_id=MODEL_ID,
+        model_digest=MODEL_DIGEST,
+        generated_at=NOW,
+    )
+
+    second_namespace = build_receipt_namespace(REPOSITORY, SOURCE_SHA, 101, 2)
+    second_binding = receipt_namespace_binding(
+        receipt_namespace=second_namespace,
+        repository=REPOSITORY,
+        source_sha=SOURCE_SHA,
+        workflow_run_id=101,
+        workflow_run_attempt=2,
+    )
+    second_payload_name, _ = receipt_artifact_names(second_namespace)
+    second_dir = tmp_path / "second"
+    _write_payload(second_dir, second_binding)
+    second = build_receipt_manifest(
+        payload_dir=second_dir,
+        receipt_namespace=second_namespace,
+        repository=REPOSITORY,
+        source_sha=SOURCE_SHA,
+        source_ref="refs/heads/main",
+        workflow_run_id=101,
+        workflow_run_attempt=2,
+        event="schedule",
+        payload_artifact_id=203,
+        payload_artifact_name=second_payload_name,
+        payload_artifact_digest=ARTIFACT_DIGEST,
+        model_id=MODEL_ID,
+        model_digest=MODEL_DIGEST,
+        generated_at=NOW,
+    )
+
+    assert first["export"]["digest"] != second["export"]["digest"]
+
+
+def test_build_rejects_payload_artifact_name_outside_namespace(tmp_path):
+    payload_dir = tmp_path / "payload"
+    _write_payload(payload_dir)
+    with pytest.raises(ReceiptVerificationError, match="artifact name"):
+        build_receipt_manifest(
+            payload_dir=payload_dir,
+            receipt_namespace=RECEIPT_NAMESPACE,
+            repository=REPOSITORY,
+            source_sha=SOURCE_SHA,
+            source_ref="refs/heads/main",
+            workflow_run_id=101,
+            workflow_run_attempt=1,
+            event="schedule",
+            payload_artifact_id=202,
+            payload_artifact_name="parity-receipts-payload-forged",
+            payload_artifact_digest=ARTIFACT_DIGEST,
+            model_id=MODEL_ID,
+            model_digest=MODEL_DIGEST,
+            generated_at=NOW,
+        )
+
+
+def test_workflow_protects_paid_producer_environment_and_digest_source():
+    workflow = (Path(__file__).parent.parent / ".github/workflows/parity-receipts.yml").read_text()
+    assert "environment: parity-receipts-production" in workflow
+    assert "PARITY_RECEIPTS_ENVIRONMENT_PROTECTED" in workflow
+    assert "DISPATCH_MODEL_DIGEST" not in workflow
+    assert workflow.count("--receipt-namespace") == 4
+    assert "receipt_runs/$RECEIPT_NAMESPACE" in workflow
+    assert "model_digest:" not in workflow.split("workflow_dispatch:", 1)[1].split("push:", 1)[0]
+
+
+def _trusted_run(**overrides) -> dict:
+    run = {
+        "id": 101,
+        "path": f"{WORKFLOW_PATH}@refs/heads/main",
+        "head_sha": SOURCE_SHA,
+        "head_branch": "main",
+        "head_repository": {"full_name": REPOSITORY},
+        "event": "schedule",
+        "status": "completed",
+        "conclusion": "success",
+        "run_attempt": 1,
+        "created_at": "2026-08-28T11:00:00Z",
+    }
+    run.update(overrides)
+    return run
+
+
+@pytest.fixture
+def receipt_case(tmp_path):
+    payload_dir = tmp_path / "payload"
+    _write_payload(payload_dir)
+    manifest = build_receipt_manifest(
+        payload_dir=payload_dir,
+        receipt_namespace=RECEIPT_NAMESPACE,
+        repository=REPOSITORY,
+        source_sha=SOURCE_SHA,
+        source_ref="refs/heads/main",
+        workflow_run_id=101,
+        workflow_run_attempt=1,
+        event="schedule",
+        payload_artifact_id=202,
+        payload_artifact_name=PAYLOAD_ARTIFACT_NAME,
+        payload_artifact_digest=ARTIFACT_DIGEST,
+        model_id=MODEL_ID,
+        model_digest=MODEL_DIGEST,
+        generated_at=NOW - timedelta(hours=1),
+    )
+    artifact = {
+        "id": 202,
+        "name": PAYLOAD_ARTIFACT_NAME,
+        "digest": f"sha256:{ARTIFACT_DIGEST}",
+        "expired": False,
+    }
+    return payload_dir, manifest, _trusted_run(), artifact
+
+
+def _verify(case, **overrides) -> None:
+    payload_dir, manifest, run, artifact = case
+    arguments = {
+        "manifest": manifest,
+        "payload_dir": payload_dir,
+        "trusted_run": run,
+        "trusted_artifact": artifact,
+        "expected_repository": REPOSITORY,
+        "expected_sha": SOURCE_SHA,
+        "expected_model_id": MODEL_ID,
+        "expected_model_digest": MODEL_DIGEST,
+        "expected_export_id": manifest["export"]["id"],
+        "expected_export_digest": manifest["export"]["digest"],
+        "now": NOW,
+    }
+    arguments.update(overrides)
+    verify_receipt_manifest(**arguments)
+
+
+def test_valid_receipt_binds_run_artifact_and_payload(receipt_case):
+    _verify(receipt_case)
+
+
+def test_rejects_self_asserted_forged_run_id(receipt_case):
+    _, manifest, _, _ = receipt_case
+    forged = copy.deepcopy(manifest)
+    forged["producer"]["workflow_run_id"] = 999999
+    with pytest.raises(ReceiptVerificationError, match="forged workflow run id"):
+        _verify(receipt_case, manifest=forged)
+
+
+def test_rejects_forged_namespace_or_run_attempt(receipt_case):
+    _, manifest, _, _ = receipt_case
+    forged = copy.deepcopy(manifest)
+    forged["receipt_namespace"]["workflow_run_attempt"] = 2
+    with pytest.raises(ReceiptVerificationError, match="namespace"):
+        _verify(receipt_case, manifest=forged)
+
+    with pytest.raises(ReceiptVerificationError, match="run attempt"):
+        _verify(receipt_case, trusted_run=_trusted_run(run_attempt=2))
+
+
+def test_rejects_pull_request_run(receipt_case):
+    with pytest.raises(ReceiptVerificationError, match="event is not allowlisted"):
+        _verify(receipt_case, trusted_run=_trusted_run(event="pull_request"))
+
+
+@pytest.mark.parametrize(
+    ("run_override", "message"),
+    [
+        ({"head_sha": "9" * 40}, "head_sha"),
+        ({"head_branch": "feature/untrusted"}, "ref is not allowlisted"),
+        ({"path": ".github/workflows/pytest.yml@refs/heads/main"}, "workflow run path"),
+        ({"head_repository": {"full_name": "attacker/tether"}}, "untrusted repository"),
+    ],
+)
+def test_rejects_wrong_sha_ref_workflow_or_repository(receipt_case, run_override, message):
+    with pytest.raises(ReceiptVerificationError, match=message):
+        _verify(receipt_case, trusted_run=_trusted_run(**run_override))
+
+
+def test_rejects_expired_receipt(receipt_case):
+    _, manifest, _, _ = receipt_case
+    expired = copy.deepcopy(manifest)
+    expired["expires_at"] = "2026-08-28T11:59:59Z"
+    with pytest.raises(ReceiptVerificationError, match="expired"):
+        _verify(receipt_case, manifest=expired)
+
+
+def test_rejects_altered_payload(receipt_case):
+    payload_dir, _, _, _ = receipt_case
+    path = payload_dir / "per_step_overhead_last_run.json"
+    path.write_text(path.read_text() + "\n")
+    with pytest.raises(ReceiptVerificationError, match="size changed"):
+        _verify(receipt_case)
+
+
+def test_rejects_unhashed_extra_payload_file(receipt_case):
+    payload_dir, _, _, _ = receipt_case
+    (payload_dir / "untrusted.json").write_text("{}")
+    with pytest.raises(ReceiptVerificationError, match="unexpected files"):
+        _verify(receipt_case)
+
+
+def test_rejects_model_digest_mismatch(receipt_case):
+    with pytest.raises(ReceiptVerificationError, match="model digest"):
+        _verify(receipt_case, expected_model_digest="8" * 64)
+
+
+def test_rejects_export_digest_mismatch(receipt_case):
+    with pytest.raises(ReceiptVerificationError, match="export digest"):
+        _verify(receipt_case, expected_export_digest="8" * 64)
+
+
+def test_build_rejects_measurements_from_a_different_export(tmp_path):
+    payload_dir = tmp_path / "payload"
+    _write_payload(payload_dir)
+    e2e_path = payload_dir / "per_step_e2e_latency_last_run.json"
+    e2e = json.loads(e2e_path.read_text())
+    e2e["per_step"]["export"]["expert_denoise.onnx"]["sha256"] = "f" * 64
+    e2e_path.write_text(json.dumps(e2e))
+    with pytest.raises(ReceiptVerificationError, match="e2e per_step export"):
+        build_receipt_manifest(
+            payload_dir=payload_dir,
+            receipt_namespace=RECEIPT_NAMESPACE,
+            repository=REPOSITORY,
+            source_sha=SOURCE_SHA,
+            source_ref="refs/heads/main",
+            workflow_run_id=101,
+            workflow_run_attempt=1,
+            event="schedule",
+            payload_artifact_id=202,
+            payload_artifact_name=PAYLOAD_ARTIFACT_NAME,
+            payload_artifact_digest=ARTIFACT_DIGEST,
+            model_id=MODEL_ID,
+            model_digest=MODEL_DIGEST,
+            generated_at=NOW,
+        )
+
+
+def test_build_rejects_incomplete_or_extra_parity_cell_set(tmp_path):
+    for mutation in ("missing", "extra"):
+        payload_dir = tmp_path / mutation
+        _write_payload(payload_dir)
+        parity_path = payload_dir / "per_step_parity_last_run.json"
+        parity = json.loads(parity_path.read_text())
+        if mutation == "missing":
+            del parity["cells"]["pi05_teacher_n1"]
+        else:
+            parity["cells"]["unexpected"] = copy.deepcopy(parity["cells"]["pi05_teacher_n1"])
+        parity_path.write_text(json.dumps(parity))
+        with pytest.raises(ReceiptVerificationError, match="cells must be exactly"):
+            build_receipt_manifest(
+                payload_dir=payload_dir,
+                receipt_namespace=RECEIPT_NAMESPACE,
+                repository=REPOSITORY,
+                source_sha=SOURCE_SHA,
+                source_ref="refs/heads/main",
+                workflow_run_id=101,
+                workflow_run_attempt=1,
+                event="schedule",
+                payload_artifact_id=202,
+                payload_artifact_name=PAYLOAD_ARTIFACT_NAME,
+                payload_artifact_digest=ARTIFACT_DIGEST,
+                model_id=MODEL_ID,
+                model_digest=MODEL_DIGEST,
+                generated_at=NOW,
+            )
+
+
+def test_build_rejects_incomplete_export_set_and_cpu_e2e_provider(tmp_path):
+    incomplete_dir = tmp_path / "incomplete"
+    _write_payload(incomplete_dir)
+    parity_path = incomplete_dir / "per_step_parity_last_run.json"
+    parity = json.loads(parity_path.read_text())
+    del parity["cells"]["pi05_teacher_n10"]["exports"]["baked"]["tether_config.json"]
+    parity_path.write_text(json.dumps(parity))
+    with pytest.raises(ReceiptVerificationError, match="must contain exactly"):
+        build_receipt_manifest(
+            payload_dir=incomplete_dir,
+            receipt_namespace=RECEIPT_NAMESPACE,
+            repository=REPOSITORY,
+            source_sha=SOURCE_SHA,
+            source_ref="refs/heads/main",
+            workflow_run_id=101,
+            workflow_run_attempt=1,
+            event="schedule",
+            payload_artifact_id=202,
+            payload_artifact_name=PAYLOAD_ARTIFACT_NAME,
+            payload_artifact_digest=ARTIFACT_DIGEST,
+            model_id=MODEL_ID,
+            model_digest=MODEL_DIGEST,
+            generated_at=NOW,
+        )
+
+    cpu_dir = tmp_path / "cpu"
+    _write_payload(cpu_dir)
+    e2e_path = cpu_dir / "per_step_e2e_latency_last_run.json"
+    e2e = json.loads(e2e_path.read_text())
+    e2e["baked"]["providers"]["expert_denoise"] = ["CPUExecutionProvider"]
+    e2e_path.write_text(json.dumps(e2e))
+    with pytest.raises(ReceiptVerificationError, match="expert_denoise did not use"):
+        build_receipt_manifest(
+            payload_dir=cpu_dir,
+            receipt_namespace=RECEIPT_NAMESPACE,
+            repository=REPOSITORY,
+            source_sha=SOURCE_SHA,
+            source_ref="refs/heads/main",
+            workflow_run_id=101,
+            workflow_run_attempt=1,
+            event="schedule",
+            payload_artifact_id=202,
+            payload_artifact_name=PAYLOAD_ARTIFACT_NAME,
+            payload_artifact_digest=ARTIFACT_DIGEST,
+            model_id=MODEL_ID,
+            model_digest=MODEL_DIGEST,
+            generated_at=NOW,
+        )
+
+
+def test_rejects_artifact_id_or_digest_mismatch(receipt_case):
+    _, _, _, artifact = receipt_case
+    wrong_id = {**artifact, "id": 303}
+    with pytest.raises(ReceiptVerificationError, match="artifact id"):
+        _verify(receipt_case, trusted_artifact=wrong_id)
+    wrong_digest = {**artifact, "digest": f"sha256:{'8' * 64}"}
+    with pytest.raises(ReceiptVerificationError, match="artifact digest"):
+        _verify(receipt_case, trusted_artifact=wrong_digest)
+
+
+def test_select_trusted_run_ignores_untrusted_candidates():
+    forged = _trusted_run(id=999, event="pull_request", created_at="2026-08-28T12:00:00Z")
+    trusted = _trusted_run(id=101)
+    assert (
+        select_trusted_run(
+            [forged, trusted], expected_repository=REPOSITORY, expected_sha=SOURCE_SHA
+        )["id"]
+        == 101
+    )
+
+
+def test_release_branch_fails_loud_when_receipt_is_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("GITHUB_REF_NAME", "release/v1.0")
+    with pytest.raises(pytest.fail.Exception, match="No trusted receipt"):
+        require_receipt(tmp_path / "missing.json", "the producer")
+
+
+def _zip_bytes(files: dict[str, bytes]) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        for name, contents in files.items():
+            info = zipfile.ZipInfo(name, date_time=(2026, 8, 28, 12, 0, 0))
+            archive.writestr(info, contents)
+    return output.getvalue()
+
+
+def test_download_discovers_exact_run_and_verifies_artifacts(tmp_path):
+    selected_namespace = build_receipt_namespace(REPOSITORY, SOURCE_SHA, 101, 2)
+    selected_binding = receipt_namespace_binding(
+        receipt_namespace=selected_namespace,
+        repository=REPOSITORY,
+        source_sha=SOURCE_SHA,
+        workflow_run_id=101,
+        workflow_run_attempt=2,
+    )
+    selected_payload_name, selected_manifest_name = receipt_artifact_names(selected_namespace)
+    payload_dir = tmp_path / "source-payload"
+    _write_payload(payload_dir, selected_binding)
+    payload_zip = _zip_bytes(
+        {
+            name: (payload_dir / name).read_bytes()
+            for name in sorted(p.name for p in payload_dir.iterdir())
+        }
+    )
+    payload_digest = hashlib.sha256(payload_zip).hexdigest()
+    manifest = build_receipt_manifest(
+        payload_dir=payload_dir,
+        receipt_namespace=selected_namespace,
+        repository=REPOSITORY,
+        source_sha=SOURCE_SHA,
+        source_ref="refs/heads/main",
+        workflow_run_id=101,
+        workflow_run_attempt=2,
+        event="schedule",
+        payload_artifact_id=202,
+        payload_artifact_name=selected_payload_name,
+        payload_artifact_digest=payload_digest,
+        model_id=MODEL_ID,
+        model_digest=MODEL_DIGEST,
+        generated_at=NOW - timedelta(hours=1),
+    )
+    manifest_zip = _zip_bytes({"receipt-manifest.json": json.dumps(manifest).encode()})
+    manifest_digest = hashlib.sha256(manifest_zip).hexdigest()
+    payload_artifact = {
+        "id": 202,
+        "name": selected_payload_name,
+        "digest": f"sha256:{payload_digest}",
+        "expired": False,
+    }
+    manifest_artifact = {
+        "id": 303,
+        "name": selected_manifest_name,
+        "digest": f"sha256:{manifest_digest}",
+        "expired": False,
+    }
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def get_json(self, path, query=None):
+            self.calls.append(("json", path, query))
+            if "/workflows/" in path:
+                return {
+                    "workflow_runs": [
+                        _trusted_run(run_attempt=1),
+                        _trusted_run(run_attempt=2),
+                    ]
+                }
+            return {
+                "artifacts": [
+                    {
+                        "id": 102,
+                        "name": PAYLOAD_ARTIFACT_NAME,
+                        "expired": False,
+                    },
+                    {
+                        "id": 103,
+                        "name": MANIFEST_ARTIFACT_NAME,
+                        "expired": False,
+                    },
+                    manifest_artifact,
+                    payload_artifact,
+                ]
+            }
+
+        def get_bytes(self, path, query=None):
+            self.calls.append(("bytes", path, query))
+            return manifest_zip if path.endswith("/303/zip") else payload_zip
+
+    client = FakeClient()
+    destination = tmp_path / "downloaded"
+    downloaded = download_verified_receipts(
+        repository=REPOSITORY,
+        expected_sha=SOURCE_SHA,
+        expected_model_id=MODEL_ID,
+        expected_model_digest=MODEL_DIGEST,
+        expected_export_id=manifest["export"]["id"],
+        expected_export_digest=manifest["export"]["digest"],
+        destination=destination,
+        token="unused-by-injected-client",
+        client=client,
+        now=NOW,
+    )
+
+    assert downloaded["producer"]["workflow_run_id"] == 101
+    assert downloaded["producer"]["workflow_run_attempt"] == 2
+    assert downloaded["receipt_namespace"]["value"] == selected_namespace
+    assert sorted(path.name for path in destination.iterdir()) == sorted(
+        [
+            "per_step_parity_last_run.json",
+            "per_step_overhead_last_run.json",
+            "per_step_e2e_latency_last_run.json",
+        ]
+    )
+    run_call = client.calls[0]
+    assert run_call[2]["head_sha"] == SOURCE_SHA
+    assert run_call[2]["status"] == "success"
+    assert any(call[1].endswith("/202/zip") for call in client.calls)
+    assert any(call[1].endswith("/303/zip") for call in client.calls)
+
+
+@pytest.mark.parametrize("case", ["forged", "duplicate"])
+def test_download_rejects_forged_or_duplicate_manifest_artifacts(tmp_path, case):
+    exact = {
+        "id": 303,
+        "name": MANIFEST_ARTIFACT_NAME,
+        "expired": False,
+    }
+    if case == "forged":
+        artifacts = [{**exact, "name": MANIFEST_ARTIFACT_NAME + "-forged"}]
+    else:
+        artifacts = [exact, {**exact, "id": 304}]
+
+    class FakeClient:
+        def get_json(self, path, query=None):
+            if "/workflows/" in path:
+                return {"workflow_runs": [_trusted_run()]}
+            return {"artifacts": artifacts}
+
+        def get_bytes(self, path, query=None):
+            raise AssertionError("ambiguous artifact must not be downloaded")
+
+    with pytest.raises(ReceiptVerificationError, match="unique receipt manifest"):
+        download_verified_receipts(
+            repository=REPOSITORY,
+            expected_sha=SOURCE_SHA,
+            expected_model_id=MODEL_ID,
+            expected_model_digest=MODEL_DIGEST,
+            expected_export_id="pi05-per-step-expert",
+            expected_export_digest="0" * 64,
+            destination=tmp_path / "downloaded",
+            token="unused-by-injected-client",
+            client=FakeClient(),
+            now=NOW,
+        )
+
+
+@pytest.mark.parametrize("case", ["forged", "duplicate"])
+def test_download_rejects_forged_or_duplicate_payload_artifacts(tmp_path, case):
+    payload_dir = tmp_path / "source-payload"
+    _write_payload(payload_dir)
+    payload_zip = _zip_bytes(
+        {
+            name: (payload_dir / name).read_bytes()
+            for name in sorted(path.name for path in payload_dir.iterdir())
+        }
+    )
+    payload_digest = hashlib.sha256(payload_zip).hexdigest()
+    manifest = build_receipt_manifest(
+        payload_dir=payload_dir,
+        receipt_namespace=RECEIPT_NAMESPACE,
+        repository=REPOSITORY,
+        source_sha=SOURCE_SHA,
+        source_ref="refs/heads/main",
+        workflow_run_id=101,
+        workflow_run_attempt=1,
+        event="schedule",
+        payload_artifact_id=202,
+        payload_artifact_name=PAYLOAD_ARTIFACT_NAME,
+        payload_artifact_digest=payload_digest,
+        model_id=MODEL_ID,
+        model_digest=MODEL_DIGEST,
+        generated_at=NOW - timedelta(hours=1),
+    )
+    if case == "forged":
+        manifest["artifact"]["name"] = PAYLOAD_ARTIFACT_NAME + "-forged"
+    manifest_zip = _zip_bytes({"receipt-manifest.json": json.dumps(manifest).encode()})
+    manifest_artifact = {
+        "id": 303,
+        "name": MANIFEST_ARTIFACT_NAME,
+        "digest": f"sha256:{hashlib.sha256(manifest_zip).hexdigest()}",
+        "expired": False,
+    }
+    payload_artifact = {
+        "id": 202,
+        "name": PAYLOAD_ARTIFACT_NAME,
+        "digest": f"sha256:{payload_digest}",
+        "expired": False,
+    }
+    artifacts = [manifest_artifact, payload_artifact]
+    if case == "duplicate":
+        artifacts.append(dict(payload_artifact))
+
+    class FakeClient:
+        def get_json(self, path, query=None):
+            if "/workflows/" in path:
+                return {"workflow_runs": [_trusted_run()]}
+            return {"artifacts": artifacts}
+
+        def get_bytes(self, path, query=None):
+            if path.endswith("/303/zip"):
+                return manifest_zip
+            return payload_zip
+
+    message = "selected run namespace" if case == "forged" else "absent or ambiguous"
+    with pytest.raises(ReceiptVerificationError, match=message):
+        download_verified_receipts(
+            repository=REPOSITORY,
+            expected_sha=SOURCE_SHA,
+            expected_model_id=MODEL_ID,
+            expected_model_digest=MODEL_DIGEST,
+            expected_export_id=manifest["export"]["id"],
+            expected_export_digest=manifest["export"]["digest"],
+            destination=tmp_path / "downloaded",
+            token="unused-by-injected-client",
+            client=FakeClient(),
+            now=NOW,
+        )


### PR DESCRIPTION
Code implementation for #292.

- requires exact workflow/SHA/ref/run/attempt/artifact/model/export provenance
- binds full config/prefix/expert export sets and immutable HF revisions
- requires exact parity cells and active CUDA providers
- isolates every paid measurement and artifact by canonical run-attempt namespace
- gates paid producers behind a protected GitHub environment
- fails release/required receipt checks loudly when evidence is absent or forged

Independent review: APPROVE after four remediation rounds. 77 affected tests passed with 17 expected operational skips; Ruff, format, mypy, YAML, compile, and diff checks passed.

This PR intentionally does not close #292. The issue remains open until an independent environment reviewer is selected, protected environment secrets/variables are configured, and one authorized A100 workflow produces live receipts.