### PR TITLE
fix(ci): recognize Actions policy status identity

### DIFF
--- a/.github/workflows/quality-ratchet.yml
+++ b/.github/workflows/quality-ratchet.yml
@@ -123,63 +123,43 @@ jobs:
             exit 0
           fi
 
-          STATUS_JSON=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/status")
-          STATUS_ENTRY=$(jq -c '
-            [.statuses[]
-             | select(.context == "quality-ratchet/policy-approved")
-             | select(.state == "success")
-             | select(.creator.login == "github-actions[bot]")]
-            | first // {}
-          ' <<< "$STATUS_JSON")
-          TARGET_URL=$(jq -r '
-            .target_url // ""
-          ' <<< "$STATUS_ENTRY")
-          if [[ ! "$TARGET_URL" =~ /actions/runs/([0-9]+)$ ]]; then
+          STATUS_FILE="$RUNNER_TEMP/policy-status.json"
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/status" > "$STATUS_FILE"
+          # The global Actions App identity is only a coarse prefilter. The
+          # protected-main run and immutable artifact below grant authorization.
+          if ! RUN_ID=$(python -I "${{ steps.commits.outputs.judge }}" \
+            --verify-policy-status-response "$STATUS_FILE" \
+            --expected-candidate-sha "$HEAD_SHA" \
+            --expected-repository "$GITHUB_REPOSITORY"); then
             echo "push_approved=false" >> "$GITHUB_OUTPUT"
             echo "candidate=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          RUN_ID="${BASH_REMATCH[1]}"
-          EXPECTED_DESCRIPTION="sha:${HEAD_SHA:0:12} run:${RUN_ID}"
-          [[ "$(jq -r '.description // ""' <<< "$STATUS_ENTRY")" == "$EXPECTED_DESCRIPTION" ]] || {
-            echo "push_approved=false" >> "$GITHUB_OUTPUT"
-            echo "candidate=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
-          RUN_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}")
-          if ! jq -e --arg base_sha "$BASE_SHA" '
-            .event == "workflow_dispatch"
-            and .head_branch == "main"
-            and .head_sha == $base_sha
-            and .conclusion == "success"
-            and .path == ".github/workflows/quality-baseline-update.yml"
-          ' <<< "$RUN_JSON" >/dev/null; then
+          RUN_FILE="$RUNNER_TEMP/policy-run.json"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" > "$RUN_FILE"
+          if ! python -I "${{ steps.commits.outputs.judge }}" \
+            --verify-policy-run-response "$RUN_FILE" \
+            --expected-base-sha "$BASE_SHA" \
+            --expected-run-id "$RUN_ID" \
+            --expected-repository "$GITHUB_REPOSITORY"; then
             echo "push_approved=false" >> "$GITHUB_OUTPUT"
             echo "candidate=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           APPROVAL_NAME="quality-policy-approval-${HEAD_SHA}-${RUN_ID}"
-          ARTIFACTS=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts")
-          MATCH_COUNT=$(jq --arg name "$APPROVAL_NAME" \
-            '[.artifacts[] | select(.name == $name and .expired == false)] | length' \
-            <<< "$ARTIFACTS")
-          [[ "$MATCH_COUNT" == "1" ]] || {
+          ARTIFACTS_FILE="$RUNNER_TEMP/policy-artifacts.json"
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+            > "$ARTIFACTS_FILE"
+          if ! ARTIFACT_ID=$(python -I "${{ steps.commits.outputs.judge }}" \
+            --verify-policy-artifacts-response "$ARTIFACTS_FILE" \
+            --expected-artifact-name "$APPROVAL_NAME"); then
             echo "push_approved=false" >> "$GITHUB_OUTPUT"
             echo "candidate=false" >> "$GITHUB_OUTPUT"
             exit 0
-          }
-          ARTIFACT_ID=$(jq -r --arg name "$APPROVAL_NAME" \
-            '.artifacts[] | select(.name == $name and .expired == false) | .id' \
-            <<< "$ARTIFACTS")
-          ARTIFACT_DIGEST=$(jq -r --arg name "$APPROVAL_NAME" \
-            '.artifacts[] | select(.name == $name and .expired == false) | .digest' \
-            <<< "$ARTIFACTS")
-          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]
-          [[ "$ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          fi
           echo "push_approved=false" >> "$GITHUB_OUTPUT"
           echo "candidate=true" >> "$GITHUB_OUTPUT"
           echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"

--- a/scripts/ci_quality_ratchet.py
+++ b/scripts/ci_quality_ratchet.py
@@ -44,6 +44,10 @@ _APPROVAL_EVIDENCE_FIELDS = frozenset(
 )
 _SHA256_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+_ACTIONS_APP_AVATAR = re.compile(r"^https://avatars\.githubusercontent\.com/in/15368(?:\?.*)?$")
+_ACTIONS_RUN_URL = re.compile(
+    r"^https://github\.com/(?P<repository>[^/]+/[^/]+)/actions/runs/(?P<run_id>[1-9][0-9]*)$"
+)
 _MYPY_LINE = re.compile(r"^(.*?):(\d+):(\d+):\s+(error|warning|note):\s+(.*?)(?:\s+\[([^\]]+)\])?$")
 _RUFF_FORMAT_LINE = re.compile(r"^Would reformat:\s+(.+?)\s*$")
 _DIFF_HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
@@ -155,6 +159,102 @@ def verify_policy_approval_evidence(
     digest = value["validation_artifact_digest"]
     if not isinstance(digest, str) or not _SHA256_DIGEST.fullmatch(digest):
         raise RatchetError("policy approval validation artifact digest is invalid")
+
+
+def verify_policy_status_response(
+    value: object,
+    *,
+    expected_candidate_sha: str,
+    expected_repository: str,
+) -> int:
+    """Return the run id from one coarse, server-attributed approval candidate.
+
+    The Actions App avatar is only a defense-in-depth prefilter: every workflow
+    in the repository uses that global App identity. Authorization comes from
+    the separately fetched protected-main run and its immutable evidence.
+    """
+    if not _COMMIT_SHA.fullmatch(expected_candidate_sha):
+        raise RatchetError("expected policy candidate SHA is invalid")
+    if not isinstance(value, dict) or value.get("sha") != expected_candidate_sha:
+        raise RatchetError("policy status response does not match candidate SHA")
+    statuses = value.get("statuses")
+    if not isinstance(statuses, list):
+        raise RatchetError("policy status response is missing statuses")
+
+    candidates: list[tuple[dict[str, object], re.Match[str]]] = []
+    for status in statuses:
+        if not isinstance(status, dict):
+            continue
+        avatar = status.get("avatar_url")
+        target = status.get("target_url")
+        match = _ACTIONS_RUN_URL.fullmatch(target) if isinstance(target, str) else None
+        if (
+            status.get("context") == "quality-ratchet/policy-approved"
+            and status.get("state") == "success"
+            and isinstance(avatar, str)
+            and _ACTIONS_APP_AVATAR.fullmatch(avatar)
+            and match is not None
+            and match.group("repository") == expected_repository
+        ):
+            candidates.append((status, match))
+    if len(candidates) != 1:
+        raise RatchetError("expected exactly one Actions-attributed policy status")
+
+    status, match = candidates[0]
+    run_id = int(match.group("run_id"))
+    expected_description = f"sha:{expected_candidate_sha[:12]} run:{run_id}"
+    if status.get("description") != expected_description:
+        raise RatchetError("policy status description does not bind candidate and run")
+    return run_id
+
+
+def verify_policy_run_response(
+    value: object,
+    *,
+    expected_base_sha: str,
+    expected_run_id: int,
+    expected_repository: str,
+) -> None:
+    """Verify that a status target is the successful protected-main workflow."""
+    if not isinstance(value, dict):
+        raise RatchetError("policy run response is not an object")
+    repository = value.get("repository")
+    checks = (
+        value.get("id") == expected_run_id
+        and not isinstance(value.get("id"), bool)
+        and value.get("event") == "workflow_dispatch"
+        and value.get("head_branch") == "main"
+        and value.get("head_sha") == expected_base_sha
+        and value.get("conclusion") == "success"
+        and value.get("path") == POLICY_WORKFLOW_PATH
+        and isinstance(repository, dict)
+        and repository.get("full_name") == expected_repository
+    )
+    if not checks:
+        raise RatchetError("policy run is not the exact successful protected workflow")
+
+
+def verify_policy_artifacts_response(value: object, *, expected_name: str) -> int:
+    """Return the id of one exact, unexpired, digest-addressed approval artifact."""
+    if not isinstance(value, dict) or not isinstance(value.get("artifacts"), list):
+        raise RatchetError("policy artifact response is invalid")
+    matches = [
+        artifact
+        for artifact in value["artifacts"]
+        if isinstance(artifact, dict)
+        and artifact.get("name") == expected_name
+        and artifact.get("expired") is False
+    ]
+    if len(matches) != 1:
+        raise RatchetError("expected exactly one unexpired policy approval artifact")
+    artifact = matches[0]
+    artifact_id = artifact.get("id")
+    digest = artifact.get("digest")
+    if isinstance(artifact_id, bool) or not isinstance(artifact_id, int) or artifact_id <= 0:
+        raise RatchetError("policy approval artifact id is invalid")
+    if not isinstance(digest, str) or not _SHA256_DIGEST.fullmatch(digest):
+        raise RatchetError("policy approval artifact digest is invalid")
+    return artifact_id
 
 
 def verify_current_main_binding(
@@ -740,6 +840,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Accept gate/policy changes approved by the protected manual workflow.",
     )
     parser.add_argument("--verify-approval-evidence", type=Path)
+    parser.add_argument("--verify-policy-status-response", type=Path)
+    parser.add_argument("--verify-policy-run-response", type=Path)
+    parser.add_argument("--verify-policy-artifacts-response", type=Path)
     parser.add_argument("--validate-policy-syntax", type=Path)
     parser.add_argument("--verify-main-ref-response", type=Path)
     parser.add_argument("--verify-policy-environment", type=Path)
@@ -750,6 +853,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--expected-base-sha")
     parser.add_argument("--expected-run-id", type=int)
     parser.add_argument("--expected-repository")
+    parser.add_argument("--expected-artifact-name")
     return parser
 
 
@@ -758,6 +862,50 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
     try:
+        if args.verify_policy_status_response is not None:
+            status_expected = (args.expected_candidate_sha, args.expected_repository)
+            if any(value is None for value in status_expected):
+                parser.error("policy status verification requires candidate and repository")
+            try:
+                status_value = json.loads(args.verify_policy_status_response.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                raise RatchetError(f"policy status API evidence is unreadable: {exc}") from exc
+            run_id = verify_policy_status_response(
+                status_value,
+                expected_candidate_sha=args.expected_candidate_sha,
+                expected_repository=args.expected_repository,
+            )
+            print(run_id)
+            return 0
+        if args.verify_policy_run_response is not None:
+            run_expected = (args.expected_base_sha, args.expected_run_id, args.expected_repository)
+            if any(value is None for value in run_expected):
+                parser.error("policy run verification requires base, run, and repository")
+            try:
+                run_value = json.loads(args.verify_policy_run_response.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                raise RatchetError(f"policy run API evidence is unreadable: {exc}") from exc
+            verify_policy_run_response(
+                run_value,
+                expected_base_sha=args.expected_base_sha,
+                expected_run_id=args.expected_run_id,
+                expected_repository=args.expected_repository,
+            )
+            print("policy approval run verified")
+            return 0
+        if args.verify_policy_artifacts_response is not None:
+            if args.expected_artifact_name is None:
+                parser.error("policy artifact verification requires --expected-artifact-name")
+            try:
+                artifacts_value = json.loads(args.verify_policy_artifacts_response.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                raise RatchetError(f"policy artifact API evidence is unreadable: {exc}") from exc
+            artifact_id = verify_policy_artifacts_response(
+                artifacts_value,
+                expected_name=args.expected_artifact_name,
+            )
+            print(artifact_id)
+            return 0
         if args.verify_policy_environment is not None:
             try:
                 environment_value = json.loads(args.verify_policy_environment.read_text())
@@ -795,13 +943,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("candidate Ruff/mypy policy parsed without executing plugins")
             return 0
         if args.verify_approval_evidence is not None:
-            expected = (
+            approval_expected = (
                 args.expected_candidate_sha,
                 args.expected_base_sha,
                 args.expected_run_id,
                 args.expected_repository,
             )
-            if any(value is None for value in expected):
+            if any(value is None for value in approval_expected):
                 parser.error("approval evidence verification requires every --expected-* value")
             try:
                 evidence = json.loads(args.verify_approval_evidence.read_text())

--- a/tests/fixtures/ci_quality_ratchet/policy_artifacts.json
+++ b/tests/fixtures/ci_quality_ratchet/policy_artifacts.json
@@ -1,0 +1,10 @@
+{
+  "artifacts": [
+    {
+      "digest": "sha256:94ae99405e87b07b88b694c145a935bf562e1a09edaff781b0a7920991309e44",
+      "expired": false,
+      "id": 9682669486,
+      "name": "quality-policy-approval-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-33163572947"
+    }
+  ]
+}

--- a/tests/fixtures/ci_quality_ratchet/policy_run.json
+++ b/tests/fixtures/ci_quality_ratchet/policy_run.json
@@ -1,0 +1,11 @@
+{
+  "conclusion": "success",
+  "event": "workflow_dispatch",
+  "head_branch": "main",
+  "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "id": 33163572947,
+  "path": ".github/workflows/quality-baseline-update.yml",
+  "repository": {
+    "full_name": "FastCrest/tether"
+  }
+}

--- a/tests/fixtures/ci_quality_ratchet/policy_status.json
+++ b/tests/fixtures/ci_quality_ratchet/policy_status.json
@@ -1,0 +1,12 @@
+{
+  "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "statuses": [
+    {
+      "avatar_url": "https://avatars.githubusercontent.com/in/15368?v=4",
+      "context": "quality-ratchet/policy-approved",
+      "description": "sha:aaaaaaaaaaaa run:33163572947",
+      "state": "success",
+      "target_url": "https://github.com/FastCrest/tether/actions/runs/33163572947"
+    }
+  ]
+}

--- a/tests/test_ci_quality_ratchet.py
+++ b/tests/test_ci_quality_ratchet.py
@@ -26,6 +26,9 @@ from scripts.ci_quality_ratchet import (
     verify_current_main_binding,
     verify_policy_environment,
     verify_policy_approval_evidence,
+    verify_policy_artifacts_response,
+    verify_policy_run_response,
+    verify_policy_status_response,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures" / "ci_quality_ratchet"
@@ -134,13 +137,18 @@ def test_workflows_separate_ordinary_and_protected_policy_changes() -> None:
     workflows = Path(__file__).parents[1] / ".github" / "workflows"
     ordinary = (workflows / "quality-ratchet.yml").read_text()
     protected = (workflows / "quality-baseline-update.yml").read_text()
+    judge = (Path(__file__).parents[1] / "scripts" / "ci_quality_ratchet.py").read_text()
     assert 'PROTECTED_POLICY="$PROTECTED_POLICY_DIR/pyproject.toml"' in protected
     assert ".protected-base-pyproject.toml" not in protected
     assert "merge-multiple: true" in protected
 
     assert "pull_request_target:" in ordinary
     assert "${BASE_SHA}:scripts/ci_quality_ratchet.py" in ordinary
-    assert "quality-ratchet/policy-approved" in ordinary
+    assert "quality-ratchet/policy-approved" in judge
+    assert "--verify-policy-status-response" in ordinary
+    assert "--verify-policy-run-response" in ordinary
+    assert "--verify-policy-artifacts-response" in ordinary
+    assert '.creator.login == "github-actions[bot]"' not in ordinary
     assert "quality-policy-approval-${HEAD_SHA}-${RUN_ID}" in ordinary
     assert '--expected-candidate-sha "$HEAD_SHA"' in ordinary
     assert '--expected-base-sha "$BASE_SHA"' in ordinary
@@ -185,6 +193,99 @@ def test_workflows_separate_ordinary_and_protected_policy_changes() -> None:
     assert protected.index(
         "Reconfirm current protected tip immediately before status"
     ) < protected.index("Authorize the exact evidence-bound commit")
+
+
+def test_policy_status_prefilter_accepts_live_shape_and_rejects_spoofs() -> None:
+    candidate = "a" * 40
+    value = json.loads((FIXTURES / "policy_status.json").read_text())
+    assert (
+        verify_policy_status_response(
+            value,
+            expected_candidate_sha=candidate,
+            expected_repository="FastCrest/tether",
+        )
+        == 33163572947
+    )
+
+    status = value["statuses"][0]
+    tampered = [
+        {**status, "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4"},
+        {key: item for key, item in status.items() if key != "avatar_url"},
+        {**status, "context": "quality-ratchet/protected"},
+        {**status, "state": "pending"},
+        {**status, "description": "sha:spoofed run:33163572947"},
+        {
+            **status,
+            "target_url": "https://github.com/attacker/fork/actions/runs/33163572947",
+        },
+    ]
+    for invalid_status in tampered:
+        with pytest.raises(RatchetError):
+            verify_policy_status_response(
+                {"sha": candidate, "statuses": [invalid_status]},
+                expected_candidate_sha=candidate,
+                expected_repository="FastCrest/tether",
+            )
+
+    with pytest.raises(RatchetError):
+        verify_policy_status_response(
+            {"sha": "b" * 40, "statuses": value["statuses"]},
+            expected_candidate_sha=candidate,
+            expected_repository="FastCrest/tether",
+        )
+
+
+def test_same_actions_identity_needs_exact_run_and_artifact_chain() -> None:
+    candidate = "a" * 40
+    base = "b" * 40
+    status = json.loads((FIXTURES / "policy_status.json").read_text())
+    run_id = verify_policy_status_response(
+        status,
+        expected_candidate_sha=candidate,
+        expected_repository="FastCrest/tether",
+    )
+    run = json.loads((FIXTURES / "policy_run.json").read_text())
+    verify_policy_run_response(
+        run,
+        expected_base_sha=base,
+        expected_run_id=run_id,
+        expected_repository="FastCrest/tether",
+    )
+    artifact_name = f"quality-policy-approval-{candidate}-{run_id}"
+    artifacts = json.loads((FIXTURES / "policy_artifacts.json").read_text())
+    assert verify_policy_artifacts_response(artifacts, expected_name=artifact_name) == 9682669486
+
+    run_tampering = [
+        {**run, "id": run_id + 1},
+        {**run, "head_sha": "c" * 40},
+        {**run, "event": "push"},
+        {**run, "head_branch": "feature"},
+        {**run, "path": ".github/workflows/unrelated.yml"},
+        {**run, "conclusion": "failure"},
+        {**run, "repository": {"full_name": "attacker/fork"}},
+    ]
+    for invalid_run in run_tampering:
+        with pytest.raises(RatchetError):
+            verify_policy_run_response(
+                invalid_run,
+                expected_base_sha=base,
+                expected_run_id=run_id,
+                expected_repository="FastCrest/tether",
+            )
+
+    artifact = artifacts["artifacts"][0]
+    artifact_tampering = [
+        {**artifact, "name": "quality-policy-approval-spoofed"},
+        {**artifact, "expired": True},
+        {**artifact, "id": 0},
+        {**artifact, "digest": "sha256:short"},
+    ]
+    for invalid_artifact in artifact_tampering:
+        with pytest.raises(RatchetError):
+            verify_policy_artifacts_response(
+                {"artifacts": [invalid_artifact]},
+                expected_name=artifact_name,
+            )
 
 
 def test_policy_approval_evidence_is_bound_to_exact_sha_base_and_run() -> None:


### PR DESCRIPTION
## Summary
- parse creator-less commit-status responses in the protected judge using GitHub Actions' server-owned global App attribution only as a coarse prefilter
- independently verify the exact current-repository workflow_dispatch run, protected-main SHA, workflow path, successful conclusion, unique artifact name/id/digest, and immutable evidence
- add behavioral API fixtures that accept the live response shape and reject wrong/missing attribution, status, repository, run, base SHA, workflow, artifact, and evidence bindings

## Live evidence
GitHub returned the valid approval status for run 33163572947 with no creator object and with the Actions integration avatar https://avatars.githubusercontent.com/in/15368?v=4. The old verifier therefore rejected it before artifact verification.

## Validation
- 16 focused quality-ratchet tests pass
- focused Ruff and mypy pass
- workflow YAML parses
- the protected judge accepts the live status shape and keeps downstream authorization fail-closed

Follow-up for #291. Because this PR changes the protected ratchet workflow and judge, its ratchet check is expected to fail until the audited bootstrap merge; all other checks must pass first.