### PR TITLE
fix(ci): load protected policy as pyproject

### DIFF
--- a/.github/workflows/quality-baseline-update.yml
+++ b/.github/workflows/quality-baseline-update.yml
@@ -89,7 +89,12 @@ jobs:
             --validate-policy-syntax "$CANDIDATE_POLICY"
           git worktree add --detach "$CANDIDATE_DIR" "${{ steps.candidate.outputs.sha }}"
           trap 'git worktree remove --force "$CANDIDATE_DIR"' EXIT
-          PROTECTED_POLICY="$CANDIDATE_DIR/.protected-base-pyproject.toml"
+          PROTECTED_POLICY_DIR="$RUNNER_TEMP/protected-base-policy"
+          mkdir -p "$PROTECTED_POLICY_DIR"
+          # Ruff recognizes a complete project configuration only when it is
+          # named pyproject.toml. A renamed file is parsed as ruff.toml and
+          # rejects standard tables such as [build-system].
+          PROTECTED_POLICY="$PROTECTED_POLICY_DIR/pyproject.toml"
           rm -f -- "$CANDIDATE_DIR/pyproject.toml"
           git show "$GITHUB_SHA:pyproject.toml" > "$PROTECTED_POLICY"
           python -I -m ruff check \

--- a/tests/test_ci_quality_ratchet.py
+++ b/tests/test_ci_quality_ratchet.py
@@ -134,6 +134,8 @@ def test_workflows_separate_ordinary_and_protected_policy_changes() -> None:
     workflows = Path(__file__).parents[1] / ".github" / "workflows"
     ordinary = (workflows / "quality-ratchet.yml").read_text()
     protected = (workflows / "quality-baseline-update.yml").read_text()
+    assert 'PROTECTED_POLICY="$PROTECTED_POLICY_DIR/pyproject.toml"' in protected
+    assert ".protected-base-pyproject.toml" not in protected
 
     assert "pull_request_target:" in ordinary
     assert "${BASE_SHA}:scripts/ci_quality_ratchet.py" in ordinary


### PR DESCRIPTION
Fixes the live protected-policy validation failure found while completing #291. Ruff treats a renamed full project TOML as ruff.toml and rejects [build-system]; the workflow now writes the protected configuration to an isolated file named pyproject.toml.

The candidate remains unable to execute before protected validation evidence is sealed. Focused ratchet tests, Ruff, format, YAML parsing, and diff checks pass.