### PR TITLE
fix(ci): flatten policy approval download

### DIFF
--- a/.github/workflows/quality-ratchet.yml
+++ b/.github/workflows/quality-ratchet.yml
@@ -170,6 +170,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           artifact-ids: ${{ steps.authorization.outputs.artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/approval-evidence
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/tests/test_ci_quality_ratchet.py
+++ b/tests/test_ci_quality_ratchet.py
@@ -153,6 +153,10 @@ def test_workflows_separate_ordinary_and_protected_policy_changes() -> None:
     assert '--expected-candidate-sha "$HEAD_SHA"' in ordinary
     assert '--expected-base-sha "$BASE_SHA"' in ordinary
     assert "artifact-ids: ${{ steps.authorization.outputs.artifact_id }}" in ordinary
+    approval_download = ordinary.split("- name: Download exact approval evidence", 1)[1].split(
+        "- name: Verify immutable approval evidence binding", 1
+    )[0]
+    assert "merge-multiple: true" in approval_download
     assert "Bind the event to the current protected-main tip" in ordinary
     assert "--verify-main-ref-response" in ordinary
     assert "--expected-current-main-sha" in ordinary


### PR DESCRIPTION
## Summary
- flatten the exact approval artifact into the verifier's declared target directory
- add regression coverage for the ordinary protected-ratchet download layout

## Live evidence
Protected run 33165642340 completed successfully and the ordinary verifier accepted its status, run, and artifact ID. Attempt 2 of ordinary run 33165637778 then failed only because download-artifact placed quality-policy-approval.json under an artifact-ID subdirectory. This applies the documented merge-multiple flattening already used by the protected validation path.

## Validation
- 16 focused quality-ratchet tests pass
- workflow YAML parses
- focused Ruff and diff checks pass

Final bootstrap follow-up for #291. The self-protected ratchet failure is expected; all ordinary checks must pass before audited admin merge.