### PR TITLE
ci: type-check untyped function bodies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -329,7 +329,7 @@ python_version = "3.10"
 mypy_path = "src"
 ignore_missing_imports = true
 follow_imports = "silent"
-check_untyped_defs = false
+check_untyped_defs = true
 warn_unused_configs = true
 exclude = [
     "src/tether/models/third_party/",


### PR DESCRIPTION
Completes the live protected-policy exercise for #291 by enabling mypy check_untyped_defs.

The protected workflow must validate and authorize this exact policy SHA before the quality ratchet accepts it. The change strengthens future analysis while the ratchet prevents existing debt from blocking unrelated changes.