### PR TITLE
fix(ci): flatten protected evidence download

### DIFF
--- a/.github/workflows/quality-baseline-update.yml
+++ b/.github/workflows/quality-baseline-update.yml
@@ -284,6 +284,10 @@ jobs:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           run-id: ${{ github.run_id }}
+          # artifact-ids still create an artifact-name subdirectory by default.
+          # Merge into the exact evidence directory so the fixed trusted path
+          # below cannot be redirected through a candidate-controlled name.
+          merge-multiple: true
 
       - name: Verify validation evidence without loading candidate content
         shell: bash

--- a/tests/test_ci_quality_ratchet.py
+++ b/tests/test_ci_quality_ratchet.py
@@ -136,6 +136,7 @@ def test_workflows_separate_ordinary_and_protected_policy_changes() -> None:
     protected = (workflows / "quality-baseline-update.yml").read_text()
     assert 'PROTECTED_POLICY="$PROTECTED_POLICY_DIR/pyproject.toml"' in protected
     assert ".protected-base-pyproject.toml" not in protected
+    assert "merge-multiple: true" in protected
 
     assert "pull_request_target:" in ordinary
     assert "${BASE_SHA}:scripts/ci_quality_ratchet.py" in ordinary


### PR DESCRIPTION
Fixes the second live protected-policy proof failure found while completing #291. actions/download-artifact places even an ID-selected artifact under its name by default; merge-multiple now extracts the single pre-verified artifact into the fixed trusted evidence directory.

The artifact ID/name/digest/run binding remains verified before download. Focused ratchet tests, Ruff, format, YAML, and diff checks pass.